### PR TITLE
removing CSV files that are now duplicated

### DIFF
--- a/csv2json/gov.uk/professions.csv
+++ b/csv2json/gov.uk/professions.csv
@@ -1,5 +1,0 @@
-Profession
-Finance
-Information Technology
-Operational Delivery
-Policy

--- a/csv2rdf/gov.uk/professions.csv
+++ b/csv2rdf/gov.uk/professions.csv
@@ -1,5 +1,0 @@
-Profession
-Finance
-Information Technology
-Operational Delivery
-Policy


### PR DESCRIPTION
the ./gov.uk directory with professions.csv has been moved to
./examples/gov.uk when the examples were reorganised … removing the
(now) duplicate
