### PR TITLE
rephrasing definition of `@id`

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -693,7 +693,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             </dd>
             <dt id="table-group-ld-id"><code>@id</code></dt>
             <dd>
-              If included, <code>@id</code> identifies the <a>table group description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.
+              If included, <code>@id</code> identifies the <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">group of tables</a>, as defined by [[!tabular-model]], described by this <a>table group description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.
             </dd>
             <dt id="table-group-ld-type"><code>@type</code></dt>
             <dd>
@@ -759,7 +759,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             </dd>
             <dt id="table-ld-id"><code>@id</code></dt>
             <dd>
-              <p>If included, <code>@id</code> identifies the <a>table description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
+              <p>If included, <code>@id</code> identifies the <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">table</a>, as defined in [[!tabular-model]], described by this <a>table description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
             </dd>
             <dt id="table-ld-type"><code>@type</code></dt>
             <dd>
@@ -838,7 +838,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
           </dd>
           <dt id="dialect-ld-id"><code>@id</code></dt>
           <dd>
-            <p>If included, <code>@id</code> identifies the <a>dialect description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
+            <p>If included, <code>@id</code> identifies the dialect described by this <a>dialect description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
           </dd>
           <dt id="dialect-ld-type"><code>@type</code></dt>
           <dd>
@@ -926,7 +926,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
             </dd>
             <dt id="conversion-ld-id"><code>@id</code></dt>
             <dd>
-              <p>If included, <code>@id</code> identifies the <a>conversion specification</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
+              <p>If included, <code>@id</code> identifies the conversion described by this <a>conversion specification</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
             </dd>
             <dt id="conversion-ld-type"><code>@type</code></dt>
             <dd>
@@ -1043,7 +1043,7 @@ GID,On Street,Species,Trim Cycle,Inventory Date
           </dd>
           <dt id="schema-ld-id"><code>@id</code></dt>
           <dd>
-            <p>If included, <code>@id</code> identifies the <a>schema description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
+            <p>If included, <code>@id</code> identifies the <a>schema</a> described by this <a>schema description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
           </dd>
           <dt id="schema-ld-type"><code>@type</code></dt>
           <dd>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1308,7 +1308,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             </dd>
             <dt id="column-ld-id"><code>@id</code></dt>
             <dd>
-              <p>If included, <code>@id</code> identifies the <a>column description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
+              <p>If included, <code>@id</code> identifies the <a href="http://w3c.github.io/csvw/syntax/#dfn-column" class="externalDFN">columns</a>, as defined in [[!tabular-model]] and potentially appearing across separate tables, described by this <a>column description</a>. Publishers MAY include this to provide additional information to JSON-LD based toolchains.</p>
             </dd>
             <dt id="column-ld-type"><code>@type</code></dt>
             <dd>


### PR DESCRIPTION
fixes #268 

This has fixed most of the definitions of `@id`. However, we need to put some thought into what we do around column descriptions. These descriptions actually describe a whole set of columns: all the columns at that particular index in tabular data that follows the relevant schema. So I think the `@id` is identifying that set of columns and `@type` should be `Columns` rather than `Column` to make that clearer. I haven't made that change though as I wanted to discuss it first.
