### PR TITLE
Describe `resources` as a core annotation of a group of tables.

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -234,11 +234,10 @@ var respecConfig = {
       <section>
         <h3>Grouped Tabular Data Model</h3>
         <p>
-          A <dfn>group of tables</dfn> comprises a set of <a title="annotated table">annotated tables</a> and a set of annotations that relate to the set.
+          A <dfn>group of tables</dfn> comprises a set of <a title="annotated table">annotated tables</a> and a set of annotations that relate to the set. The core annotation of a group of tables is:
         </p>
-        <p class="note">
-          Tables can be loosely related to each other simply through annotations; not all tables that are related to each other need to grouped together. Groups of tables are useful because they can be annotated with metadata that applies to all the tables in the group.
-        </p>
+        <ul>
+          <li><dfn title="table group resources">resources</dfn> &mdash; the list of <a title="table">tables</a> in the group of tables. A group of tables MUST have one or more tables</li>
       </section>
     </section>
     <section>


### PR DESCRIPTION
This fixes #260.
