### PR TITLE
Amended reference from RFC3066 to BCP47

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -31,17 +31,7 @@ var respecConfig = {
         "rawDate" : "2013-09-24",
         "publisher" : "Unicode Consortium",
         "status" : "Report"
-      },
-      "RFC3066" : {
-          "authors" : [
-            "H. Alvestrand"
-          ],
-          "title" : "Tags for the Identification of Languages 1995",
-          "rawDate" : "2001-01",
-          "status": "Internet Best Current Practice",
-          "publisher" : "IETF",
-          "href" : "http://www.ietf.org/rfc/rfc3066.txt"
-        }
+      }
     },
     specStatus: "ED",
     shortName: "tabular-metadata",
@@ -422,7 +412,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             <ul>
               <li><strong>strings</strong> &mdash; interpreted as natural language strings in the <a>default language</a></li>
               <li><strong>arrays</strong> &mdash; interpreted as alternative natural language strings in the <a>default language</a></li>
-              <li><strong>objects</strong> whose properties MUST be language codes as defined by [[!RFC3066]] and whose values are either strings or arrays, providing natural language strings in that language</li>
+              <li><strong>objects</strong> whose properties MUST be language codes as defined by [[!BCP47]] and whose values are either strings or arrays, providing natural language strings in that language</li>
             </ul>
             <p>
               Natural language properties are used for things like descriptions and titles. For example, the <code>title</code> property provides a natural language label for a column. If it's a plain string like this:


### PR DESCRIPTION
In line with other references to language codes; also removed the
localbiblio description of RFC3066 as it is no longer used.
