### PR TITLE
Regex syntax

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1458,10 +1458,10 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
         <section>
           <h3>Formats for strings</h3>
           <p>
-            If the <code>datatype</code> is a string type, the <code>format</code> property provides a regular expression for the string values, in the syntax defined by [[!ECMASCRIPT]].
+            If the <code>datatype</code> is a string type, the <code>format</code> property provides a regular expression for the string values, in the syntax and processed as defined by [[!ECMASCRIPT]].
           </p>
-          <p class="issue" data-number="55">
-            We invite comment about which reference to use for regular expression syntax. Other possibilities are to use that defined by XML Schema or XPath.
+          <p class="note">
+            Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
           </p>
         </section>
         <section>


### PR DESCRIPTION
fixes #55 

@gkellogg As discussed in the telcon, I've added a note saying authors should be conservative in the regexes that they use, but I'm not sure what the purpose of that is. Either we're normatively referencing ECMAScript syntax and implementation must implement it and it doesn't matter what authors do, or we're leaving it implementation defined and encouraging authors to use a syntax that's conservative.
