### PR TITLE
Made a number of small changes on csv2rdf

### DIFF
--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -168,7 +168,7 @@ var respecConfig = {
 
       <p>The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-grouped-tabular-data-model" class="externalDFN">grouped tabular data model</a> describes a <a href="http://www.w3.org/TR/tabular-data-model/#dfn-group-of-tables" class="externalDFN">table group</a> that is a collection of <a href="http://www.w3.org/TR/tabular-data-model/#dfn-table" class="externalDFN">tables</a> published as a single atomic unit.</p>
 
-      <p>The conversion procedure described in this specification operates on the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-tabular-data" class="externalDFN">tabular data</a>. No discussion is given to the processes needed to convert CSV-encoded data into tabular data form. Please refer to [[!tabular-data-model]] for details of <a href="http://www.w3.org/TR/tabular-data-model/#parsing">parsing tabular data</a>.</p>
+      <p>The conversion procedure described in this specification operates on the <a href="http://www.w3.org/TR/tabular-data-model/#dfn-tabular-data" class="externalDFN">tabular data</a>. This specification does not specify the processes needed to convert CSV-encoded data into tabular data form. Please refer to [[!tabular-data-model]] for details of <a href="http://www.w3.org/TR/tabular-data-model/#parsing">parsing tabular data</a>.</p>
 
       <p>Conversion applications MUST provide at least two modes of operation: <a title="standard mode">standard</a> and <a title="minimal mode">minimal</a>.</p>
 
@@ -220,7 +220,7 @@ var respecConfig = {
           <dd>The <a href="http://www.w3.org/TR/tabular-data-model/#dfn-annotated-table" class="externalDFN">annotated table</a> is defined in [[!tabular-data-model]] as describing a particular <a href="http://www.w3.org/TR/tabular-data-model/#dfn-table-description" class="externalDFN">table</a> and its metadata.</dd>
 
           <dt><dfn>blank node</dfn></dt>
-          <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node" class="externalDFN">blank node</a> is defined in [[!rdf11-concepts]] as a <a>node</a> without an identifier.</dd>
+          <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node" class="externalDFN">blank node</a> is defined in [[!rdf11-concepts]] as an <a href="http://www.w3.org/TR/rdf11-concepts/#section-triples" class="externalDFN">RDF Term</a> disjoint from IRIs or <a title="literal node">literals</a>.</dd>
 
           <dt><dfn>cell</dfn></dt>
           <dd>A <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell" class="externalDFN">cell</a> is defined in [[!tabular-data-model]] as the intersection of a <a>row</a> and a <a>column</a> within a <a title="annotated table">table</a>.</dd>
@@ -229,7 +229,7 @@ var respecConfig = {
           <dd><a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-errors" class="externalDFN">Cell errors</a> are defined in [[!tabular-data-model]] as a (possibly empty) list of validation errors generated while parsing the literal content of a <a>cell</a> to generate the <a title="cell value">semantic value</a>.</dd>
 
           <dt><dfn>cell value</dfn></dt>
-          <dd>A <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is defined in [[!tabular-data-model]] as the semantic value of the <a>cell</a>; this MAY be <code>null</code> or, the event that the <a>cell</a> specifies a <a href="http://www.w3.org/TR/tabular-metadata/#cell-separator"><code>separator</code></a> property, a sequence of values.</dd>
+          <dd>A <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell-value" class="externalDFN">cell value</a> is defined in [[!tabular-data-model]] as the semantic value of the <a>cell</a>; this MAY be <code>null</code> or, in the case that the <a>cell</a> specifies a <a href="http://www.w3.org/TR/tabular-metadata/#cell-separator"><code>separator</code></a> property, a sequence of values.</dd>
 
           <dt><dfn>column</dfn></dt>
           <dd>A <a href="http://www.w3.org/TR/tabular-data-model/#dfn-column" class="externalDFN">column</a> is defined in [[!tabular-data-model]] as a vertical arrangement of <a title="cell">cells</a> within a <a title="annotated table">table</a>.</dd>
@@ -244,7 +244,7 @@ var respecConfig = {
           <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal" class="externalDFN">literal node</a> is defined in [[!rdf11-concepts]] as a <a>node</a> within an RDF graph that provides values such as strings, numbers, and dates.</dd>
           
           <dt><dfn>node</dfn></dt>
-          <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-node" class="externalDFN">node</a> is defined in [[!rdf11-concepts]] as a subject of an RDF triple.</dd>
+          <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-node" class="externalDFN">node</a> is defined in [[!rdf11-concepts]] as a subject or an object of an RDF triple. When in subject position, it can be either a <a>blank node</a> or identified with a URL; when in object position, it can be a <a>blank node</a>, a <a title="literal node">literal</a>, or identified with a URL.</dd>
 
           <dt><dfn>notes</dfn></dt>
           <dd>A list of <a href="http://www.w3.org/TR/tabular-data-model/#dfn-table-notes" class="externalDFN">notes</a>, as defined in [[!tabular-data-model]], attached to an <a title="annotated table">annotated table</a> using the <code>notes</code> property. This may be an empty list.</dd>
@@ -290,7 +290,7 @@ var respecConfig = {
         <ol>
           <li>
             <p>In <strong><a>standard mode</a></strong> only, establish a new <a>node</a> <var>G</var> in the <a>output graph</a>.</p>
-            <p>If the <a>table group</a> has an <a>identifier</a> then <a>node</a> <var>G</var> SHALL be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>G</var> SHALL be a <a>blank node</a>.</p>
+            <p>If the <a>table group</a> has an <a>identifier</a> then <a>node</a> <var>G</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>G</var> MUST be a <a>blank node</a>.</p>
           </li>
           <li>
             <p>In <strong><a>standard mode</a></strong> only, specify the type of <a>node</a> <var>G</var> as <code>csvw:TableGroup</code>; emit the following triple:
@@ -305,8 +305,8 @@ var respecConfig = {
             </p>
           </li>
           <li>
-            <p>In <strong><a>standard mode</a></strong> only, recursively insert the triples resulting from running running the [[!json-ld-api]] <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">toRdf</a></cite> algorithm over any <a>common properties</a> specified for the <a>table group</a>.</p>
-            <p>Where where langauge information is specified within the metadata description the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag(s)</a> (as defined in [[!rdf11-concepts]]) MUST be included in the <a>output graph</a>.</p>
+            <p>In <strong><a>standard mode</a></strong> only, recursively insert the triples resulting from running the [[!json-ld-api]] <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">toRdf</a></cite> algorithm over any <a>common properties</a> specified for the <a>table group</a>, with <a>node</a> <var>G</var> as an initial <a>subject</a>.</p>
+            <p>Where where language information is specified within the metadata description the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag(s)</a> (as defined in [[!rdf11-concepts]]) MUST be included in the <a>output graph</a>.</p>
           </li>
           <li>
             <p>Each <a title="annotated table">table</a> is processed sequentially in the order they are referenced in the <a>table group description</a>.</p>
@@ -314,7 +314,7 @@ var respecConfig = {
             <ol>
               <li>
                 <p>In <strong><a>standard mode</a></strong> only, establish a new <a>node</a> <var>T</var> in the <a>output graph</a> which represents the current <a title="annotated table">table</a>.</p>
-                <p>If the <a title="annotated table">table</a> has an <a>identifier</a> then <a>node</a> <var>T</var> SHALL be identified accordingly; ; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>T</var> SHALL be a <a>blank node</a>.</p>
+                <p>If the <a title="annotated table">table</a> has an <a>identifier</a> then <a>node</a> <var>T</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>T</var> MUST be a <a>blank node</a>.</p>
               </li>
               <li>
                 <p>In <strong><a>standard mode</a></strong> only, specify the type of <a>node</a> <var>T</var> as <code>csvw:Table</code>; emit the following triple:
@@ -336,13 +336,14 @@ var respecConfig = {
                     <dt>predicate</dt>
                     <dd><code>csvw:url</code></dd>
                     <dt>object</dt>
-                    <dd><var>URL</var></dd>
+                    <dd>a <a>node</a> identified by <var>URL</var></dd>
                   </dl>
                 </p>
               </li>
               <li>
-                <p>In <strong><a>standard mode</a></strong> only, recursively insert the triples resulting from running running the [[!json-ld-api]] <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">toRdf</a></cite> algorithm over any <a>notes</a> and <a>common properties</a> specified for the <a title="annotated table">table</a>.</p>
-                <p>Where where langauge information is specified within the metadata description for <a>notes</a> or <a>common properties</a> the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag(s)</a> (as defined in [[!rdf11-concepts]]) MUST be included in the <a>output graph</a>.</p>
+                <p>In <strong><a>standard mode</a></strong> only, recursively insert the triples resulting from running the [[!json-ld-api]] <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">toRdf</a></cite> algorithm over any <a>notes</a> and <a>common properties</a> specified for the <a title="annotated table">table</a>, with <a>node</a> <var>T</var> as an initial <a>subject</a>.</p>
+                <p>Where where language information is specified within the metadata description for <a>notes</a> or <a>common properties</a> the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag(s)</a> (as defined in [[!rdf11-concepts]]) MUST be included in the <a>output graph</a>.</p>
+
                 <p class="note">All other annotations for the <a title="annotated table">table</a> are ignored during the conversion; including information about <a href="http://www.w3.org/TR/tabular-metadata/#dfn-tableSchema" class="externalDFN">table schemas</a> and <a href="http://www.w3.org/TR/tabular-metadata/#dfn-column-description" class="externalDFN">column descriptions</a> specified therein, <a href="http://www.w3.org/TR/tabular-metadata/#dfn-dialect-description" class="externalDFN">dialect descriptions</a>, <a href="http://www.w3.org/TR/tabular-metadata/#dfn-foreign-key-definition" class="externalDFN">foreign-key-definitions</a> etc.</p>
               </li>
               <li>
@@ -372,7 +373,7 @@ var respecConfig = {
                         <dt>predicate</dt>
                         <dd><code>csvw:rownum</code></dd>
                         <dt>object</dt>
-                        <dd><var>n</var></dd>
+                        <dd>a <a title="literal node">literal</a> <var>n</var></dd>
                       </dl>
                     </p>
                   </li>
@@ -384,19 +385,19 @@ var respecConfig = {
                         <dt>predicate</dt>
                         <dd><code>csvw:url</code></dd>
                         <dt>object</dt>
-                        <dd><var>URL</var><code>#</code><var>n<sub>source</sub></var></dd>
+                        <dd>a <a>node</a> identified by <var>URL</var><code>#row=</code><var>n<sub>source</sub></var></dd>
                       </dl>
                     </p>
                   </li>
                   <li>
                     <p>The <a title="subject">subjects</a> described by each <a>row</a> are determined according to the <a>aboutUrl</a> property for each <a>cell</a> in the current <a>row</a>. Where <a>aboutUrl</a> is undefined, a default <a>subject</a> for the <a>row</a> is used.</p>
                     <p class="note">A <a>row</a> MAY describe multiple interrelated <a title="subject">subjects</a>; where the <a>valueUrl</a> property for one cell matches the <a>aboutUrl</a> property for another <a>cell</a> in the same <a>row</a>.</p>
-                    <p>Determine the unique <a title="subject">subjects</a> for the current <a>row</a> - including a default <a>subject</a> if <a>aboutUrl</a> is unspecified for any <a title="cell">cells</a> in the <a>row</a>.</p>
+                    <p>Determine the unique <a title="subject">subjects</a> for the current <a>row</a>—including a default <a>subject</a> if <a>aboutUrl</a> is unspecified for any <a title="cell">cells</a> in the <a>row</a>.</p>
                     <p>For each <a>subject</a> that the current <a>row</a> describes where at least one of the <a title="cell">cells</a> that refers to that <a>subject</a> has a <a title="cell value">value</a> that is not <code>null</code>:</p>
                     <ol>
                       <li>
                         <p>Establish a new <a>node</a> <var>S</var> in the <a>output graph</a> which represents the current <a>subject</a>.</p>
-                        <p><p>If the <a>subject</a> is explicitly identified (e.g. because a <a>cell</a> in the current <a>row</a> specified the <a>subject</a> using the <a>aboutUrl</a> property), then <a>node</a> <var>S</var> SHALL be identified accordingly; else <a>node</a> <var>S</var> SHALL be a <a>blank node</a>.</p></p>
+                        <p><p>If the <a>subject</a> is explicitly identified (e.g., because a <a>cell</a> in the current <a>row</a> specified the <a>subject</a> using the <a>aboutUrl</a> property), then <a>node</a> <var>S</var> MUST be identified accordingly; else <a>node</a> <var>S</var> MUST be a <a>blank node</a>.</p></p>
                       </li>
                       <li>
                         <p>In <strong><a>standard mode</a></strong> only, relate the current <a>subject</a> to the current <a>row</a>; emit the following triple:
@@ -425,7 +426,7 @@ var respecConfig = {
                                 <dd><a>node</a> <var>V<sub>url</sub></var></dd>
                               </dl>
                             </p>
-                            <p>Else, if the <a>cell</a> specifies a <a href="http://www.w3.org/TR/tabular-metadata/#cell-separator"><code>separator</code></a> property and the <a>cell value</a> is not an empty sequence and the <a>cell</a> specifies that boolean property <a href="http://www.w3.org/TR/tabular-metadata/#cell-ordered"><code>ordered</code></a> is <var>true</var>, then the <a>cell value</a> provides an <em>ordered</em> sequence of <a title="literal node">literal nodes</a> for inclusion within the <a>output graph</a> using an instance of <code>rdf:List</code> <var>V<sub>list</sub></var> as defined in [[rdf-schema]] which is related to the <a>subject</a> using the <a>propertyUrl</a> <var>P</var> for the current <a>cell</a>; emit the triples defining list <var>V<sub>list</sub></var> plus:
+                            <p>Else, if the <a>cell</a> specifies a <a href="http://www.w3.org/TR/tabular-metadata/#cell-separator"><code>separator</code></a> property and the <a>cell value</a> is not an empty sequence and the <a>cell</a> specifies that boolean property <a href="http://www.w3.org/TR/tabular-metadata/#cell-ordered"><code>ordered</code></a> is <var>true</var>, then the <a>cell value</a> provides an <em>ordered</em> sequence of <a title="literal node">literal nodes</a> for inclusion within the <a>output graph</a> using an instance of <code>rdf:List</code> <var>V<sub>list</sub></var> as defined in [[rdf-schema]]. This instance is related to the <a>subject</a> using the <a>propertyUrl</a> <var>P</var> for the current <a>cell</a>; emit the triples defining list <var>V<sub>list</sub></var> plus:
                               <dl class="triple">
                                 <dt>subject</dt>
                                 <dd><a>node</a> <var>S</var></dd>
@@ -442,7 +443,7 @@ var respecConfig = {
                                 <dt>predicate</dt>
                                 <dd><var>P</var></dd>
                                 <dt>object</dt>
-                                <dd><a>node</a> <var>V<sub>literal</sub></var></dd>
+                                <dd><a>literal node</a> <var>V<sub>literal</sub></var></dd>
                               </dl>
                             </p>
                             <p>Else, if the <a>cell value</a> is not <code>null</code> and the <a>cell</a> does not specify a <a href="http://www.w3.org/TR/tabular-metadata/#cell-separator"><code>separator</code></a> property, then the <a>cell value</a> provides a single <a>literal node</a> <var>V<sub>literal</sub></var> for inclusion within the <a>output graph</a> that is related the current <a>subject</a> using the <a>propertyUrl</a> <var>P</var> for the current <a>cell</a>; emit the following triple:
@@ -452,10 +453,10 @@ var respecConfig = {
                                 <dt>predicate</dt>
                                 <dd><var>P</var></dd>
                                 <dt>object</dt>
-                                <dd><a>node</a> <var>V<sub>literal</sub></var></dd>
+                                <dd><a>literal node</a> <var>V<sub>literal</sub></var></dd>
                               </dl>
                             </p>
-                            <p>The <a title="literal node">literal nodes</a> derived from the <a title="cell value">cell values</a> SHALL be expressed in the <a>output graph</a> according to the <a href="http://www.w3.org/TR/tabular-metadata/#cell-datatype"><code>datatype</code></a> property of the cell as defined below: <a href="#datatypes">Interpretting datatypes</a>.</p> 
+                            <p>The <a title="literal node">literal nodes</a> derived from the <a title="cell value">cell values</a> MUST be expressed in the <a>output graph</a> according to the <a href="http://www.w3.org/TR/tabular-metadata/#cell-datatype"><code>datatype</code></a> property of the cell as defined below: <a href="#datatypes">Interpreting datatypes</a>.</p> 
                             <p class="note">In the case where a sequence of values is provided, the <code>datatype</code> applies to all members of the sequence.</p>
                           </li>
                         </ol>
@@ -470,7 +471,7 @@ var respecConfig = {
       </section>
 
       <section id="datatypes">
-        <h3>Interpretting datatypes</h3>
+        <h3>Interpreting datatypes</h3>
         <p><a title="cell value">Cell values</a> are expressed in the <a>output graph</a> according to the cell's <a href="http://www.w3.org/TR/tabular-metadata/#cell-datatype"><code>datatype</code></a> property. The relationship between the value of the <a href="http://www.w3.org/TR/tabular-metadata/#cell-datatype"><code>datatype</code></a> property and the <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> used in the RDF is provided in the table below.</p>
         
         <div class="note">
@@ -480,7 +481,7 @@ var respecConfig = {
 
         <table style="width: 100%; text-align: left">
           <thead>
-            <tr><th><code>datetype</code></th><th>RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a></th><th>Remarks</th></tr>
+            <tr><th><code>datatype</code></th><th>RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a></th><th>Remarks</th></tr>
           </thead>
           <tbody>
             <tr><td><code>number</code></td><td><code>xsd:double</code></td><td></td></tr>
@@ -523,7 +524,7 @@ var respecConfig = {
             <tr><td><code>gYearMonth</code></td><td><code>xsd:gYearMonth</code></td><td></td></tr>
             <tr><td><code>hexBinary</code></td><td><code>xsd:hexBinary</code></td><td></td></tr>
             <tr><td><code>QName</code></td><td><code>xsd:QName</code></td><td></td></tr>
-            <tr><td><code>string</code></td><td><code>xsd:string</code></td><td>Where the <a href="http://www.w3.org/TR/tabular-metadata/#cell-language"><code>lang</code></a> property is defined for a cell, the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> (as defined in [[!rdf11-concepts]]) SHALL be provided for the string.</td></tr>
+            <tr><td><code>string</code></td><td><code>xsd:string</code></td><td>Where the <a href="http://www.w3.org/TR/tabular-metadata/#cell-language"><code>lang</code></a> property is defined for a cell, the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> (as defined in [[!rdf11-concepts]]) MUST be provided for the string.</td></tr>
             <tr><td><code>normalizedString</code></td><td><code>xsd:normalizedString</code></td><td>(as for <code>string</code>)</td></tr>
             <tr><td><code>token</code></td><td><code>xsd:token</code></td><td>(as for <code>string</code>)</td></tr>
             <tr><td><code>langauge</code></td><td><code>xsd:language</code></td><td>(as for <code>string</code>)</td></tr>
@@ -711,6 +712,7 @@ _:e8f2e8e9-3d02-4bf5-b4f1-4794ba5b52c9
         <p><strong><a title="standard mode">Standard mode</a></strong> output for this example is provided in Turtle [[turtle]] syntax below:</p>
 
         <pre class="example highlight" id="example-countries-standard-ttl">
+@base &lt;http://example.org/countries.csv&gt; .
 @prefix csvw: &lt;http://www.w3.org/ns/csvw#&gt; .
 @prefix rel: &lt;http://www.iana.org/assignments/link-relations/&gt; .
 @prefix t1: &lt;http://example.org/countries.csv#&gt; .
@@ -720,15 +722,15 @@ _:d4f8e548-9601-4e41-aadb-09a8bce32625 a csvw:TableGroup ;
     csvw:url &lt;http://example.org/countries.csv&gt; ;
     csvw:row [
       csvw:rownum 1 ;
-      csvw:url t1:row\=2 ;
+      csvw:url &lt;#row=2&gt; ;
       rel:describes _:8228a149-8efe-448d-b15f-8abf92e7bd17
     ], [
       csvw:rownum 2 ;
-      csvw:url t1:row\=3 ;
+      csvw:url &lt;#row=3&gt; ;
       rel:describes _:ec59dcfc-872a-4144-822b-9ad5e2c6149c
     ], [
       csvw:rownum 3 ;
-      csvw:url t1:row\=4 ;
+      csvw:url &lt;#row=4&gt; ;
       rel:describes _:e8f2e8e9-3d02-4bf5-b4f1-4794ba5b52c9
     ]
   ] .
@@ -993,6 +995,7 @@ GID,On Street,Species,Trim Cycle,Diameter at Breast Ht,Inventory Date,Comments,P
         <p><strong><a title="standard mode">Standard mode</a></strong> output for this example is provided in Turtle [[turtle]] syntax below:</p>
 
         <pre class="example highlight" id="example-tree-ops-ext-standard-ttl">
+@base &lt;http://example.org/tree-ops-ext.csv&gt; .
 @prefix csvw: &lt;http://www.w3.org/ns/csvw#&gt; .
 @prefix dc: &lt;http://purl.org/dc/terms/&gt; .
 @prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
@@ -1016,15 +1019,15 @@ _:68fc08e5-56a0-47e2-a784-3a644d8257c4 a csvw:TableGroup ;
   dc:modified "2010-12-31"^^xsd:date ;
   csvw:row [
     csvw:rownum 1 ;
-    csvw:url t1:row\=2 ;
+    csvw:url &lt;#row=2&gt; ;
     rel:describes &lt;http://example.org/tree-ops-ext#gid-1&gt;
   ], [
     csvw:rownum 2 ;
-    csvw:url t1:row\=3 ;
+    csvw:url &lt;#row=3&gt; ;
     rel:describes &lt;http://example.org/tree-ops-ext#gid-2&gt;
   ], [
     csvw:rownum 3 ;
-    csvw:url t1:row\=4 ;
+    csvw:url &lt;#row=4&gt; ;
     rel:describes &lt;http://example.org/tree-ops-ext#gid-6&gt;
   ] .
 
@@ -1280,6 +1283,7 @@ t1:offer-2 a schema:Offer ;
         <p><strong><a title="standard mode">Standard mode</a></strong> output for this example is provided in Turtle [[turtle]] syntax below:</p>
 
         <pre class="example highlight" id="example-events-listing-standard-ttl">
+@base &lt;http://example.org/events-listing.csv&gt; .
 @prefix csvw: &lt;http://www.w3.org/ns/csvw#&gt; .
 @prefix rel: &lt;http://www.iana.org/assignments/link-relations/&gt; .
 @prefix schema: &lt;http://schema.org/&gt; .
@@ -1291,11 +1295,11 @@ _:95cc7970-ce99-44b0-900c-e2c2c028bbd3 a csvw:TableGroup ;
     csvw:url &lt;http://example.org/events-listing.csv&gt; ;
     csvw:row [
       csvw:rownum 1 ;
-      csvw:url t1:row\=2 ;
+      csvw:url &lt;#row=2&gt; ;
       rel:describes t1:event-1, t1:place-1, t1:offer-1
     ], [
       csvw:rownum 2 ;
-      csvw:url t1:row\=3 ;
+      csvw:url &lt;#row=3&gt; ;
       rel:describes t1:event-2, t1:place-2, t1:offer-2
     ]
   ] .
@@ -1687,28 +1691,31 @@ _:fa1fa954-dd5f-4aa1-b2bc-20bf9867fac6
 @prefix t1: &lt;http://example.org/conf/professions.csv#&gt; .
 @prefix t2: &lt;http://example.org/senior-roles.csv#&gt; .
 @prefix t3: &lt;http://example.org/junior-roles.csv#&gt; .
+@prefix t1r: &lt;http://example.org/conf/professions.csv#row=&gt; .
+@prefix t2r: &lt;http://example.org/senior-roles.csv#row=&gt; .
+@prefix t3r: &lt;http://example.org/junior-roles.csv#row=&gt; .
 
 _:3d36cfbb-d2d5-4573-a1a7-3bf817062db8 a csvw:TableGroup ;
   csvw:table [ a csvw:Table ;
     csvw:url &lt;http://example.org/senior-roles.csv&gt; ;
     csvw:row [
       csvw:rownum 1 ;
-      csvw:url t2:row\=2 ;
+      csvw:url t2r:2 ;
       rel:describes t2:post-90115
     ], [
       csvw:rownum 2 ;
-      csvw:url t2:row\=3 ;
+      csvw:url t2r:3 ;
       rel:describes t2:post-90334
     ]
   ], [ a csvw:Table ;
     csvw:url &lt;http://example.org/junior-roles.csv&gt; ;
     csvw:row [
       csvw:rownum 1 ;
-      csvw:url t3:row\=2 ;
+      csvw:url t3r:2 ;
       rel:describes _:d8b8e40c-8c74-458b-99f7-64d1cf5c65f2
     ], [
       csvw:rownum 2 ;
-      csvw:url t3:row\=3 ;
+      csvw:url t3r:3 ;
       rel:describes _:fa1fa954-dd5f-4aa1-b2bc-20bf9867fac6
     ]
   ] .


### PR DESCRIPTION
- Minor grammatical or stylistic changes
- The RDF related definitions in 3.1 were not entirely o.k., I changed those
- When handling the common properties (steps 3 and 4.4) specified that `node G` is the initial subject
- Had to change SHALL to MUST (strangely, although it is a valid RFC term, it is not used in W3C documents, usually)
- Made it clear when an object is a literal
- The RFC7111 usage was wrong for csvw:url
- Have changed the \= in the example as agreed on the call
