### PR TITLE
Remove `title` as an optional property of `Table`. This was never added ...

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -693,10 +693,6 @@ CSVW,foaf:Project,table;data;conversion
                 The <a href="http://www.w3.org/annotation/">Web Annotation Working Group</a> is developing a vocabulary for expressing annotations. In future versions of this specification, we anticipate referencing that vocabulary.
               </p>
             </dd>
-            <dt id="table-title"><code>title</code></dt>
-            <dd>
-              <p>A <a>natural language property</a> that describes the title of the table.</p>
-            </dd>
             <dt id="tableDirection"><code>tableDirection</code></dt>
             <dd><p>As defined for <a href="#table-group-direction">table groups</a>. The value of this property becomes the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-table-direction" class="externalDFN">direction</a> annotation for this table.</p></dd>
             <dt id="table-transformations"><code>transformations</code></dt>


### PR DESCRIPTION
...to the namespace/context.

Fixes #278.
