### PR TITLE
Use Compact IRI reference instead of CURIE

### DIFF
--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -144,7 +144,7 @@ var respecConfig = {
     <section id="conformance">
       <p><a href="http://www.w3.org/TR/tabular-data-model/#dfn-tabular-data" class="externalDFN">Tabular data</a> MUST conform to the description from [[!tabular-data-model]]. In particular note that each <a href="http://www.w3.org/TR/tabular-data-model/#dfn-row" class="externalDFN">row</a> MUST contain the same number of <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell" class="externalDFN">cells</a> (although some of these <a href="http://www.w3.org/TR/tabular-data-model/#dfn-cell" class="externalDFN">cells</a> may be empty). Given this constraint, not all CSV-encoded data can be considered to be tabular data. As such, the conversion procedure described in this specification cannot be applied to all CSV files.</p>
 
-      <p>This specification makes use of the <dfn title="CURIE">CURIE Syntax</dfn>; please refer to the <a href="http://www.w3.org/TR/rdfa-core/#s_curies">CURIE Syntax Definition Section</a> from [[!rdfa-core]].</p>
+      <p>This specification makes use of the <dfn title="compact IRI">compact IRI Syntax</dfn>; please refer to the <a href="http://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a> from [[!JSON-LD]].</p>
      
       <p>This specification makes use of the following namespaces:</p>
       <dl>


### PR DESCRIPTION
This aligns with conformance for metadata/syntax from issue #308.

Fixes #352.
