### PR TITLE
Remove language on merging common properties, so that the default is use...

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1943,7 +1943,6 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <li>If the property is an <a>array property</a>, the way in which values are merged depends on the property; see the relevant property for this definition.</li>
           <li>If the property is an <a>object property</a> the objects are merged as described here.</li>
           <li>If the property is a <a>natural language property</a>, the result is an object whose properties are language codes and where the values of those properties are arrays. The arrays MUST provide the values from <code>A</code> followed by those from <code>B</code> that were not already a value in <code>A</code>. If a value exists in the array for the undefined language (<code>und</code>) and in the array for any other language, the value from the array for <code>und</code> MUST be removed, ensuring that the <code>und</code> property is removed entirely if it's value becomes an empty array.</li>
-          <li>If the property is a <a>common property</a>, the result is an array containing values from <code>A</code> followed by values from <code>B</code>.</li>
           <li>Otherwise, the value from <code>A</code> overrides that from <code>B</code>.</li>
         </ul>
       </section>


### PR DESCRIPTION
...d. This causes intersecting common properties from either A or B, but not by appending B to A.

Fixes #270.
