### PR TITLE
Made role of tableSchema on table groups clear

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -671,7 +671,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
           <dl>
             <dt id="table-group-schema"><code>tableSchema</code></dt>
             <dd>
-              <p>An <a>object property</a> that provides a single <a>schema description</a> as described in <a href="#schemas" class="sectionRef"></a>, for all the tables in the group. This may be provided as an embedded object within the JSON metadata or as a URL reference to a separate JSON schema document.</p>
+              <p>An <a>object property</a> that provides a single <a>schema description</a> as described in <a href="#schemas" class="sectionRef"></a>, used as the default for all the tables in the group. This may be provided as an embedded object within the JSON metadata or as a URL reference to a separate JSON schema document.</p>
             </dd>
             <dt id="table-group-direction"><code>tableDirection</code></dt>
             <dd>
@@ -732,7 +732,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
           <dl>
             <dt id="table-schema"><code>tableSchema</code></dt>
             <dd>
-              <p>An <a>object property</a> that provides a single <a>schema description</a> as described in <a href="#schemas" class="sectionRef"></a>. This may be provided as an embedded object within the JSON metadata or as a URL reference to a separate JSON schema document.</p>
+              <p>An <a>object property</a> that provides a single <a>schema description</a> as described in <a href="#schemas" class="sectionRef"></a>. This may be provided as an embedded object within the JSON metadata or as a URL reference to a separate JSON schema document. If a table description is within a <a>table group description</a>, the <code>tableSchema</code> from that table group acts as the default for this property.</p>
             </dd>
             <dt id="table-notes"><code>notes</code></dt>
             <dd>


### PR DESCRIPTION
fixes #195 

The interaction between the defaulting of `tableSchema` and the merge algorithm needs to be made clear (ie does it happen during normalisation, or after the merge has taken place - I think the latter), but I think this should happen as part of resolving #200.
