### PR TITLE
respec needs to load over https on github.io

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <meta content="width=device-width,initial-scale=1" name="viewport">
     <title>Generating JSON from Tabular Data on the Web</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common">
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
 	  </script>
     <script class="remove">
 var respecConfig = {

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <meta content="width=device-width,initial-scale=1" name="viewport">
     <title>Generating RDF from Tabular Data on the Web</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common">
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
 	  </script>
     <script class="remove">
 var respecConfig = {

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>Metadata Vocabulary for Tabular Data</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common">
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
 		</script>
     <script class="remove">
 var respecConfig = {

--- a/ns/index.html
+++ b/ns/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset='utf-8'/>
     <title>Metadata Vocabulary for Tabular Data</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
     <script class="remove">
 var respecConfig = {
     localBiblio: {

--- a/ns/template.html
+++ b/ns/template.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset='utf-8'/>
     <title><%= ont["dc:title"]["en"] %></title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
     <script class="remove">
 var respecConfig = {
     localBiblio: {

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>Model for Tabular Data and Metadata on the Web</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common">
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
 		</script>
     <script class="remove">
 var respecConfig = {

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>CSV on the Web: Use Cases and Requirements</title>
-    <script class="remove" src="http://www.w3.org/Tools/respec/respec-w3c-common">
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
 		</script>
     <script class="remove">
 var respecConfig = {


### PR DESCRIPTION
I just rewrote some respec JavaScript URLs to be https instead of http so they work properly on github.io.  Compare:

![screen shot 2014-12-31 at 3 44 48 am](https://cloud.githubusercontent.com/assets/33829/5586895/c5e8937e-90a0-11e4-84ca-16f0e1da0697.png)

to:

![screen shot 2014-12-31 at 3 52 49 am](https://cloud.githubusercontent.com/assets/33829/5586898/cc3046dc-90a0-11e4-9cce-e2aaf9b8ee11.png)
