### PR TITLE
As described in issue #184, allow columns to match if they share a title...

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -930,7 +930,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             </p>
             <ul>
               <li>if there is a column description at the same index within A and that column description has the same <code>name</code>, the column description from B is <a>merged</a> into the matching column description in A</li>
-              <li>otherwise, if there is a column description at the same index within A and that column description has a title, is also in A, and the column <a>default language</a> is the same in both A and B, the column description from B is imported into the matching column description in A</li>
+              <li>otherwise, if there is a column description at the same index within A with a <code>title</code> that is also a <code>title</code> in A, considering the language of each <code>title</code> where <code>und</code> matches a value in any language, the column description from B is imported into the matching column description in A.</li>
               <li>otherwise, if there is no column description at the same index within A, then the column description is taken from that index of B</li>
               <li>otherwise, the column description is ignored. A validator MUST issue a warning if such a column description is encountered.</li>
             </ul>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1200,7 +1200,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <p>
                 An <a>atomic property</a> that gives a single canonical name for the column. This MUST be a string. Conversion specifications MUST use this property as the basis for the names of properties/elements/attributes in the results of conversions.
               </p>
-              <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first <a>property value</a> of <code>title</code> as a string without language, if any. Otherwise, it is the string <code>"_col=<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-column-number">column number</a>.
+              <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first value from the <a>property value</a> of <code>title</code> having the same language tag as <a>default language</a> or <code>und</code> of not specified, as a string without language, if any. Otherwise, it is the string <code>"_col=<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-column-number">column number</a>.
               </p>
               <p>
                 For ease of reference within <a title="URI template property">URI template properties</a>, column names SHOULD consist only of alphanumeric characters or underscores (<code>[a-zA-Z0-9_]+</code>). Names beginning with <code>_</code> are reserved by this specification and MUST NOT be used.

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -654,18 +654,10 @@ Content-Type: text/csv;header=absent
         <li>Skip the number of rows indicated by the <a>skip rows</a> parameter. These form <code>rdfs:comment</code> annotations on the table. If a skipped row begins with the <a>comment prefix</a>, strip that prefix from the beginning of the row to create the content of the <code>rdfs:comment</code> annotation.</li>
         <li>Gather the number of header rows indicated by the <a>header row count</a> parameter; the remaining rows are data rows.</li>
         <li>
-          <p>
-            Split the header and data rows into cells using the <a>delimiter</a>. Values that are enclosed within the <a>quote character</a> may contain the <a>delimiter</a>. The <a>quote character</a> may be escaped using the <a>escape character</a> where it appears within cells. If the <a>escape character</a> is not the same as the <a>quote character</a> then the <a>escape character</a> is also used to escape the character that immediately follows it.
-          </p>
-          <p>
-            If <a>trim</a> is <code>true</code> or <code>start</code> then whitespace from the start of values that are not enclosed within the <a>quote character</a> is removed from the value. If <a>trim</a> is <code>true</code> or <code>end</code> then whitespace from the end of values that are not enclosed within the <a>quote character</a> is removed from the value.
-          </p>
+          Split the header and data rows into cells using the <a>delimiter</a>. Values that are enclosed within the <a>quote character</a> may contain the <a>delimiter</a>. The <a>quote character</a> may be escaped using the <a>escape character</a> where it appears within cells. If the <a>escape character</a> is not the same as the <a>quote character</a> then the <a>escape character</a> is also used to escape the character that immediately follows it.<br/>If <a>trim</a> is <code>true</code> or <code>start</code> then whitespace from the start of values that are not enclosed within the <a>quote character</a> is removed from the value. If <a>trim</a> is <code>true</code> or <code>end</code> then whitespace from the end of values that are not enclosed within the <a>quote character</a> is removed from the value.
         </li>
         <li>
-          Construct <a>embedded metadata</a> as Table Metadata (see <cite><a href="http://www.w3.org/TR/tabular-metadata/#tables"></a></cite> in [[!tabular-metadata]]) using the <code>@context</code> from <a>merged metadata</a> and setting the <code>lang</code> annotation to the default language from the <code>@context</code>.
-          <div class="issues">
-            This change as a result of processing the CSV and deriving embedded metadata. If the asserted metadata has <code>@language: e</code>n, and the column titles are then interpreted to be in English, it won't match with the actual column headings from the CSV, unless they are also in English, thus the addition of adding both <code>@language: en</code> and <code>language: en</code> to the resulting embedded metadata.
-          </div>
+          Construct <a>embedded metadata</a> as Table Metadata (see <cite><a href="http://www.w3.org/TR/tabular-metadata/#tables"></a></cite> in [[!tabular-metadata]]).
         </li>
         <li>In each row, ignore the number of columns indicated by the <a>skip columns</a> parameter. Always start from the first character in the row when counting columns (see <a href="#bidirectionality-in-csv-files" class="sectionRef"></a>).</li>
         <li>Gather the number of header columns indicated by the <a>header column count</a> parameter. Always start from the first character in the row when counting columns (see <a href="#bidirectionality-in-csv-files" class="sectionRef"></a>).</li>


### PR DESCRIPTION
..., where `und` matches any language title.
