### PR TITLE
Amended UCR document to reflect decisions of F2F meeting

### DIFF
--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -3785,9 +3785,6 @@ catalogNumber,scientificName,individualCount,datasetID
                 geometry expressed as well-known-text (<code>geo:wktLiteral</code>,
                 GeoSPARQL [[geosparql]] section <em>8.5.1 RDFS Datatypes</em> refers).</p>
               </div>
-              <div class="issue">
-                <p>Is there any intent for the CSV parser to validate that a given cell conforms to the type declaration?</p>
-              </div>
               <p>
                 <strong>Motivation:</strong>
                 <a href="#UC-SurfaceTemperatureDatabank">SurfaceTemperatureDatabank</a>, 

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -2012,16 +2012,6 @@ data:
           data consumer may wish to work directly with the canonical mapping and wish to ignore any semantic
           annotations provided by the publisher.</p>
         
-        <div class="issue">
-          <p>This use case lacks a concrete example to further illustrate the concerns. Whilst the concerns
-            outlined above are relevant for a gamut of open data publication, it would be useful to include 
-            an example dataset here - which might be subsequently used in test suites relating to the 
-            motivating requirements of this use case.</p>
-          
-          <p>It may be appropriate to merge this use case with <a href="#UC-IntelligentlyPreviewingCSVFiles">
-            UC-IntelligentlyPreviewingCSVFiles</a> as that is concerned with using an interim JSON
-            encoding to support intelligent preview of unannotated tabular data.</p>
-          </div>
       </section>
       <section id="UC-SupportingSemantic-basedRecommendations">
         <h2>Use Case #18 - Supporting Semantic-based Recommendations</h2>

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -3099,10 +3099,6 @@ Major Group,Minor Group,Broad Group,Detailed Occupation,                        
         identifier for a detailed occupation code into its constituent parts from which the 
         identifiers for the associated broader concepts could be constructed.</p>
 
-        <div class="issue">
-          <p>The REGEXP needs to be verified as correct.</p>
-        </div>
-
         <p><strong>Requires:</strong>
           <a href="#R-CellMicrosyntax">CellMicrosyntax</a>.</p>
 

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -2612,10 +2612,6 @@ OBSNEV:SINFONEVADA:SINFON-100-008211-20040930	2013-06-20T11:18:18	OBSNEV	SINFONE
           of writing. Details can be found on the <a href="https://github.com/geojson/geojson-ld">GeoJSON GitHub</a>.</p>
         </div>
         
-        <div class="issue">
-          <p>The example "GeoJSON-LD" needs to be verified as correct.</p>
-        </div>
-        
         <div class="note">
           <p>It is the hope of the DwC-A format specification authors that the availability
           of general metadata vocabulary for describing CSV files, or indeed any tabular text

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -382,18 +382,7 @@ var respecConfig = {
           <strong>Requires:</strong>
           <a href="#R-MultipleHeadingRows">MultipleHeadingRows</a> and
           <a href="#R-AnnotationAndSupplementaryInfo">AnnotationAndSupplementaryInfo</a>.
-        </p>	
-        
-        
-        <div class="issue">
-          <p>Do we want to be able to assert within the CSV+ metadata that the "data" exists at a
-            particular region within the CSV? When talking about multiple tables within a single CSV
-            file, AndyS <a
-              href="http://lists.w3.org/Archives/Public/public-csv-wg/2014Feb/0108.html"
-              >stated</a>:</p>
-          <p> "<em>Maybe put the location of the data table within a single CSV file into the
-            associated metadata: a package description for a single file.</em>" </p>
-        </div>
+        </p>
         
         
         <p>Correct interpretation of the statistics requires additional qualification or

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -3645,13 +3645,6 @@ catalogNumber,scientificName,individualCount,datasetID
                 e.g. using a foreign key type reference. The cross-referenced CSV files may, or may
                 not, be packaged together.</p>
               <p>
-              <div class="issue">
-                <p>AndyS <a href="http://lists.w3.org/Archives/Public/public-csv-wg/2014May/0102.html">suggests</a> 
-                that: "<em>The cross reference between files should be limited to files
-                from one publisher - else they are just web links with no guarantee of whether the target
-                of the link exists which 'foreign key' might imply.</em>"</p>
-                <p>This seems like a sensible recommendation - but needs confirmation from the group.</p>
-              </div>
                 <strong>Motivation:</strong>
                 <a href="#UC-DigitalPreservationOfGovernmentRecords">DigitalPreservationOfGovernmentRecords</a>, 
                 <a href="#UC-OrganogramData">OrganogramData</a>, 

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -54,6 +54,7 @@ var respecConfig = {
            href: "https://github.com/w3c/csvw/commits/gh-pages"
        }]
     }],
+    issueBase: "https://github.com/w3c/csvw/issues/",
     localBiblio: {
       "rdf11-concepts": {
           "authors": [
@@ -3295,20 +3296,10 @@ ex:15-1199.03 a ex:ONETSOC-Occupation ;
                 <a href="#UC-NetCdFcDl">NetCdFcDl</a> and
                 <a href="#UC-PaloAltoTreeData">PaloAltoTreeData</a>.
               </p>
-              <div class="issue">
-                <p>David Booth <a href="http://lists.w3.org/Archives/Public/public-csv-wg/2014Apr/0045.html">suggests</a>:</p>
-                <p>"<em>It sounds like the R-CsvValidation requirement may need to be split into 
-                  two separate validation requirements:</em></p>
-                <p><em>R-CsvOpenValidation:
-                  Does the data in the CSV conform to the metadata, ignoring 
-                  inapplicable metadata?  For example, is every column in the CSV 
-                  described by some metadata?</em></p>
-                <p><em>R-CsvClosedValidation:
-                  Does the metadata describe anything that does NOT appear in the CSV?</em></p>
-                <p><em>I suppose if the metadata had a notion of optional columns then both of 
-                  these cases could be covered at once.</em>"</p>
-                <p>However, at this point the use cases only appear to relate to the <em>closed</em>
-                validation case. <strong>Do we need another use case to support <em>open</em> validation?</strong></p>
+              <div class="issue" data-number="246">
+                <p><a href="https://github.com/w3c/csvw/pull/225">PR #225</a> introduced multiple validation modes into the metadata vocabulary in response to <a href="https://github.com/w3c/csvw/issues/14">ISSUE #14</a> (now closed) that identified the need for open and closed validation.</p>
+                <p>However, the Use Case document doesn't explicitly provide a case for this functionality. At present, the Use Cases only refer to closed validation. A new Use Case should be added to discuss open validation.</p>
+                <p>Furthermore, the Requirement <a href="#R-CsvValidation">R-CsvValidation</a> needs to be amended to describe the difference between open and closed validation - and the additional modes 'extension' and 'restriction' that have been added to the metadata vocabulary.</p>
               </div>
             </dd>
             <dt id="R-CsvToRdfTransformation">R-CsvToRdfTransformation</dt>

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -3590,12 +3590,6 @@ catalogNumber,scientificName,individualCount,datasetID
                   to <a href="#R-SyntacticTypeDefinition">R-SyntacticTypeDefinition</a> for more details on validation
                   of data types.</p>
               </div>
-
-              <div class="issue">
-                <p>Do we want to provide a mechanism to hook user-defined call-back functions 
-                (or <a href="http://heycam.github.io/webidl/#idl-promise">Promises</a>) into the CSV parser
-                to validate and process / convert embedded structured or semi-structured content?</p>
-              </div>
                         
               <p><strong>Motivation:</strong>
                 <a href="#UC-JournalArticleSearch">JournalArticleSearch</a>,

--- a/use-cases-and-requirements/index.html
+++ b/use-cases-and-requirements/index.html
@@ -3761,10 +3761,6 @@ catalogNumber,scientificName,individualCount,datasetID
                 <a href="#UC-ChemicalImaging">ChemicalImaging</a> and
                 <a href="#UC-NetCdFcDl">NetCdFcDl</a>.
               </p>
-              <div class="issue">
-                <p>Ivan <a href="http://lists.w3.org/Archives/Public/public-csv-wg/2014May/0103.html">says</a>:</p>
-                <p>"<em>Hm. Do we define CSV packaging in this Working Group? Is this in scope? We could decide it is, though we should check this with the charter.</em>"</p>
-              </div>
             </dd>
             <dt id="R-SyntacticTypeDefinition">R-SyntacticTypeDefinition</dt>
             <dd>


### PR DESCRIPTION
9 out of 10 issues are now removed from the document. The only one remaining relates to provision of a use case for open validation and ensuring that the validation requirement reflects the modes of validation now described in the metadata document.
