### PR TITLE
Add conformance section to metadata and syntax documents

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -136,11 +136,37 @@ var respecConfig = {
         Implementations may fulfil one or more of these functions. In particular, <a>Converters</a> may or may not act as a <a title="Validators">Validator</a> (perhaps through the setting of a flag), and check the data that they are converting to ensure that it is complant with the schema. If a Converter does not also act as a <a title="validators">Validator</a> it may produce invalid output.
       </p>
       <p>
-        The <a href="http://www.w3.org/TR/tabular-data-model/">Model for Tabular Data and Metadata on the Web</a> specification defines an <a href="http://w3c.github.io/csvw/syntax/#annotated-tabular-data-model">Annotated Tabular Data Model</a> in which tables, columns, rows and cells can be annotated with annotations, and a <a href="http://w3c.github.io/csvw/syntax/#grouped-tabular-data-model">Grouped Tabular Data Model</a> in which a group of tables is annotated. That specification also describes <a href="http://w3c.github.io/csvw/syntax/#locating-metadata">how to locate metadata</a> about a given CSV file.
+        The <a href="http://w3c.github.io/csvw/syntax/">Model for Tabular Data and Metadata on the Web</a> specification defines an <a href="http://w3c.github.io/csvw/syntax/#annotated-tabular-data-model">Annotated Tabular Data Model</a> in which tables, columns, rows and cells can be annotated with annotations, and a <a href="http://w3c.github.io/csvw/syntax/#grouped-tabular-data-model">Grouped Tabular Data Model</a> in which a group of tables is annotated. That specification also describes <a href="http://w3c.github.io/csvw/syntax/#locating-metadata">how to locate metadata</a> about a given CSV file.
       </p>
       <p>
-        This document defines the format and structure of metadata documents, and how these are interpreted to create an Annotated Tabular Data Model. It also defines how to validate tabular data based on some of these annotations. The metadata format is based on a dialect of [[!JSON-LD]] as defined in <a href="#json-ld-dialect" class="sectionRef"></a>. This metadata can be expressed as an RDF graph. However, all applications that conform to this specification (including <a>validators</a> and applications that read or convert tabular data) MUST read the JSON-based format described in this document.
+        This document defines the format and structure of metadata documents, and how these are interpreted to create an Annotated Tabular Data Model. It also defines how to validate tabular data based on some of these annotations.
       </p>
+    </section>
+    <section id="conformance">
+      <p>The metadata format is based on a dialect of [[!JSON-LD]] as defined in <a href="#json-ld-dialect" class="sectionRef"></a>. This metadata can be expressed as an RDF graph. However, all applications that conform to this specification (including <a>validators</a> and applications that read or convert tabular data) MUST read the JSON-based format described in this document.</p>
+
+      <p><a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">Tabular data</a> MUST conform to the description from [[!tabular-data-model]]. In particular note that each <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">row</a> MUST contain the same number of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> (although some of these <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> may be empty). Given this constraint, not all CSV-encoded data can be considered to be tabular data. As such, the metadata format described in this specification cannot be applied to all CSV files.</p>
+
+      <p>This specification makes use of the <dfn title="compact IRI">compact IRI Syntax</dfn>; please refer to the <a href="http://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a> from [[!JSON-LD]].</p>
+     
+      <p>This specification makes use of the following namespaces:</p>
+      <dl>
+        <dt><code>csvw</code>:</dt>
+        <dd><code>http://www.w3.org/ns/csvw#</code></dd>
+        <dt><code>dc</code>:</dt>
+        <dd><code>http://purl.org/dc/terms/</code></dd>
+        <dt><code>dcat</code>:</dt>
+        <dd><code>http://www.w3.org/ns/dcat#</code></dd>
+        <dt><code>foaf</code>:</dt>
+        <dd><code>http://xmlns.com/foaf/0.1/</code></dd>
+        <dt><code>rdf</code>:</dt>
+        <dd><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></dd>
+        <dt><code>schema</code>:</dt>
+        <dd><code>http://schema.org/</code></dd>
+        <dt><code>xsd</code>:</dt>
+        <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
+      </dl>
+
     </section>
     <section>
       <h2>Annotating Tables</h2>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -143,7 +143,7 @@ var respecConfig = {
       </p>
     </section>
     <section id="conformance">
-      <p>The metadata format is based on a dialect of [[!JSON-LD]] as defined in <a href="#json-ld-dialect" class="sectionRef"></a>. This metadata can be expressed as an RDF graph. However, all applications that conform to this specification (including <a>validators</a> and applications that read or convert tabular data) MUST read the JSON-based format described in this document.</p>
+      <p>The metadata format is based on a dialect of [[!JSON-LD]] as defined in <a href="#json-ld-dialect" class="sectionRef"></a>. This metadata can be expressed as an RDF graph. However, all applications that conform to this specification (including <a>validators</a> and applications that read or convert tabular data) MUST read the JSON-based format described in this document. It is not necessary for conformant applications to be able to process all JSON-LD, only the dialect defined in this specification.</p>
 
       <p><a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">Tabular data</a> MUST conform to the description from [[!tabular-data-model]]. In particular note that each <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">row</a> MUST contain the same number of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> (although some of these <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> may be empty). Given this constraint, not all CSV-encoded data can be considered to be tabular data. As such, the metadata format described in this specification cannot be applied to all CSV files.</p>
 

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -306,7 +306,7 @@ var respecConfig = {
           </p>
           <ol class="algorithm">
             <li>applying the template against the cell in that column in the row that is currently being processed</li>
-            <li>expanding any prefixes as if the value were the name of a <a>common property</a>, as described in <a href="#common-properties" class="sectionRef"></a></li>
+            <li>expanding any <a href="http://www.w3.org/TR/json-ld/#dfn-prefix" class="externalDFN">prefixes</a> as if the value were the name of a <a>common property</a>, as described in <a href="#common-properties" class="sectionRef"></a></li>
             <li>resolving the resulting URL against the base URL of the <a href="http://w3c.github.io/csvw/syntax/#dfn-table-url" class="externalDFN">table url</a> if not null</li>
           </ol>
           <p>
@@ -1364,7 +1364,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <dt id="cell-datatype"><code>datatype</code></dt>
           <dd>
             <p>
-              An <a>atomic property</a> that contains either a single string that is the main datatype of the values of the cell or a <a>datatype description</a> object. If the value of this property is a string, it is a term defined in the default context representing a built-in datatype URL; if it is an object then it describes a more specialised datatype. If a cell contains a sequence (ie the <code>separator</code> property is specified and not <code>null</code>) then this property specifies the datatype of each value within that sequence. See <a href="#datatypes"></a> for more details.
+              An <a>atomic property</a> that contains either a single string that is the main datatype of the values of the cell or a <a>datatype description</a> object. If the value of this property is a string, it is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the default context representing a built-in datatype URL; if it is an object then it describes a more specialised datatype. If a cell contains a sequence (ie the <code>separator</code> property is specified and not <code>null</code>) then this property specifies the datatype of each value within that sequence. See <a href="#datatypes"></a> for more details.
             </p>
             <p>
               A value for this property is <a>compatible with</a> an inherited value if they are identical, or if the value is a subtype within the datatype hierarchy defined in <a href="#datatypes" class="sectionRef"></a>, including if the inherited value is explicitly specified as the <a href="#datatype-base"><code>base</code></a> of this value.
@@ -1437,7 +1437,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <dt id="datatype-base"><code>base</code></dt>
             <dd>
               <p>
-                An <a>atomic property</a> that contains a single string: a term defined in the default context representing a built-in datatype URL, as listed above. If this property is missing, its default is <code>string</code>. All values of the datatype MUST be valid values of the base datatype.
+                An <a>atomic property</a> that contains a single string: a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the default context representing a built-in datatype URL, as listed above. If this property is missing, its default is <code>string</code>. All values of the datatype MUST be valid values of the base datatype.
               </p>
             </dd>
             <dt id="datatype-format"><code>format</code></dt>
@@ -1850,7 +1850,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               <li>If the value is an object with a <code>@value</code> property, it remains as is.</li>
               <li>If the value is any other object, normalize each property of that object as follows:
                 <ol class="algorithm">
-                  <li>If the property is <code>@id</code>, <a title="expansion">expand</a> any prefixes and resolve its value against the <a>base URL</a>.</li>
+                  <li>If the property is <code>@id</code>, <a title="expansion">expand</a> any <a href="http://www.w3.org/TR/json-ld/#dfn-prefix" class="externalDFN">prefixed names</a> and resolve its value against the <a>base URL</a>.</li>
                   <li>If the property is <code>@type</code>, then its value remains as is.</li>
                   <li>Otherwise, normalize the value of the property according to this algorithm.</li>
                 </ol>
@@ -2207,7 +2207,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
       <p>
         The JSON-LD context, located at <code><a href="http://www.w3.org/ns/csvw.jsonld">http://www.w3.org/ns/csvw.jsonld</a></code> is used with metadata documents. When used within a metadata document,
         the context can be referenced as <code>http://www.w3.org/ns/csvw</code>.
-        See [[csvw-context]] for a full description of defined terms and prefixes. This context may be updated from time-to-time to define new terms and prefixes.
+        See [[csvw-context]] for a full description of defined <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">terms</a> and <a href="http://www.w3.org/TR/json-ld/#dfn-prefix" class="externalDFN">prefixes</a>. This context may be updated from time-to-time to define new terms and prefixes.
       </p>
     </section>
   </body>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -129,6 +129,22 @@ var respecConfig = {
         This specification does not normatively define a format for exchanging tabular data. However, it does provide some best practice guidelines for publishing tabular data as CSV, in section <a href="#syntax" class="sectionRef"></a>, and for parsing both this syntax and those similar to it, in <a href="#parsing" class="sectionRef"></a>.
       </p>
     </section>
+    <section id="conformance">
+      <p>This specification makes use of the <dfn title="compact IRI">compact IRI Syntax</dfn>; please refer to the <a href="http://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a> from [[!JSON-LD]].</p>
+     
+      <p>This specification makes use of the following namespaces:</p>
+      <dl>
+        <dt><code>dc</code>:</dt>
+        <dd><code>http://purl.org/dc/terms/</code></dd>
+        <dt><code>rdfs</code>:</dt>
+        <dd><code>http://www.w3.org/2000/01/rdf-schema#</code></dd>
+        <dt><code>schema</code>:</dt>
+        <dd><code>http://schema.org/</code></dd>
+        <dt><code>xsd</code>:</dt>
+        <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
+      </dl>
+
+    </section>
     <section id="model">
       <h2>Tabular Data Models</h2>
       <p>


### PR DESCRIPTION
Note the use of compact IRI rather than CURIE, which IMO is more appropriate for our use.
