### PR TITLE
Added specified formats for dates & times

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1470,16 +1470,13 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             It is not uncommon for numbers within tabular data to be formatted for human consumption, which may involve using commas for decimal points, grouping digits in the number using commas, or adding currency symbols or percent signs to the number.
           </p>
           <p>
-            If the <code>datatype</code> is a numeric type, the <code>format</code> property indicates the expected format for that number. Validators MUST check that the numbers in the column adhere to the specified format. Converters MUST use the <code>format</code> property to parse the number when mapping it into a suitable type in the target language of the conversion.
+            If the <code>datatype</code> is a numeric type, the <code>format</code> property indicates the expected format for that number. Validators MUST check that the numbers in the column adhere to the specified format. Converters MUST use the <code>format</code> property to parse the number when mapping it into a suitable type in the target format of the conversion.
           </p>
           <p>
             When the <code>datatype</code> is a numeric type, the <code>format</code> property's value MUST be a number format as specified in [[!xslt-21]].
           </p>
           <p class="issue" data-number="54">
             We invite comment on the best format to specify how to parse numbers.
-          </p>
-          <p class="issue" data-number="65">
-            Register of recognised date-time picture string formats.
           </p>
         </section>
         <section>
@@ -1500,16 +1497,51 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             If the <code>datatype</code> is a date or time type, the <code>format</code> property indicates the expected format for that date or time. Validators MUST check that the dates or times in the column adhere to the specified format. Converters MUST use the <code>format</code> property to parse the date or time when mapping it into a suitable type in the target language of the conversion.
           </p>
           <p>
-            When the <code>datatype</code> is a date or time type, the <code>format</code> property's value MUST be a date/time format as specified in [[!xslt-21]].
+            The following date formats MUST be recognised by implementations:
           </p>
-          <p class="issue" data-number="54">
-            We invite comment on which format to use when parsing dates and times.
+          <ul>
+            <li><code>yyyy-MM-dd</code> eg <code>2015-03-22</code></li>
+            <li><code>yyyyMMdd</code> eg <code>20150322</code></li>
+            <li><code>dd-MM-yyyy</code> eg <code>22-03-2015</code></li>
+            <li><code>d-M-yyyy</code> eg <code>22-3-2015</code></li>
+            <li><code>MM-dd-yyyy</code> eg <code>03-22-2015</code></li>
+            <li><code>M-d-yyyy</code> eg <code>3-22-2015</code></li>
+            <li><code>dd/MM/yyyy</code> eg <code>22/03/2015</code></li>
+            <li><code>d/M/yyyy</code> eg <code>22/3/2015</code></li>
+            <li><code>MM/dd/yyyy</code> eg <code>03/22/2015</code></li>
+            <li><code>M/d/yyyy</code> eg <code>3/22/2015</code></li>
+            <li><code>dd.MM.yyyy</code> eg <code>22.03.2015</code></li>
+            <li><code>d.M.yyyy</code> eg <code>22.3.2015</code></li>
+            <li><code>MM.dd.yyyy</code> eg <code>03.22.2015</code></li>
+            <li><code>M.d.yyyy</code> eg <code>3.22.2015</code></li>
+          </ul>
+          <p>
+            The following time formats MUST be recognised by implementations:
+          </p>
+          <ul>
+            <li><code>HH:mm:ss</code> eg <code>15:02:37</code></li>
+            <li><code>HHmmss</code> eg <code>150237</code></li>
+            <li><code>HH:mm</code> eg <code>15:02</code></li>
+            <li><code>HHmm</code> eg <code>1502</code></li>
+          </ul>
+          <p>
+            The following date/time formats MUST be recognised by implementations:
+          </p>
+          <ul>
+            <li><code>yyyy-MM-ddTHH:mm:ss</code> eg <code>2015-03-15T15:02:37</code></li>
+            <li>Any of the date formats above, followed by a space, followed by any of the time formats above, eg <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
+          </ul>
+          <p>
+            The supported date and time formats listed above are expressed in terms of the <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table">date field symbols</a> defined in [[!UAX35]] and should be interpreted by implementations as defined in that specification.
+          </p>
+          <p class="note">
+            For simplicity, this version of this standard does not support abbreviated or full month or day names, or double digit years. Future versions of this standard may support other date and time formats, or general purpose date/time pattern strings. Authors of schemas SHOULD use appropriate regular expressions, along with the <code>string</code> datatype, for dates and times that use a format other than that specified here.
           </p>
         </section>
         <section>
           <h3>Formats for durations</h3>
-          <p class="issue" data-number="54">
-            We invite comment on whether there are standard formats to use when parsing durations.
+          <p>
+            Durations MUST be formatted and interpreted as defined in [[!xmlschema-2]], using the [[!ISO8601]] format <code>P<var>n</var>Y<var>n</var>M<var>n</var>DT<var>n</var>H<var>n</var>M<var>n</var>S</code>.
           </p>
         </section>
       </section>


### PR DESCRIPTION
fixes #65
relevant for #54 (but doesn’t tackle number formats)

Is the list of date & time formats the right list? Note that I've assumed all durations in data in CSVs will have to be in the standard ISO8601 `PnYnMnDTnHnMnS` format. (Durations are very rarely included in data; when they are they're commonly something like numbers of days rather than the standard format, but in that case they can be typed as a number.)
