### PR TITLE
tweaked valueUrl example

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1518,17 +1518,16 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             Also, with this configuration, if the string value of the cell were <code>""</code> (ie it was an empty cell) the value of the cell would be an empty list.
           </p>
           <p>
-            Using the <code>valueUrl</code> property, a transformation can create a URL representation of a value, including if the value has a <a href="#cell-datatype"><code>datatype</code></a> and <a href="#cell-separator"><code>separator</code></a> (presuming the cell name is <code>values</code>):
+            A <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> can be inserted into a URL created using a <a>URI template property</a> such as <code>valueUrl</code>. For example, if a cell with the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-string-value" class="externalDFN">string value</a> <code>"1 5 7.0"</code> were in a column named <code>values</code>, defined with:
           </p>
           <pre class="example highlight">
-"datatype": "integer",
-"minimum": 1,
-"maximum": 10,
-"default": "5",
+"datatype": "decimal",
 "separator": " ",
 "valueUrl": "{?values}"
           </pre>
-          <p>After exampansion, the resulting <code>valueUrl</code> would be <code>?values=1,5,7.0</code>.</p>
+          <p>
+            then after expansion of the URI template, the resulting <code>valueUrl</code> would be <code>?values=1.0,5.0,7.0</code>. The canonical representations of the decimal values are used within the URL.
+          </p>
         </section>
         <section>
           <h3>Formats for numeric types</h3>


### PR DESCRIPTION
to show canonical representations being used as well as a sequence of
values
