### PR TITLE
Fixes the link in 'CSV Dialect Description Format'

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -304,7 +304,7 @@ TEXTDATA =  %x20-21 / %x23-2B / %x2D-7E
           hash for the resource in the <code>datapackage.json</code> descriptor MUST:</p>
 
           <ul>
-            <li>Include a <code>dialect</code> key that conforms to that described in the <a href="/csv-dialect/">CSV Dialect Description Format</a></li>
+            <li>Include a <code>dialect</code> key that conforms to that described in the <a href="http://dataprotocols.org/csv-dialect/">CSV Dialect Description Format</a></li>
           </ul>
 
           <p>Applications processing the CSV file SHOULD read use the <code>dialect</code> of the CSV file to guide parsing.</p>


### PR DESCRIPTION
The link was relative, it is now absolute.
