### PR TITLE
use .json instead of .csvm

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -84,7 +84,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 3,EMERSON ST,Liquidambar styraciflua,Large Tree Routine Prune,6/2/2010
       </pre>
       <p>
-        A human consumer of this data might be able to figure out the meaning of the different columns, particularly if there were some additional human-readable documentation made available. Automated processors would have a much harder time; realistically they would be limited to displaying the information in a table. Making available machine-readable metadata helps with the interpretation of the tabular data. For example, say that the following metadata file were available at <code>http://example.org/trees-ops.csv.csvm</code>:
+        A human consumer of this data might be able to figure out the meaning of the different columns, particularly if there were some additional human-readable documentation made available. Automated processors would have a much harder time; realistically they would be limited to displaying the information in a table. Making available machine-readable metadata helps with the interpretation of the tabular data. For example, say that the following metadata file were available at <code>http://example.org/trees-ops.csv.json</code>:
       </p>
       <pre class="example highlight">
 {
@@ -212,7 +212,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
         </pre>
       </div>
       <p>
-        Given the location of the CSV file, this metadata file can be located by appending <code>.csvm</code> to the URL (as described in <a href="http://www.w3.org/TR/tabular-data-model/#standard-path">Model for Tabular Data and Metadata on the Web</a>). It provides information for different types of applications:
+        Given the location of the CSV file, this metadata file can be located by appending <code>.json</code> to the URL (as described in <a href="http://www.w3.org/TR/tabular-data-model/#standard-path">Model for Tabular Data and Metadata on the Web</a>). It provides information for different types of applications:
       </p>
       <ul>
         <li><strong>Viewers</strong> can use the indicated metadata to provide a more user-friendly or human-readable view of the CSV file, which might include displaying it in a table or as graphs or charts.</li>


### PR DESCRIPTION
Using `.json` is better than introducing a new `.csvm` extension because this will be automatically detected as a JSON file by viewers etc, which means a smoother viewing/editing experience for metadata.
