### PR TITLE
consistent use of 'property' and 'annotation'

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -193,7 +193,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
         Implementations may fulfil one or more of these functions. In particular, <a>Converters</a> may or may not act as a <a title="Validators">Validator</a> (perhaps through the setting of a flag), and check the data that they are converting to ensure that it is complant with the schema. If a Converter does not also act as a Validator it may produce invalid output.
       </p>
       <p>
-        The <a href="http://www.w3.org/TR/tabular-data-model/">Model for Tabular Data and Metadata on the Web</a> specification defines an <a href="http://www.w3.org/TR/tabular-data-model/#annotated-tabular-data-model">Annotated Tabular Data Model</a> in which tables, columns, rows and cells can be annotated with properties and values, and a <a href="http://www.w3.org/TR/tabular-data-model/#grouped-tabular-data-model">Grouped Tabular Data Model</a> in which a group of tables is annotated. That specification also describes <a href="http://www.w3.org/TR/tabular-data-model/#locating-metadata">how to locate metadata</a> about a given CSV file.
+        The <a href="http://www.w3.org/TR/tabular-data-model/">Model for Tabular Data and Metadata on the Web</a> specification defines an <a href="http://www.w3.org/TR/tabular-data-model/#annotated-tabular-data-model">Annotated Tabular Data Model</a> in which tables, columns, rows and cells can be annotated with annotations, and a <a href="http://www.w3.org/TR/tabular-data-model/#grouped-tabular-data-model">Grouped Tabular Data Model</a> in which a group of tables is annotated. That specification also describes <a href="http://www.w3.org/TR/tabular-data-model/#locating-metadata">how to locate metadata</a> about a given CSV file.
       </p>
       <p>
         This document defines the format and structure of metadata documents, and how these are interpreted to create an Annotated Tabular Data Model. It also defines how to validate tabular data based on some of these annotations. This metadata can be expressed as an RDF graph. However, all applications that conform to this specification (including validators and applications that read or convert tabular data) MUST read the JSON-based format described in this document.
@@ -202,7 +202,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
     <section>
       <h2>Annotating Tables</h2>
       <p>
-        The metadata defined in this specification is used to annotate an existing <a href="http://www.w3.org/TR/tabular-data-model/#dfn-annotated-table">annotated table</a> or <a href="http://www.w3.org/TR/tabular-data-model/#dfn-group-of-tables">group of tables</a>, as defined in [[!tabular-data-model]]. Annotated tables form the basis for all further processing, such as validating or displaying the tables. All compliant applications MUST create annotated tables based on the algorithm defined here.
+        The metadata defined in this specification is used to provide annotations on an <a href="http://www.w3.org/TR/tabular-data-model/#dfn-annotated-table">annotated table</a> or <a href="http://www.w3.org/TR/tabular-data-model/#dfn-group-of-tables">group of tables</a>, as defined in [[!tabular-data-model]]. Annotated tables form the basis for all further processing, such as validating, converting or displaying the tables. All compliant applications MUST create annotated tables based on the algorithm defined here.
       </p>
       <p>
         Metadata documents contain descriptions of groups of tables, tables, columns, rows, cells and regions which are used to create annotations on a tabular data model. There are two types of description objects:
@@ -215,7 +215,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
         The description objects themselves contain a number of properties. These are:
       </p>
       <ul>
-        <li>properties that are used to identify the table or column that the annotations should appear on; these match up to core properties on those objects in the annotated tabular data model defined in [[!tabular-data-model]] and do not form additional annotations</li>
+        <li>properties that are used to identify the table or column that the annotations should appear on; these match up to core annotations on those objects in the annotated tabular data model defined in [[!tabular-data-model]] and do not create new annotations</li>
         <li>properties that map directly to annotations that appear directly on the group of tables, table, column, row or cell whose description they appear on, such as the <code>name</code> of a column or the <code>dc:provenance</code> of a table</li>
         <li>properties that are specified on the description of a group of tables, table or column to provide a default value for the equivalent annotation on each of the cells that appear in that table or column</li>
       </ul>
@@ -232,13 +232,13 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 }
       </pre>
       <p>
-        the properties <code>name</code>, <code>title</code> and <code>dc:description</code> are <a title="direct annotation">direct annotations</a> that become <code>name</code>, <code>title</code> and <code>dc:description</code> properties on the column in the data model. The <code>datatype</code> and <code>format</code> properties are <a title="inherited property">inherited properties</a> that become <code>datatype</code> and <code>format</code> properties on the cells within the column.
+        the properties <code>name</code>, <code>title</code> and <code>dc:description</code> are <a title="direct property">direct properties</a> that become <code>name</code>, <code>title</code> and <code>dc:description</code> properties on the column in the data model. The <code>datatype</code> and <code>format</code> properties are <a title="inherited property">inherited properties</a> that become <code>datatype</code> and <code>format</code> properties on the cells within the column.
       </p>
       <p>The <dfn>property value</dfn> of an annotation is that defined in the metadata, unless otherwise noted.</p>
       <section>
-        <h3>Direct Annotations</h3>
+        <h3>Direct Properties</h3>
         <p>
-          <dfn title="direct annotation">Direct annotations</dfn> are properties on the description object for a given table, column, row or cell which map directly to properties on the described table, column, row or cell. The name of the annotation is the same as the name of the property on the annotation. The value of the annotation is the same as the value of the property on the description object.
+          <dfn title="direct property">Direct properties</dfn> are properties on the description object for a given table group, table, column, row or cell which map directly to annotations on the described table group, table, column, row or cell. The name of the annotation is the same as the name of the property. The value of the annotation is the same as the <a>property value</a>.
         </p>
       </section>
       <section>
@@ -257,7 +257,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
     <section>
       <h2>Metadata Format</h2>
       <p>
-        This section defines a set of properties and permitted values for annotating tabular data, and how these annotations should be interpreted by applications.
+        This section defines a set of properties and permitted values for annotating tabular data, and how these properties should be interpreted by applications.
       </p>
       <p>
         A metadata document is a JSON document which holds an object at the top level. This object is a <a>description object</a> of either a table group or a single table. A <dfn>description object</dfn> is a JSON object that describes a component of the tabular data model (a table group, a table, a column, a row or a cell) and has one or more properties are mapped into properties on that component. 
@@ -687,16 +687,10 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             <dt id="table-notes"><code>notes</code></dt>
             <dd>
               <p>
-                An <a>object property</a> that provides an array of objects representing annotations. This specification does not place any constraints on the structure of these objects.
+                An <a>object property</a> that provides an array of objects representing arbitrary annotations on the annotated tabular data model. This specification does not place any constraints on the structure of these objects.
               </p>
               <p class="note">
                 The <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> is developing a vocabulary for expressing annotations. In future versions of this specification, we anticipate referencing that vocabulary.
-              </p>
-              <p class="issue" data-number="70">
-                Should there be column or level notes as well?
-              </p>
-              <p class="issue" data-number="71">
-                The Annotation Model can indeed become very complex.
               </p>
             </dd>
             <dt id="table-title"><code>title</code></dt>
@@ -1357,7 +1351,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             </p>
           </dd>
         </dl>
-        <p>The <a>property value</a> of an <a>inherited property</a> is the first value, if any, found by looking in the current annotation object through all of its containing objects: a <a>inherited property</a> defined in a <a>column description</a> takes precidence of one defined in a <a>schema description</a>, which in turn takes precidence of one defined in a <a>table description</a>, which in turn takes precidence of one defined in a <a>table group description</a>.</p>
+        <p>The <a>property value</a> of an <a>inherited property</a> is the first value, if any, found by looking in the current description object through all of its containing objects: a <a>inherited property</a> defined in a <a>column description</a> takes precedence of one defined in a <a>schema description</a>, which in turn takes precedence of one defined in a <a>table description</a>, which in turn takes precedence of one defined in a <a>table group description</a>.</p>
       </section>
       <section>
         <h2>Datatypes</h2>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -139,22 +139,25 @@ var respecConfig = {
       <section>
         <h3>Annotated Tabular Data Model</h3>
         <p>
-          An <dfn>annotated table</dfn> is a <dfn>table</dfn> that is annotated with additional metadata. The core properties of a table are:
+          An <dfn>annotated table</dfn> is a <dfn>table</dfn> that is annotated with additional metadata. The core annotations of a table are:
         </p>
         <ul>
           <li><dfn title="table columns">columns</dfn> &mdash; the list of <a title="column">columns</a> in the table. A table MUST have one or more columns and the order of the columns within the list is significant and MUST be preserved by applications</li>
           <li><dfn title="table rows">rows</dfn> &mdash; the list of rows in the table</li>
         </ul>
         <p>
-          The table MAY in addition have any number of <dfn title="property">properties</dfn> which provide information about the table as a whole. The <dfn title="value">values</dfn> of these properties may be lists, structured objects, or atomic values. Annotations on a table may include:
+          The table MAY in addition have any number of <dfn title="annotation">annotations</dfn> which provide information about the table as a whole. The <dfn title="value">values</dfn> of these annotations may be lists, structured objects, or atomic values. Annotations on a table may include:
         </p>
         <ul>
           <li>titles or descriptions of the table</li>
           <li>information about the source or provenance of the data in the table</li>
           <li>links to other tables (eg to indicate tables that include related information)</li>
         </ul>
+        <p class="note">
+          In this document, the term <a>annotation</a> refers to any metadata associated with an object in the annotated tabular data model. These are not necessarily web annotations in the sense of [[annotation-model]].
+        </p>
         <p>
-          A <dfn>column</dfn> represents a vertical arrangement of <a title="cell">cells</a> within a <a>table</a>. The core properties of a column are:
+          A <dfn>column</dfn> represents a vertical arrangement of <a title="cell">cells</a> within a <a>table</a>. The core annotations of a column are:
         </p>
         <ul>
           <li><dfn title="column table">table</dfn> &mdash; the <a>table</a> that the column appears in</li>
@@ -162,7 +165,7 @@ var respecConfig = {
           <li><dfn title="column cells">cells</dfn> &mdash; the list of <a title="cell">cells</a> in the column. A column MUST contain one cell from each <a>row</a> in the table. The order of the cells in the list MUST match the order of the rows in which they appear within the <a title="table rows">rows</a> for the associated <a title="column table">table</a>.</li>
         </ul>
         <p>
-          Columns MAY in addition have any number of <a title="property">properties</a>. The annotations on a column might provide information about how to interpret the <a title="cell">cells</a> in the column or information about the column as a whole. Examples of annotations might be:
+          Columns MAY in addition have any number of <a title="annotation">annotations</a>. The annotations on a column might provide information about how to interpret the <a title="cell">cells</a> in the column or information about the column as a whole. Examples of annotations might be:
         </p>
         <ul>
           <li>a name or title for the column</li>
@@ -170,7 +173,7 @@ var respecConfig = {
           <li>an indication of whether the column contains unique values</li>
         </ul>
         <p>
-          A <dfn>row</dfn> represents a horizontal arrangement of <a title="cell">cells</a> within a <a>table</a>. The core properties of a row are:
+          A <dfn>row</dfn> represents a horizontal arrangement of <a title="cell">cells</a> within a <a>table</a>. The core annotations of a row are:
         </p>
         <ul>
           <li><dfn title="row table">table</dfn> &mdash; the <a>table</a> that the row appears in</li>
@@ -178,14 +181,14 @@ var respecConfig = {
           <li><dfn title="row cells">cells</dfn> &mdash; the list of <a title="cell">cells</a> in the row. A row MUST contain one cell from each <a>column</a> in the table. The order of the cells in the list MUST match the order of the columns in which they appear within the <a>table columns</a> for the row's table.</li>
         </ul>
         <p>
-          Rows MAY have any number of additional <a title="property">properties</a>. The annotations on a row provide additional metadata about the information held in the row, such as:
+          Rows MAY have any number of additional <a title="annotation">annotations</a>. The annotations on a row provide additional metadata about the information held in the row, such as:
         </p>
         <ul>
           <li>the certainty of the information in that row</li>
           <li>information about the source or provenance of the data in that row</li>
         </ul>
         <p>
-          A <dfn>cell</dfn> represents a cell at the intersection of a <a>row</a> and a <a>column</a> within a <a>table</a>. The core properties of a cell are:
+          A <dfn>cell</dfn> represents a cell at the intersection of a <a>row</a> and a <a>column</a> within a <a>table</a>. The core annotations of a cell are:
         </p>
         <ul>
           <li><dfn title="cell table">table</dfn> &mdash; the <a>table</a> that the cell appears in</li>
@@ -199,7 +202,7 @@ var respecConfig = {
           There presence or absence of quotes around a value within a CSV file is a syntactic detail that is not reflected in the tabular data model. In other words, there is no distinction in the model between the second value in <code>a,,z</code> and the second value in <code>a,"",z</code>.
         </p>
         <p>
-          Cells MAY have any number of additional <a title="property">properties</a>. The annotations on a cell provide metadata about the value held in the cell, particularly when this overrides the information provided for the <a>column</a> and <a>row</a> that the cell falls within. Annotations on a cell might be:
+          Cells MAY have any number of additional <a title="annotation">annotations</a>. The annotations on a cell provide metadata about the value held in the cell, particularly when this overrides the information provided for the <a>column</a> and <a>row</a> that the cell falls within. Annotations on a cell might be:
         </p>
         <ul>
           <li>notes to aid the interpretation of the value</li>
@@ -213,7 +216,7 @@ var respecConfig = {
       <section>
         <h3>Grouped Tabular Data Model</h3>
         <p>
-          A <dfn>group of tables</dfn> comprises a set of <a title="table">tables</a> (which may be <a title="annotated table">annotated tables</a>) and a set of annotations (<a title="property">properties</a> and <a title="value">values</a>) that relate to the set.
+          A <dfn>group of tables</dfn> comprises a set of <a title="annotated table">annotated tables</a> and a set of annotations that relate to the set.
         </p>
         <p class="note">
           Tables can be loosely related to each other simply through annotations; not all tables that are related to each other need to grouped together. Groups of tables are useful because they can be annotated with metadata that applies to all the tables in the group.
@@ -673,11 +676,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 2,EMERSON ST,Liquidambar styraciflua,Large Tree Routine Prune,6/2/2010
           </pre>
           <p>
-            Parsing this file results in an <a>annotated tabular data model</a> of a single <a>table</a> <var>T</var> with five columns and two rows. The columns have the properties shown in the following table:
+            Parsing this file results in an <a>annotated tabular data model</a> of a single <a>table</a> <var>T</var> with five columns and two rows. The columns have the annotations shown in the following table:
           </p>
           <table style="width: 100%; text-align: left">
             <thead>
-              <tr><th rowspan="2">id</th><th colspan="3">core properties</th><th>annotations</th></tr>
+              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th><th>annotations</th></tr>
               <tr><th>table</th><th>number</th><th>cells</th><th><code>title</code></th></tr>
             </thead>
             <tbody>
@@ -705,11 +708,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 }
           </pre>
           <p>
-            The rows have the properties shown in the following table:
+            The rows have the annotations shown in the following table:
           </p>
           <table style="width: 100%; text-align: left">
             <thead>
-              <tr><th rowspan="2">id</th><th colspan="3">core properties</th></tr>
+              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th></tr>
               <tr><th>table</th><th>number</th><th>cells</th></tr>
             </thead>
             <tbody>
@@ -718,11 +721,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             </tbody>
           </table>
           <p>
-            The cells have the properties shown in the following table (note that the <a title="cell value">values</a> of all the cells in the table are strings, denoted by the double quotes in the table below):
+            The cells have the annotations shown in the following table (note that the <a title="cell value">values</a> of all the cells in the table are strings, denoted by the double quotes in the table below):
           </p>
           <table style="width: 100%; text-align: left">
             <thead>
-              <tr><th rowspan="2">id</th><th colspan="6">core properties</th></tr>
+              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th></tr>
               <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th></tr>
             </thead>
             <tbody>
@@ -754,11 +757,11 @@ data.parse({
           		The parser could then create an <a>annotated tabular data model</a> that included <code>name</code> annotations on the columns, <code>datatype</code> and <code>format</code> annotations on the cells, and created cells whose <a title="cell value">values</a> were of appropriate types (in the case of this Javascript implementation, the cells in the last column would be <code>Date</code> objects, for example).
           	</p>
 						<p>
-							Assuming this kind of implementation-defined parsing, the columns would then have the properties shown in the following table:
+							Assuming this kind of implementation-defined parsing, the columns would then have the annotations shown in the following table:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th><th colspan="2">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th><th colspan="2">annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th></tr>
 	            </thead>
 	            <tbody>
@@ -791,11 +794,11 @@ data.parse({
 }
           </pre>
 	          <p>
-	            The cells have the properties shown in the following table. Because of the overrides provided by the consumer to guide the parsing, and the way the parser works, these include additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
+	            The cells have the annotations shown in the following table. Because of the overrides provided by the consumer to guide the parsing, and the way the parser works, these include additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="6">core properties</th><th colspan="2">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th><th colspan="2">annotations</th></tr>
 	              <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th><th>datatype</th><th>format</th></tr>
 	            </thead>
 	            <tbody>
@@ -886,11 +889,11 @@ data.parse({
           		Note that the value of the <code>primaryKey</code> annotation is a pointer to the <a>column</a> <var>C1</var> within the annotated tabular data model.
           	</p>
 						<p>
-							The columns would have the properties shown in the following table:
+							The columns would have the annotations shown in the following table:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th><th colspan="3">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th><th colspan="3">annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>dc:description</code></th></tr>
 	            </thead>
 	            <tbody>
@@ -902,11 +905,11 @@ data.parse({
 	            </tbody>
 	          </table>
 	          <p>
-	            Thanks to the provided metadata, the cells again have the properties shown in the following table. The metadata file has provided the information to supplement the model with additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
+	            Thanks to the provided metadata, the cells again have the annotations shown in the following table. The metadata file has provided the information to supplement the model with additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="6">core properties</th><th colspan="2">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th><th colspan="2">annotations</th></tr>
 	              <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th><th>datatype</th><th>format</th></tr>
 	            </thead>
 	            <tbody>
@@ -935,11 +938,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 2,,"Liquidambar styraciflua","Large Tree Routine Prune",
           </pre>
           <p>
-            Parsing this file similarly results in an <a>annotated tabular data model</a> of a single <a>table</a> <var>T</var> with five columns and two rows. The columns and rows have exactly the same properties as previously, but there are two <code>null</code> cell values for <var>C2.2</var> and <var>C2.5</var>. Note that the quoting of values within the CSV makes no difference to either the <a>string value</a> or <a title="cell value">value</a> of the cell.
+            Parsing this file similarly results in an <a>annotated tabular data model</a> of a single <a>table</a> <var>T</var> with five columns and two rows. The columns and rows have exactly the same annotations as previously, but there are two <code>null</code> cell values for <var>C2.2</var> and <var>C2.5</var>. Note that the quoting of values within the CSV makes no difference to either the <a>string value</a> or <a title="cell value">value</a> of the cell.
           </p>
           <table style="width: 100%; text-align: left">
             <thead>
-              <tr><th rowspan="2">id</th><th colspan="6">core properties</th></tr>
+              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th></tr>
               <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th></tr>
             </thead>
             <tbody>
@@ -976,11 +979,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 	        <section>
 	          <h5>Naive Parsing</h5>
 	          <p>
-	            Naive parsing of the above data will assume a comma separator and thus results in a single <a>table</a> <var>T</var> with a single column and six rows. The column has the properties shown in the following table:
+	            Naive parsing of the above data will assume a comma separator and thus results in a single <a>table</a> <var>T</var> with a single column and six rows. The column has the annotations shown in the following table:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th><th>annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th><th>annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th><th><code>title</code></th></tr>
 	            </thead>
 	            <tbody>
@@ -988,11 +991,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 	            </tbody>
 	          </table>
 	          <p>
-	            The rows have the properties shown in the following table:
+	            The rows have the annotations shown in the following table:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th></tr>
 	            </thead>
 	            <tbody>
@@ -1005,11 +1008,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 	            </tbody>
 	          </table>
 	          <p>
-	            The cells have the properties shown in the following table (note that the <a title="cell value">values</a> of all the cells in the table are strings, denoted by the double quotes in the table below):
+	            The cells have the annotations shown in the following table (note that the <a title="cell value">values</a> of all the cells in the table are strings, denoted by the double quotes in the table below):
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="6">core properties</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th></tr>
 	              <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th></tr>
 	            </thead>
 	            <tbody>
@@ -1076,11 +1079,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 							<dd><code>12/31/2010</code></dd>
 						</dl>
 						<p>
-							The columns have the properties shown in the following table:
+							The columns have the annotations shown in the following table:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th><th colspan="2">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th><th colspan="2">annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th></tr>
 	            </thead>
 	            <tbody>
@@ -1092,11 +1095,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 	            </tbody>
 	          </table>
 	          <p>
-	            The rows have the properties shown in the following table, exactly as in previous examples:
+	            The rows have the annotations shown in the following table, exactly as in previous examples:
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="3">core properties</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="3">core annotations</th></tr>
 	              <tr><th>table</th><th>number</th><th>cells</th></tr>
 	            </thead>
 	            <tbody>
@@ -1105,11 +1108,11 @@ GID,On Street,Species,Trim Cycle,Inventory Date
 	            </tbody>
 	          </table>
 	          <p>
-	            The cells have the properties shown in the following table. Because of the way the particular tabular data format has been specified, these include additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
+	            The cells have the annotations shown in the following table. Because of the way the particular tabular data format has been specified, these include additional annotations but also, for the <code>Inventory Date</code> column (cells <var>C1.5</var> and <var>C2.5</var>), have a <a title="cell value">value</a> that is a parsed date rather than an unparsed string.
 	          </p>
 	          <table style="width: 100%; text-align: left">
 	            <thead>
-	              <tr><th rowspan="2">id</th><th colspan="6">core properties</th><th colspan="2">annotations</th></tr>
+	              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th><th colspan="2">annotations</th></tr>
 	              <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th><th>datatype</th><th>format</th></tr>
 	            </thead>
 	            <tbody>


### PR DESCRIPTION
fixes #196 

The tabular data model has 'annotations' on it. The metadata contains 'properties' which are interpreted to create those annotations.
