### PR TITLE
Correct language on normalizing `@type`... 

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1972,7 +1972,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <li>If the value is any other object, normalize each property of that object as follows:
                 <ol class="algorithm">
                   <li>If the property is <code>@id</code>, <a title="expansion">expand</a> any prefixes and resolve its value against the <a>base URL</a>.</li>
-                  <li>If the property is <code>@type</code>, then if its value (or any of its values if it holds an array) is a relative URL, resolve it against the <a>base URL</a>.</li>
+                  <li>If the property is <code>@type</code>, then if its value (or any of its values if it holds an array) MUST be a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a>, <a>prefixed name</a>, or absolute URL and no further normalization is required.</li>
                   <li>Otherwise, normalize the value of the property according to this algorithm.</li>
                 </ol>
               </li>
@@ -2296,12 +2296,12 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
       <h2>JSON-LD Dialect</h2>
       <p>The Metadata Vocabulary for Tabular Data uses a format based on JSON-LD [[!JSON-LD]] with some restrictions.</p>
       <ul>
-        <li>All <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">terms</a> used within a metadata document MUST be defined in the JSON-LD context defined for this specification (see <a href="#json-ld-context" class="sectionRef"></a>).</li>
+        <li>All <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">terms</a> used within a metadata document MUST be defined in [[csvw-context]] defined for this specification (see <a href="#json-ld-context" class="sectionRef"></a>).</li>
         <li><p>The value of any <code>@id</code> or <code>@type</code> contained within a metadata document MUST NOT be a <a href="http://www.w3.org/TR/json-ld/#dfn-blank-node" class="externalDFN">blank node</a></p></li>
         <li><p>A metadata document MUST NOT add a new context, or extend the top-level context in anyway other than as specifically allowed in <a href="#top-level-properties" class="sectionRef"></a>.</p></li>
         <li><p>Common properties and notes may contain arbitrary JSON-LD with the following restrictions:</p>
           <ul>
-            <li><p>The value of any member of <code>@type</code> MUST be either a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the JSON-LD context, a <a href="http://www.w3.org/TR/json-ld/#dfn-compact-iri" class="externalDFN">prefixed name</a> where the prefix is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the JSON-LD context, or an absolute URL.</p></li>
+            <li><p>The value of any member of <code>@type</code> MUST be either a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in [[csvw-context]], a <a href="http://www.w3.org/TR/json-ld/#dfn-compact-iri" class="externalDFN">prefixed name</a> where the prefix is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in [[csvw-context]], or an absolute URL.</p></li>
             <li><p>Values MAY be a <a href="http://www.w3.org/TR/json-ld/#dfn-string" class="externalDFN">string</a>, native JSON type (such as <a href="http://www.w3.org/TR/json-ld/#dfn-number" class="externalDFN">number</a>, <code>true</code>, or <code>false</code>.), <a href="http://www.w3.org/TR/json-ld/#dfn-value-object" class="externalDFN">value object</a>, <a href="http://www.w3.org/TR/json-ld/#dfn-node-object" class="externalDFN">node object</a> or an array of zero or more any of these.</p></li>
             <li><p>Values MUST NOT use <a href="http://www.w3.org/TR/json-ld/#dfn-list-object" class="externalDFN">list objects</a> or <a href="http://www.w3.org/TR/json-ld/#dfn-set-object" class="externalDFN">set objects</a>.</p></li>
             <li><p>Keys of <a href="http://www.w3.org/TR/json-ld/#dfn-node-object" class="externalDFN">node objects</a> MUST NOT include <code>@graph</code>,  <code>@context</code>, <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">terms</a>, or <a href="http://www.w3.org/TR/json-ld/#dfn-blank-node" class="externalDFN">blank nodes</a>.</p></li>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1972,7 +1972,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <li>If the value is any other object, normalize each property of that object as follows:
                 <ol class="algorithm">
                   <li>If the property is <code>@id</code>, <a title="expansion">expand</a> any prefixes and resolve its value against the <a>base URL</a>.</li>
-                  <li>If the property is <code>@type</code>, then if its value (or any of its values if it holds an array) MUST be a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a>, <a>prefixed name</a>, or absolute URL and no further normalization is required.</li>
+                  <li>If the property is <code>@type</code>, then its value remains as is.</li>
                   <li>Otherwise, normalize the value of the property according to this algorithm.</li>
                 </ol>
               </li>


### PR DESCRIPTION
... as relative URLs are _not_ resolved against the document base in JSON-LD.

Change references to the JSON-LD context to [csvw-context].
