### PR TITLE
As discussed in #327, this defines a `numeric atomic property`

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -482,7 +482,7 @@ CSVW,foaf:Project,table;data;conversion
             <li><strong>arrays</strong> &mdash; lists of numbers, booleans, strings, or objects</li>
           </ul>
           <p>
-            The <a>property value</a> of an atomic property is that set in metadata or <code>null</code>, if unset. Processors MUST raise an error if a property is set to an invalid value type, such as a boolean atomic property being set to the number <code>1</code> or a numeric atomic property being set to the string <code>"3.1415"</code>.
+            The <a>property value</a> of a boolean atomic property is <code>false</code> if unset; otherwise, the <a>property value</a> of an atomic property is that set in metadata or <code>null</code>, if unset. Processors MUST raise an error if a property is set to an invalid value type, such as a boolean atomic property being set to the number <code>1</code> or a numeric atomic property being set to the string <code>"3.1415"</code>.
           </p>
         </section>
       </section>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -481,6 +481,7 @@ CSVW,foaf:Project,table;data;conversion
             <li><strong>objects</strong> &mdash; interpreted as defined by the property</li>
             <li><strong>arrays</strong> &mdash; lists of numbers, booleans, strings, or objects</li>
           </ul>
+          <p>The <a>property value</a> of a boolean atomic property is <code>true</code> if set to <code>true</code> or the case-insensitive string values <code>true</code> or <code>1</code> and <code>false</code>otherwise. The <a>property value</a> of a numeric atomic property is the integer value of the set value, or <code>0</code>, otherwise. The property value of any other atomic property is that set in metadata or <code>null</code>, if unset.</p>
           <p class="note">
             JSON does not have date or time types. Where a property takes a date as a value, this MUST be a string in the format <code>YYYY-MM-DD</code>.
           </p>
@@ -682,7 +683,7 @@ CSVW,foaf:Project,table;data;conversion
             <dt id="table-schema"><code>tableSchema</code></dt>
             <dd>
               <p>An <a>object property</a> that provides a single <a>schema description</a> as described in <a href="#schemas" class="sectionRef"></a>. This may be provided as an embedded object within the JSON metadata or as a URL reference to a separate JSON schema document. If a table description is within a <a>table group description</a>, the <code>tableSchema</code> from that table group acts as the default for this property.</p>
-              <p>The <a>property value</a> of a <code>tableSchema</code>is that defined in the <a>table description</a>, if any, or that defined in the <a>table group description</a>, if any, or <code>null</code>.</p>
+              <p>The <a>property value</a> of a <code>tableSchema</code> is that defined in the <a>table description</a>, if any, or that defined in the <a>table group description</a>, if any, or <code>null</code>.</p>
             </dd>
             <dt id="table-notes"><code>notes</code></dt>
             <dd>
@@ -740,11 +741,11 @@ CSVW,foaf:Project,table;data;conversion
           </dd>
           <dt id="dialect-doubleQuote"><code>doubleQuote</code></dt>
           <dd>
-            <p>A single boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-escape-character" class="externalDFN">escape character</a> flag to <code>"</code>. If <code>false</code>, to <code>\</code>.</p>
+            <p>A boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-escape-character" class="externalDFN">escape character</a> flag to <code>"</code>. If <code>false</code>, to <code>\</code>.</p>
           </dd>
           <dt id="dialect-skipRows"><code>skipRows</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-rows" class="externalDFN">skip rows</a> flag to the single provided numeric value, which MUST be a non-negative integer.</p>
+            <p>An numeric <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-rows" class="externalDFN">skip rows</a> flag to the single provided numeric value, which MUST be a non-negative integer.</p>
           </dd>
           <dt id="dialect-commentPrefix"><code>commentPrefix</code></dt>
           <dd>
@@ -752,11 +753,11 @@ CSVW,foaf:Project,table;data;conversion
           </dd>
           <dt id="dialect-header"><code>header</code></dt>
           <dd>
-            <p>A single boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-row-count" class="externalDFN">header row count</a> flag to <code>1</code>, and if <code>false</code> to <code>0</code>, unless <a href="#dialect-headerRowCount"><code>headerRowCount</code></a> is provided, in which case the value provided for the <code>header</code> property is ignored.</p>
+            <p>A boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-row-count" class="externalDFN">header row count</a> flag to <code>1</code>, and if <code>false</code> to <code>0</code>, unless <a href="#dialect-headerRowCount"><code>headerRowCount</code></a> is provided, in which case the value provided for the <code>header</code> property is ignored.</p>
           </dd>
           <dt id="dialect-headerRowCount"><code>headerRowCount</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-row-count" class="externalDFN">header row count</a> flag to the single provided value, which MUST be a non-negative integer.</p>
+            <p>An numeric <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-row-count" class="externalDFN">header row count</a> flag to the single provided value, which MUST be a non-negative integer.</p>
           </dd>
           <dt id="dialect-delimiter"><code>delimiter</code></dt>
           <dd>
@@ -764,23 +765,23 @@ CSVW,foaf:Project,table;data;conversion
           </dd>
           <dt id="dialect-skipColumns"><code>skipColumns</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-columns" class="externalDFN">skip columns</a> flag to the single provided numeric value, which MUST be a non-negative integer.</p>
+            <p>An numeric <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-columns" class="externalDFN">skip columns</a> flag to the single provided numeric value, which MUST be a non-negative integer.</p>
           </dd>
           <dt id="dialect-headerColumnCount"><code>headerColumnCount</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-column-count" class="externalDFN">header column count</a> flag to the single provided value, which MUST be non-negative integer.</p>
+            <p>An numeric <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-header-column-count" class="externalDFN">header column count</a> flag to the single provided value, which MUST be non-negative integer.</p>
           </dd>
           <dt id="dialect-skipBlankRows"><code>skipBlankRows</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-blank-rows" class="externalDFN">skip blank rows</a> flag to the single provided boolean value.</p>
+            <p>An boolean <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-blank-rows" class="externalDFN">skip blank rows</a> flag to the single provided boolean value.</p>
           </dd>
           <dt id="dialect-skipInitialSpace"><code>skipInitialSpace</code></dt>
           <dd>
-            <p>A single boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to <code>"start"</code>. If <code>false</code>, to <code>false</code>. If the <a href="#dialect-trim"><code>trim</code></a> property is provided, the <code>skipInitialSpace</code> property is ignored.</p>
+            <p>A boolean <a>atomic property</a> that, if <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to <code>"start"</code>. If <code>false</code>, to <code>false</code>. If the <a href="#dialect-trim"><code>trim</code></a> property is provided, the <code>skipInitialSpace</code> property is ignored.</p>
           </dd>
           <dt id="dialect-trim"><code>trim</code></dt>
           <dd>
-            <p>A single <a>atomic property</a> that, if the boolean <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to <code>true</code> and if the boolean <code>false</code> to <code>false</code>. If the value provided is a string, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to the provided value, which MUST be one of <code>"true"</code>, <code>"false"</code>, <code>"start"</code> or <code>"end"</code>.</p>
+            <p>An <a>atomic property</a> that, if the boolean <code>true</code>, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to <code>true</code> and if the boolean <code>false</code> to <code>false</code>. If the value provided is a string, sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-trim" class="externalDFN">trim</a> flag to the provided value, which MUST be one of <code>"true"</code>, <code>"false"</code>, <code>"start"</code> or <code>"end"</code>.</p>
           </dd>
           <dt id="dialect-ld-id"><code>@id</code></dt>
           <dd>
@@ -1203,7 +1204,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             </dd>
             <dt id="column-required"><code>required</code></dt>
             <dd>
-              <p>A boolean <a>atomic property</a> taking a single value which indicates whether every cell within the column must have a non-null value. The value of this property is used to create the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-required" class="externalDFN">required</a> annotation for the described column. Its <a>property value</a> is that defined in metadata, or <code>false</code> otherwise.</p>
+              <p>A boolean <a>atomic property</a> taking a single value which indicates whether every cell within the column must have a non-null value. The value of this property is used to create the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-required" class="externalDFN">required</a> annotation for the described column.</p>
             </dd>
             <dt id="column-suppressOutput"><code>suppressOutput</code></dt>
             <dd>
@@ -1423,7 +1424,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <dt id="datatype-length"><code>length</code></dt>
             <dd>
               <p>
-                An <a>atomic property</a> that contains a single integer that is the exact length of the value. See <a href="#length-constraints" class="sectionRef"></a> for details.
+                A numeric <a>atomic property</a> that contains a single integer that is the exact length of the value. See <a href="#length-constraints" class="sectionRef"></a> for details.
               </p>
             </dd>
             <dt id="datatype-minLength"><code>minLength</code></dt>
@@ -1435,7 +1436,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <dt id="datatype-maxLength"><code>maxLength</code></dt>
             <dd>
               <p>
-                An <a>atomic property</a> that contains a single integer that is the maximum length of the value. See <a href="#length-constraints" class="sectionRef"></a> for details.
+                A numeric <a>atomic property</a> that contains a single integer that is the maximum length of the value. See <a href="#length-constraints" class="sectionRef"></a> for details.
               </p>
             </dd>
             <dt id="datatype-minimum"><code>minimum</code></dt>
@@ -1815,6 +1816,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <li>If the property is a <a>link property</a> the value is turned into an absolute URL using the <a>base URL</a>.</li>
           <li>If the property is an <a>object property</a> with a string value, the string is a URL referencing a JSON document containing a single object. Dereference this URL and replace the string value with that object.</li>
           <li>If the property is a <a>natural language property</a> and the value is not already an object, it is turned into an object whose properties are language codes and where the values of those properties are arrays. The suitable language code for the values is determined through the <a>default language</a>; if it can't be determined the language code <code>und</code> MUST be used.</li>
+          <li>If the property is a boolean <a>atomic property</a> or a numeric <a>atomic property</a>, normalize to its <a>property value</a>.</li>
           <li>If the property is an <a>atomic property</a> accepting strings or objects, normalize to the object form as described for that property.</li>
           <li>
             If the property is a <a>common property</a> or <a href="#table-notes"><code>notes</code></a> the value MUST be normalized as follows:

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -481,9 +481,8 @@ CSVW,foaf:Project,table;data;conversion
             <li><strong>objects</strong> &mdash; interpreted as defined by the property</li>
             <li><strong>arrays</strong> &mdash; lists of numbers, booleans, strings, or objects</li>
           </ul>
-          <p>The <a>property value</a> of a boolean atomic property is <code>true</code> if set to <code>true</code> or the case-insensitive string values <code>true</code> or <code>1</code> and <code>false</code>otherwise. The <a>property value</a> of a numeric atomic property is the integer value of the set value, or <code>0</code>, otherwise. The property value of any other atomic property is that set in metadata or <code>null</code>, if unset.</p>
-          <p class="note">
-            JSON does not have date or time types. Where a property takes a date as a value, this MUST be a string in the format <code>YYYY-MM-DD</code>.
+          <p>
+            The <a>property value</a> of an atomic property is that set in metadata or <code>null</code>, if unset. Processors MUST raise an error if a property is set to an invalid value type, such as a boolean atomic property being set to the number <code>1</code> or a numeric atomic property being set to the string <code>"3.1415"</code>.
           </p>
         </section>
       </section>
@@ -1816,8 +1815,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           <li>If the property is a <a>link property</a> the value is turned into an absolute URL using the <a>base URL</a>.</li>
           <li>If the property is an <a>object property</a> with a string value, the string is a URL referencing a JSON document containing a single object. Dereference this URL and replace the string value with that object.</li>
           <li>If the property is a <a>natural language property</a> and the value is not already an object, it is turned into an object whose properties are language codes and where the values of those properties are arrays. The suitable language code for the values is determined through the <a>default language</a>; if it can't be determined the language code <code>und</code> MUST be used.</li>
-          <li>If the property is a boolean <a>atomic property</a> or a numeric <a>atomic property</a>, normalize to its <a>property value</a>.</li>
-          <li>If the property is an <a>atomic property</a> accepting strings or objects, normalize to the object form as described for that property.</li>
+          <li>If the property is an <a>atomic property</a> that can be a string or an object, normalize to the object form as described for that property.</li>
           <li>
             If the property is a <a>common property</a> or <a href="#table-notes"><code>notes</code></a> the value MUST be normalized as follows:
             <ol class="algorithm">


### PR DESCRIPTION
and clarifies others as being `boolean atomic properites`. It defines the `property value` for both types and describes normalization.

This allows algorithms to say if `suppressOutput` is `false`, rather than `not true`.
