### PR TITLE
More detailed parsing algorithm

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1270,7 +1270,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <dt id="cell-default"><code>default</code></dt>
           <dd>
             <p>
-              An <a>atomic property</a> holding a single string that is used to create a default <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> for the cell in cases where the original <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> is an empty string. This default value MAY be used when converting the table into other formats, or when the table is displayed. If not specified, the default for the <code>default</code> property is <code>null</code>.
+              An <a>atomic property</a> holding a single string that is used to create a default <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> for the cell in cases where the original <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> is an empty string. This default value MAY be used when converting the table into other formats, or when the table is displayed. If not specified, the default for the <code>default</code> property is the empty string, <code>""</code>.
             </p>
           </dd>
           <dt id="cell-format"><code>format</code></dt>
@@ -1470,14 +1470,15 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
         <ol>
           <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code> or <code>anySimpleType</code> or <code>any</code>, strip leading and trailing whitespace from the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a></li>
           <li>if the resulting string is an empty string, apply the remaining steps to the string given by the <a href="#cell-default"><code>default</code></a> property</li>
-          <li>if the resulting string is the same as the value of the <a href="#cell-null"><code>null</code></a> property, then the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is <code>null</code></li>
-          <li>otherwise, if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code>, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is a list of values created by:
+          <li>if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code> and the resulting string is an empty string, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is an empty list</li>
+          <li>if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code>, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is a list of values created by:
             <ol>
               <li>splitting the resulting string at the character specified by the <code>separator</code> property</li>
               <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code> or <code>anySimpleType</code> or <code>any</code>, stripping leading and trailing whitespace from these strings</li>
               <li>applying the remaining steps to each of the strings in turn</li>
             </ol>
           </li>
+          <li>if the string is the same as the value of the <a href="#cell-null"><code>null</code></a> property, then the resulting value is <code>null</code></li>
           <li>validate the string based on the datatype, using the <a href="#cell-format"><code>format</code></a> property if one is specified, as described below, and then against the constraints described in <a href="#datatypes" class="sectionRef"></a>; if there are any errors, add them to the list of <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> for the cell; the resulting value is typed as a <code>string</code> with the language provided by the <a href="#cell-lang"><code>lang</code></a> property</li>
           <li>otherwise, if there are no errors, parse the string using the <a href="#cell-format"><code>format</code></a> if one is specified, as described below; the resulting value is typed according to the <a href="#cell-datatype"><code>datatype</code></a> and if the <code>datatype</code> is <code>string</code> it has the language provided by the <a href="#cell-lang"><code>lang</code></a> property</li>
         </ol>
@@ -1531,6 +1532,9 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           </pre>
           <p>
             and this would mean that the cell's value would be an array containing two integers and a string: <code>[1, 5, "7.0"]</code>. The final value of the array is a string because it is not a valid integer; the cell's <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> annotation will also contain a validation error.
+          </p>
+          <p>
+            Also, with this configuration, if the string value of the cell were <code>""</code> (ie it was an empty cell) the value of the cell would be an empty list.
           </p>
         </section>
         <section>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1246,7 +1246,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <dt id="cell-empty-value"><code>null</code></dt>
           <dd>
             <p>
-              An <a>atomic property</a> giving the string or strings used for null values. If not specified, the default for this is the empty string.
+              An <a>atomic property</a> giving the string or strings used for null values within the data. If the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> of the cell is equal to this value, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is <code>null</code>. If not specified, the default for the <code>null</code> property is the empty string.
             </p>
           </dd>
           <dt id="cell-language"><code>lang</code></dt>
@@ -1270,7 +1270,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <dt id="cell-default"><code>default</code></dt>
           <dd>
             <p>
-              An <a>atomic property</a> holding a single string that provides a default string value for the cell in cases where the original string value is a <code>null</code> values. This default value MAY be used when converting the table into other formats.
+              An <a>atomic property</a> holding a single string that is used to create a default <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> for the cell in cases where the original <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> is an empty string. This default value MAY be used when converting the table into other formats, or when the table is displayed. If not specified, the default for the <code>default</code> property is <code>null</code>.
             </p>
           </dd>
           <dt id="cell-format"><code>format</code></dt>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1536,6 +1536,18 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <p>
             Also, with this configuration, if the string value of the cell were <code>""</code> (ie it was an empty cell) the value of the cell would be an empty list.
           </p>
+          <p>
+            Using the <code>valueUrl</code> property, a transformation can create a URL representation of a value, including if the value has a <a href="#cell-datatype"><code>datatype</code></a> and <a href="#cell-separator"><code>separator</code></a> (presuming the cell name is <code>values</code>):
+          </p>
+          <pre class="example highlight">
+"datatype": "integer",
+"minimum": 1,
+"maximum": 10,
+"default": "5",
+"separator": " ",
+"valueUrl": "{?values}"
+          </pre>
+          <p>After exampansion, the resulting <code>valueUrl</code> would be <code>?values=1,5,7.0</code>.</p>
         </section>
         <section>
           <h3>Formats for numeric types</h3>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -318,7 +318,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
               <dd><code>_name</code> is set to the URI decoded <a>property value</a> of the <code>name</code> property on the cell column that is currently being processed. <span class="note">URI decoding is necessary as <code>name</code> may have been encoded if taken from <code>title</code>; this prevents double URI encoding.</span>
               </dd>
               <dt>column names</dt>
-              <dd>a variable is set for each column within the schema; the name of the variable is the name of the column and the value is the canonical representation of the value of the cell in that column in the row that is currently being processed</dd>
+              <dd>a variable is set for each column within the schema; the name of the variable is the <a href="#cell-name"><code>name</code></a> of the column and the value is the canonical representation of the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> of the cell in that column in the row that is currently being processed</dd>
             </dl>
             <p>The <a>property value</a> of a <a>URI template property</a> is only available while converting tables as defined in <a href="#converting-tables" class="sectionRef"></a>. The value is the result of applying the template against the cell in that column in the row that is currently being processed, resolving against the <a>base URL</a> as a <a>link property</a> if the metadata value is explicit in the metadata, or the default value if defined; otherwise there is no value.</p>
             <p>
@@ -1243,7 +1243,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           Cell descriptions may override <a title="inherited property">inherited properties</a>, as described in <a href="#annotating-tables" class="sectionRef"></a>. It is good practice to define these properties on columns, so that all cells within a given column are handled in the same way, or on tables if appropriate. These properties are:
         </p>
         <dl>
-          <dt id="cell-empty-value"><code>null</code></dt>
+          <dt id="cell-null"><code>null</code></dt>
           <dd>
             <p>
               An <a>atomic property</a> giving the string or strings used for null values within the data. If the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> of the cell is equal to this value, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is <code>null</code>. If not specified, the default for the <code>null</code> property is the empty string.
@@ -1448,7 +1448,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
       <section>
         <h2>Parsing cells</h2>
         <p>
-          Unlike many other data formats, tabular data is designed to be read by humans. For that reason, it's common for data to be represented within tabular data in a human-readable way. The <a href="#cell-valueUrl"><code>valueUrl</code></a>, <code>separator</code> and <code>format</code> properties indicates the format used to represent data within the table. This is used:
+          Unlike many other data formats, tabular data is designed to be read by humans. For that reason, it's common for data to be represented within tabular data in a human-readable way. The <a href="#cell-null"><code>null</code></a>, <a href="#cell-default"><code>default</code></a>, <a href="#cell-separator"><code>separator</code></a>, <a href="#cell-datatype"><code>datatype</code></a>, <a href="#cell-format"><code>format</code></a> and <a href="#cell-lang"><code>lang</code></a> properties provide the information needed to parse the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell into its (semantic) <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a>. This is used:
         </p>
         <ul>
           <li>by <strong>validators</strong> to check that the data in the table is in the expected format</li>
@@ -1456,43 +1456,81 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <li>when <strong>displaying</strong> data, to map it into formats that are meaningful for those viewing the data (as opposed to those publishing it)</li>
           <li>when <strong>inputting</strong> data, to turn entered values into representations in a consistent format</li>
         </ul>
-        <p>The <strong><a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a></strong> of a cell is the result of processing the cell as defined here and applying any format-specific mappings to create on or more values. Converters MUST be provided these cell values, along with any in-scope <code>lang</code> and <code>datatype</code> <a title="property value">property values</a>.</p>
-        <div class="issue">
-          Adding inline coversation here until resolved.
-          <ul>
-            <li>@jenit said:
-              <blockquote>
-                Aren't converters provided everything from the metadata?
-              </blockquote>
-            </li>
-            <li>@gkellogg said:
-              <blockquote>
-                This statement just indicates the an implementation must provide lang and datatype information along with the value for use in the converter. My implementation creates a Cell class including everything needed for RDF or JSON to properly perform a transformation, but that detail is not defined here. Wording improvements are welcome.
-              </blockquote>
-            </li>
-          </ul>
-        </div>
+        <p>
+          After parsing, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> can be:
+        </p>
+        <ul>
+          <li><code>null</code></li>
+          <li>a single value with an associated optional datatype or language</li>
+          <li>a sequence of such values</li>
+        </ul>
         <p>
           The process of parsing the string value of a cell into a single value or a list of values is as follows:
         </p>
-        <p class="issue" data-number="61">
-          What should be the mapping of an empty cell? 
-        </p>
         <ol>
-          <li>unless the <code>datatype</code> is <code>string</code> or <code>anySimpleType</code> or <code>any</code>, strip leading and trailing whitespace from the value</li>
-          <li>if the value is the same as the <code>null</code> value, then the value is <code>null</code></li>
-          <li>if the <code>separator</code> property is not <code>null</code>, create a list of values by splitting the string at the character specified by the <code>separator</code> property</li>
-          <li>validate the value(s) against the <code>format</code>, if one is specified, as described below; raise an error if any of the values do not match the specified format</li>
-          <li>if the cell column has a <a href="#cell-valueUrl"><code>valueUrl</code></a> the value(s) are the result of applying the URI template to each value as described in <a>URI template property</a>.</cite></li>
-          <li>parse the value(s) using the <code>format</code>, as described below</li>
+          <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code> or <code>anySimpleType</code> or <code>any</code>, strip leading and trailing whitespace from the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a></li>
+          <li>if the resulting string is an empty string, apply the remaining steps to the string given by the <a href="#cell-default"><code>default</code></a> property</li>
+          <li>if the resulting string is the same as the value of the <a href="#cell-null"><code>null</code></a> property, then the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is <code>null</code></li>
+          <li>otherwise, if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code>, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is a list of values created by:
+            <ol>
+              <li>splitting the resulting string at the character specified by the <code>separator</code> property</li>
+              <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code> or <code>anySimpleType</code> or <code>any</code>, stripping leading and trailing whitespace from these strings</li>
+              <li>applying the remaining steps to each of the strings in turn</li>
+            </ol>
+          </li>
+          <li>validate the string based on the datatype, using the <a href="#cell-format"><code>format</code></a> property if one is specified, as described below, and then against the constraints described in <a href="#datatypes" class="sectionRef"></a>; if there are any errors, add them to the list of <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> for the cell; the resulting value is typed as a <code>string</code> with the language provided by the <a href="#cell-lang"><code>lang</code></a> property</li>
+          <li>otherwise, if there are no errors, parse the string using the <a href="#cell-format"><code>format</code></a> if one is specified, as described below; the resulting value is typed according to the <a href="#cell-datatype"><code>datatype</code></a> and if the <code>datatype</code> is <code>string</code> it has the language provided by the <a href="#cell-lang"><code>lang</code></a> property</li>
         </ol>
-        <section>
-          <h3>Formats for strings</h3>
+        <section class="informative">
+          <h3>Parsing examples</h3>
           <p>
-            If the <code>datatype</code> is a string type, the <code>format</code> property provides a regular expression for the string values, in the syntax and processed as defined by [[!ECMASCRIPT]].
+            When no metadata is available, the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> of a cell is the same as its <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a>. For example, a cell with a string value of <code>"99"</code> would similarly have the (semantic) value <code>"99"</code>.
           </p>
-          <p class="note">
-            Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
+          <p>
+            If a <a href="#cell-datatype"><code>datatype</code></a> is provided for the cell, that is used to create a (semantic) value for the cell. For example, if the metadata contains:
+          </p>
+          <pre class="example highlight">
+"datatype": "integer"
+          </pre>
+          <p>
+            for the cell with the string value <code>"99"</code> then the value of that cell will be the integer <code>99</code>. A cell whose string value was not a valid integer (such as <code>"one"</code> or <code>"1.0"</code>) would be assigned that string value as its (semantic) value, but also have a validation error listed in its <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> annotation.
+          </p>
+          <p>
+            Sometimes data uses special codes to indicate unknown or null values. For example, a particular column might contain a number that is expected to be between <code>1</code> and <code>10</code>, with the string <code>99</code> used in the original tabular data file to indicate a null value. The metadata for such a column would include:
+          </p>
+          <pre class="example highlight">
+"datatype": "integer",
+"minimum": 1,
+"maximum": 10,
+"null": "99"
+          </pre>
+          <p>
+            In this case, a cell with a string value of <code>"5"</code> would have the (semantic) value of the integer <code>5</code>; a cell with a string value of <code>"99"</code> would have the value <code>null</code>.
+          </p>
+          <p>
+            Similarly, a cell may be assigned a default value if the string value for the cell is empty. A configuration such as:
+          </p>
+          <pre class="example highlight">
+"datatype": "integer",
+"minimum": 1,
+"maximum": 10,
+"default": "5"
+          </pre>
+          <p>
+            In this case, a cell whose string value is <code>""</code> would be assigned the value of the integer <code>5</code>. A cell whose string value contains whitespace, such as a single tab character, would also be assigned the value of the integer <code>5</code>: when the datatype is something other than <code>string</code> or <code>anySimpleType</code> or <code>any</code>, leading and trailing whitespace is stripped from string values before the remainder of the processing is carried out.
+          </p>
+          <p>
+            Cells can contain sequences of values. For example, a cell might have the string value <code>"1 5 7.0"</code>. In this case, the separator is a space character. The appropriate configuration would be:
+          </p>
+          <pre class="example highlight">
+"datatype": "integer",
+"minimum": 1,
+"maximum": 10,
+"default": "5",
+"separator": " "
+          </pre>
+          <p>
+            and this would mean that the cell's value would be an array containing two integers and a string: <code>[1, 5, "7.0"]</code>. The final value of the array is a string because it is not a valid integer; the cell's <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> annotation will also contain a validation error.
           </p>
         </section>
         <section>
@@ -1501,10 +1539,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             It is not uncommon for numbers within tabular data to be formatted for human consumption, which may involve using commas for decimal points, grouping digits in the number using commas, or adding currency symbols or percent signs to the number.
           </p>
           <p>
-            If the <code>datatype</code> is a numeric type, the <code>format</code> property indicates the expected format for that number. <a>Validators</a> MUST check that the numbers in the column adhere to the specified format. <a>Converters</a> MUST use the <code>format</code> property to parse the number when mapping it into a suitable type in the target format of the conversion.
-          </p>
-          <p>
-            When the <code>datatype</code> is a numeric type, the <code>format</code> property's value MUST be either a single string or an object with one or more of the properties:
+            If the <a href="#cell-datatype"><code>datatype</code></a> is a numeric type, the <a href="#cell-format"><code>format</code></a> property indicates the expected format for that number. Its value MUST be either a single string or an object with one or more of the properties:
           </p>
           <dl>
             <dt id="decimalChar"><code>decimalChar</code></dt>
@@ -1515,10 +1550,10 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <dd>A regular expression string, in the syntax and interpreted as defined by [[!ECMASCRIPT]].</dd>
           </dl>
           <p>
-            If the <code>format</code> property is a single string, this is interpreted in the same way as if it were an object with a <code>pattern</code> property whose value is that string.
+            If the <a href="#cell-format"><code>format</code></a> property is a single string, this is interpreted in the same way as if it were an object with a <code>pattern</code> property whose value is that string.
           </p>
           <p>
-            When parsing a value against this format specification, implementations MUST recognise and parse numbers that consist of:
+            When parsing the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell against this format specification, implementations MUST recognise and parse numbers that consist of:
           </p>
           <ol>
             <li>an optional <code>+</code> or <code>-</code> sign</li>
@@ -1529,10 +1564,17 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <li>followed by an optional percent (<code>%</code>) or per-mille (<code>&permil;</code>) sign</li>
           </ol>
           <p>
-            Implementations MUST raise an error if a number does not meet the format defined above, or if it contains two consecutive <a href="#groupChar"><code>groupChar</code></a> characters, or if it does not match the regular expression defined in the <a href="#number-pattern"><code>pattern</code></a> property, if there is one.
+            Implementations MUST add a validation error to the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">errors</a> annotation for the cell if the string being parsed:
           </p>
+          <ul>
+            <li>does not meet the numeric format defined above</li>
+            <li>contains two consecutive <a href="#groupChar"><code>groupChar</code></a> characters</li>
+            <li>does not match the regular expression defined in the <a href="#number-pattern"><code>pattern</code></a> property, if there is one</li>
+            <li>contains the <a href="#decimalChar"><code>decimalChar</code></a>, if the <a href="#cell-datatype"><code>datatype</code></a> is <code>integer</code> or one of its sub-values</li>
+            <li>contains an exponent, if the <a href="#cell-datatype"><code>datatype</code></a> is <code>decimal</code> or one of its sub-values</li>
+          </ul>
           <p>
-            <a>Converters</a> MUST use the sign, exponent, percent and per-mille signs when interpreting the number ready for conversion. For example, the string value <code>-25%</code> must be interpreted as <code>-0.25</code> and the string value <code>1E6</code> as <code>1000000</code>.
+            Implementations MUST use the sign, exponent, percent and per-mille signs when parsing the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell to provide the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">value</a> of the cell. For example, the string value <code>"-25%"</code> must be interpreted as <code>-0.25</code> and the string value <code>"1E6"</code> as <code>1000000</code>.
           </p>
         </section>
         <section>
@@ -1541,9 +1583,11 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             Boolean values may be represented in many ways aside from the standard <code>1</code> and <code>0</code> or <code>true</code> and <code>false</code>.
           </p>
           <p>
-            If the <code>datatype</code> is <code>boolean</code>, the <code>format</code> property provides the true and false values expected, separated by <code>|</code>. For example if <code>format</code> is <code>Y|N</code> then cells must hold either <code>Y</code> or <code>N</code> with <code>Y</code> meaning <code>true</code> and <code>N</code> meaning <code>false</code>.
+            If the <a href="#cell-datatype"><code>datatype</code></a> for a cell is <code>boolean</code>, the <a href="#cell-format"><code>format</code></a> property provides the true and false values expected, separated by <code>|</code>. For example if <code>format</code> is <code>Y|N</code> then cells must hold either <code>Y</code> or <code>N</code> with <code>Y</code> meaning <code>true</code> and <code>N</code> meaning <code>false</code>.
           </p>
-          <p>The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is one or more <code>true</code> or <code>false</code> values.</p>
+          <p>
+            The resulting <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> will be one or more boolean <code>true</code> or <code>false</code> values.
+          </p>
         </section>
         <section>
           <h3>Formats for dates and times</h3>
@@ -1551,7 +1595,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             Dates and times are commonly represented in tabular data in formats other than those defined in [[!xmlschema-2]].
           </p>
           <p>
-            If the <code>datatype</code> is a date or time type, the <code>format</code> property indicates the expected format for that date or time. <a>Validators</a> MUST check that the dates or times in the column adhere to the specified format. <a>Converters</a> MUST use the <code>format</code> property to parse the date or time when mapping it into a suitable type in the target language of the conversion.
+            If the <a href="#cell-datatype"><code>datatype</code></a> is a date or time type, the <a href="#cell-format"><code>format</code></a> property indicates the expected format for that date or time.
           </p>
           <p>
             The following date formats MUST be recognised by implementations:
@@ -1586,24 +1630,34 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           </p>
           <ul>
             <li><code>yyyy-MM-ddTHH:mm:ss</code> eg <code>2015-03-15T15:02:37</code></li>
-            <li>Any of the date formats above, followed by a space, followed by any of the time formats above, eg <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
+            <li>any of the date formats above, followed by a space, followed by any of the time formats above, eg <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
           </ul>
           <p>
             The supported date and time formats listed above are expressed in terms of the <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table">date field symbols</a> defined in [[!UAX35]] and should be interpreted by implementations as defined in that specification.
           </p>
-          <p>The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is one or more dates or times extracted using the <code>format</code>.</p>
+          <p>
+            The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> will one or more dates/time values extracted using the <code>format</code>.
+          </p>
           <p class="note">
             For simplicity, this version of this standard does not support abbreviated or full month or day names, or double digit years. Future versions of this standard may support other date and time formats, or general purpose date/time pattern strings. Authors of schemas SHOULD use appropriate regular expressions, along with the <code>string</code> datatype, for dates and times that use a format other than that specified here.
-          </p>
-          <p class="issue" data-number="65">
-            Register of recognised date-time picture string formats.
           </p>
         </section>
         <section>
           <h3>Formats for durations</h3>
           <p>
             Durations MUST be formatted and interpreted as defined in [[!xmlschema-2]], using the [[!ISO8601]] format <code>P<var>n</var>Y<var>n</var>M<var>n</var>DT<var>n</var>H<var>n</var>M<var>n</var>S</code>.
-          <p>The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is one or more durations extracted using the <code>format</code>.</p>
+          </p>
+          <p>
+            The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> will be one or more durations extracted using the <code>format</code>.</p>
+          </p>
+        </section>
+        <section>
+          <h3>Formats for other types</h3>
+          <p>
+            If the <a href="#cell-datatype"><code>datatype</code></a> is not numeric, <code>boolean</code>, a date/time type or a duration type, the <code>format</code> property provides a regular expression for the string values, in the syntax and processed as defined by [[!ECMASCRIPT]].
+          </p>
+          <p class="note">
+            Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
           </p>
         </section>
       </section>


### PR DESCRIPTION
For #61. Includes specific order of processing of `null` and `default` properties, more detail about the handling of sequences, and including examples.

Note that I've made it more explicit that the parsing is all to do with creating the **cell value**. I've also changed things such that the `valueUrl` is not used to provide a **cell value**. I think instead that the `valueUrl` should be a separate property on the column, and any conversion look first to see if the `valueUrl` exists (and use that) before looking at the **cell value**. This makes things easier when it comes to expanding the URI template properties, because they can always reference the **cell value** to expand properties without getting into an infinite recursion if the `valueUrl` contains a variable reference to the column it is on.

(Don't merge yet, need to double check handling of empty sequences.)
