### PR TITLE
Name syntactic restrictions

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1196,9 +1196,6 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <p>
                 For ease of reference within <a title="URI template property">URI template properties</a>, column names MUST consist only of alphanumeric characters, underscores, or <code>"."</code> (<code>[a-zA-Z0-9][a-zA-Z0-9_\.]*</code>). Names beginning with <code>"_"</code> or  <code>"."</code> are reserved by this specification and MUST NOT be used.
               </p>
-              <p class="issue" data-number="53">
-                We invite comment on what the syntactic limitations should be on column names to make them most useful when used as the basis of conversion into other formats, bearing in mind that different target languages such as JSON, RDF and XML have different syntactic limitations and common naming conventions.
-              </p>
               <p>
                 During validation, if there is no <code>title</code> property and the column already has a <code>title</code> annotation then a validator MUST issue a warning if the existing <code>title</code> annotation does not match the <code>name</code> specified in the column description.
               </p>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1194,7 +1194,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first value from the <a>property value</a> of <code>title</code> having the same language tag as <a>default language</a> or <code>und</code> of not specified percent-encoded as necessary to conform to the syntactic requirements described below, as a string without language, if any. Otherwise, it is the string <code>"_col.<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-column-number">column number</a>.
               </p>
               <p>
-                For ease of reference within <a title="URI template property">URI template properties</a>, column names MUST consist only of alphanumeric characters, underscores, or <code>"."</code> (<code>[a-zA-Z0-9][a-zA-Z0-9_\.]*</code>). Names beginning with <code>"_"</code> or  <code>"."</code> are reserved by this specification and MUST NOT be used.
+                For ease of reference within <a title="URI template property">URI template properties</a>, column names MUST consist only of alphanumeric characters, underscores, or <code>"."</code> (matching <code>[a-zA-Z0-9][a-zA-Z0-9_\.]*</code>). Names beginning with <code>"_"</code> are reserved by this specification and MUST NOT be used.
               </p>
               <p>
                 During validation, if there is no <code>title</code> property and the column already has a <code>title</code> annotation then a validator MUST issue a warning if the existing <code>title</code> annotation does not match the <code>name</code> specified in the column description.


### PR DESCRIPTION
Simply removed the issue #53 marker, as it seems that the text describes the syntactic restrictions.

@JeniT, please pull if I've correctly captured what you think is necessary, otherwise, please suggest a change that would satisfy this.
