### PR TITLE
Test vocabulary/manifest in Turtle, JSON-LD and HTML+RDFa

### DIFF
--- a/local-biblio.js
+++ b/local-biblio.js
@@ -53,6 +53,14 @@ var localBibliography = {
       "href" : "http://www.w3.org/ns/csvw",
       "publisher": "W3C"
   },
+  "csvw-tests": {
+      "authors": [
+        "Gregg Kellogg"
+      ],
+      "title": "CSVW Test Suite",
+      "href" : "http://www.w3.org/ns/csvw",
+      "publisher": "W3C"
+  },
   "EBNF-NOTATION" : {
     "authors" : [
       "Tim Bray",

--- a/tests/index.html
+++ b/tests/index.html
@@ -46,22 +46,22 @@
           <a href='#manifest-json'>CSVW JSON tests</a>
         </li>
         <li>
-          <a href='#manifest-rdf'>CSVW RDF tests</a>
+          <a href='#manifest-rdf'>CSVW RDF Tests</a>
         </li>
       </ol>
     </section>
     <section id='manifest-json' inlist property='mf:entry' resource='manifest-json' typeof='mf:Manifest'>
       <h2>CSVW JSON tests</h2>
-      <p property='rdfs:comment'>Tests transformation of CSV to JSON</p>
+      <p property='rdfs:comment'>Tests transformation of CSV to JSON.</p>
       <p>
         Instructions specific to running JSON tests.
       </p>
       <dl class='test-description'>
         <dt>
-          manifest-json#test001:
-          <span about='#test001' property='mf:name'>Simple table</span>
+          metadata-json#test001:
+          <span about='metadata-json#test001' property='mf:name'>Simple table</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test001' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test001' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>The simplest possible table without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -77,15 +77,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test002:
-          <span about='#test002' property='mf:name'>Quoted field</span>
+          metadata-json#test002:
+          <span about='metadata-json#test002' property='mf:name'>Quoted field</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test002' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test002' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Table with one quoted field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -101,15 +101,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test003:
-          <span about='#test003' property='mf:name'>Surrounding spaces</span>
+          metadata-json#test003:
+          <span about='metadata-json#test003' property='mf:name'>Surrounding spaces</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test003' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test003' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -125,15 +125,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test005:
-          <span about='#test005' property='mf:name'>Identifier references</span>
+          metadata-json#test005:
+          <span about='metadata-json#test005' property='mf:name'>Identifier references</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test005' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test005' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -149,15 +149,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test006:
-          <span about='#test006' property='mf:name'>No identifiers</span>
+          metadata-json#test006:
+          <span about='metadata-json#test006' property='mf:name'>No identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test006' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test006' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -173,15 +173,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test007:
-          <span about='#test007' property='mf:name'>Joined table with unique identifiers</span>
+          metadata-json#test007:
+          <span about='metadata-json#test007' property='mf:name'>Joined table with unique identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test007' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test007' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Joined data with identified records without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -197,15 +197,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test008:
-          <span about='#test008' property='mf:name'>Microsyntax - internal field separator</span>
+          metadata-json#test008:
+          <span about='metadata-json#test008' property='mf:name'>Microsyntax - internal field separator</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test008' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test008' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -221,15 +221,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test009:
-          <span about='#test009' property='mf:name'>Microsyntax - formatted time</span>
+          metadata-json#test009:
+          <span about='metadata-json#test009' property='mf:name'>Microsyntax - formatted time</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test009' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test009' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -245,15 +245,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test010:
-          <span about='#test010' property='mf:name'>Country-codes-and-names example</span>
+          metadata-json#test010:
+          <span about='metadata-json#test010' property='mf:name'>Country-codes-and-names example</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test010' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test010' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Country-codes-and-names example</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -269,15 +269,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test011:
-          <span about='#test011' property='mf:name'>tree-ops example with metadata</span>
+          metadata-json#test011:
+          <span about='metadata-json#test011' property='mf:name'>tree-ops example with metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test011' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test011' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -297,15 +297,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test012:
-          <span about='#test012' property='mf:name'>tree-ops example with directory metadata</span>
+          metadata-json#test012:
+          <span about='metadata-json#test012' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test012' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test012' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -325,15 +325,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test013:
-          <span about='#test013' property='mf:name'>tree-ops example from directory metadata</span>
+          metadata-json#test013:
+          <span about='metadata-json#test013' property='mf:name'>tree-ops example from directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test013' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test013' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -353,17 +353,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test013-user-metadata.json'>test013-user-metadata.json</span>
+              <a href='test013-user-metadata.json' property='csvt:metadata'>test013-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test014:
-          <span about='#test014' property='mf:name'>tree-ops example with linked metadata</span>
+          metadata-json#test014:
+          <span about='metadata-json#test014' property='mf:name'>tree-ops example with linked metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test014' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test014' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -387,15 +387,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test015:
-          <span about='#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+          metadata-json#test015:
+          <span about='metadata-json#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test015' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test015' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -416,17 +416,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test015/user-metadata.json'>test015/user-metadata.json</span>
+              <a href='test015/user-metadata.json' property='csvt:metadata'>test015/user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test016:
-          <span about='#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+          metadata-json#test016:
+          <span about='metadata-json#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test016' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test016' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -451,15 +451,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test017:
-          <span about='#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+          metadata-json#test017:
+          <span about='metadata-json#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test017' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test017' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -480,15 +480,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test018:
-          <span about='#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+          metadata-json#test018:
+          <span about='metadata-json#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test018' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test018' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -510,17 +510,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test018/user-metadata.json'>test018/user-metadata.json</span>
+              <a href='test018/user-metadata.json' property='csvt:metadata'>test018/user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test019:
-          <span about='#test019' property='mf:name'>no header</span>
+          metadata-json#test019:
+          <span about='metadata-json#test019' property='mf:name'>no header</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test019' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test019' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -533,18 +533,22 @@
             <dd>
               <a href='test019.json' property='mf:result'>test019.json</a>
             </dd>
+            <dt>Content Type</dt>
+            <dd content='text/csv;header=absent' property='csvt:contentType'>
+              <code>text/csv;header=absent</code>
+            </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test020:
-          <span about='#test020' property='mf:name'>trim=start</span>
+          metadata-json#test020:
+          <span about='metadata-json#test020' property='mf:name'>trim=start</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test020' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test020' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -564,15 +568,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test021:
-          <span about='#test021' property='mf:name'>trim=end</span>
+          metadata-json#test021:
+          <span about='metadata-json#test021' property='mf:name'>trim=end</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test021' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test021' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -592,15 +596,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test022:
-          <span about='#test022' property='mf:name'>trim=true</span>
+          metadata-json#test022:
+          <span about='metadata-json#test022' property='mf:name'>trim=true</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test022' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test022' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -620,15 +624,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test023:
-          <span about='#test023' property='mf:name'>dialect: header=false</span>
+          metadata-json#test023:
+          <span about='metadata-json#test023' property='mf:name'>dialect: header=false</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test023' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test023' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -648,17 +652,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test023-user-metadata.json'>test023-user-metadata.json</span>
+              <a href='test023-user-metadata.json' property='csvt:metadata'>test023-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test024:
-          <span about='#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+          metadata-json#test024:
+          <span about='metadata-json#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test024' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test024' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -678,17 +682,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test024-user-metadata.json'>test024-user-metadata.json</span>
+              <a href='test024-user-metadata.json' property='csvt:metadata'>test024-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test025:
-          <span about='#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+          metadata-json#test025:
+          <span about='metadata-json#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test025' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test025' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -708,17 +712,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test025-user-metadata.json'>test025-user-metadata.json</span>
+              <a href='test025-user-metadata.json' property='csvt:metadata'>test025-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-json#test026:
-          <span about='#test026' property='mf:name'>tree-ops example with directory metadata</span>
+          metadata-json#test026:
+          <span about='metadata-json#test026' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-json#test026' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='metadata-json#test026' typeof='csvt:CSVtoJsonTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -739,24 +743,24 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
       </dl>
     </section>
     <section id='manifest-rdf' inlist property='mf:entry' resource='manifest-rdf' typeof='mf:Manifest'>
-      <h2>CSVW RDF tests</h2>
-      <p property='rdfs:comment'>Tests transformation of CSV to RDF</p>
+      <h2>CSVW RDF Tests</h2>
+      <p property='rdfs:comment'>Tests transformation of CSV to RDF.</p>
       <p>
         Instructions specific to running RDF tests.
       </p>
       <dl class='test-description'>
         <dt>
-          manifest-rdf#test001:
-          <span about='#test001' property='mf:name'>Simple table</span>
+          metadata-rdf#test001:
+          <span about='metadata-rdf#test001' property='mf:name'>Simple table</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test001' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test001' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>The simplest possible table without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -772,15 +776,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test002:
-          <span about='#test002' property='mf:name'>Quoted field</span>
+          metadata-rdf#test002:
+          <span about='metadata-rdf#test002' property='mf:name'>Quoted field</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test002' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test002' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Table with one quoted field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -796,15 +800,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test003:
-          <span about='#test003' property='mf:name'>Surrounding spaces</span>
+          metadata-rdf#test003:
+          <span about='metadata-rdf#test003' property='mf:name'>Surrounding spaces</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test003' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test003' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -820,15 +824,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test005:
-          <span about='#test005' property='mf:name'>Identifier references</span>
+          metadata-rdf#test005:
+          <span about='metadata-rdf#test005' property='mf:name'>Identifier references</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test005' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test005' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -844,15 +848,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test006:
-          <span about='#test006' property='mf:name'>No identifiers</span>
+          metadata-rdf#test006:
+          <span about='metadata-rdf#test006' property='mf:name'>No identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test006' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test006' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -868,15 +872,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test007:
-          <span about='#test007' property='mf:name'>Joined table with unique identifiers</span>
+          metadata-rdf#test007:
+          <span about='metadata-rdf#test007' property='mf:name'>Joined table with unique identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test007' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test007' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Joined data with identified records without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -892,15 +896,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test008:
-          <span about='#test008' property='mf:name'>Microsyntax - internal field separator</span>
+          metadata-rdf#test008:
+          <span about='metadata-rdf#test008' property='mf:name'>Microsyntax - internal field separator</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test008' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test008' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -916,15 +920,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test009:
-          <span about='#test009' property='mf:name'>Microsyntax - formatted time</span>
+          metadata-rdf#test009:
+          <span about='metadata-rdf#test009' property='mf:name'>Microsyntax - formatted time</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test009' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test009' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -940,15 +944,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test010:
-          <span about='#test010' property='mf:name'>Country-codes-and-names example</span>
+          metadata-rdf#test010:
+          <span about='metadata-rdf#test010' property='mf:name'>Country-codes-and-names example</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test010' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test010' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Country-codes-and-names example</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -964,15 +968,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test011:
-          <span about='#test011' property='mf:name'>tree-ops example with metadata</span>
+          metadata-rdf#test011:
+          <span about='metadata-rdf#test011' property='mf:name'>tree-ops example with metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test011' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test011' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -992,15 +996,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test012:
-          <span about='#test012' property='mf:name'>tree-ops example with directory metadata</span>
+          metadata-rdf#test012:
+          <span about='metadata-rdf#test012' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test012' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test012' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1020,15 +1024,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test013:
-          <span about='#test013' property='mf:name'>tree-ops example from directory metadata</span>
+          metadata-rdf#test013:
+          <span about='metadata-rdf#test013' property='mf:name'>tree-ops example from directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test013' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test013' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1048,17 +1052,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test013-user-metadata.json'>test013-user-metadata.json</span>
+              <a href='test013-user-metadata.json' property='csvt:metadata'>test013-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test014:
-          <span about='#test014' property='mf:name'>tree-ops example with linked metadata</span>
+          metadata-rdf#test014:
+          <span about='metadata-rdf#test014' property='mf:name'>tree-ops example with linked metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test014' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test014' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1082,15 +1086,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test015:
-          <span about='#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+          metadata-rdf#test015:
+          <span about='metadata-rdf#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test015' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test015' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1111,17 +1115,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test015/user-metadata.json'>test015/user-metadata.json</span>
+              <a href='test015/user-metadata.json' property='csvt:metadata'>test015/user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test016:
-          <span about='#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+          metadata-rdf#test016:
+          <span about='metadata-rdf#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test016' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test016' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1146,15 +1150,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test017:
-          <span about='#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+          metadata-rdf#test017:
+          <span about='metadata-rdf#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test017' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test017' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1175,15 +1179,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test018:
-          <span about='#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+          metadata-rdf#test018:
+          <span about='metadata-rdf#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test018' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test018' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1205,17 +1209,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test018/user-metadata.json'>test018/user-metadata.json</span>
+              <a href='test018/user-metadata.json' property='csvt:metadata'>test018/user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test019:
-          <span about='#test019' property='mf:name'>no header</span>
+          metadata-rdf#test019:
+          <span about='metadata-rdf#test019' property='mf:name'>no header</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test019' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test019' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1228,18 +1232,22 @@
             <dd>
               <a href='test019.rdf' property='mf:result'>test019.rdf</a>
             </dd>
+            <dt>Content Type</dt>
+            <dd content='text/csv;header=absent' property='csvt:contentType'>
+              <code>text/csv;header=absent</code>
+            </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test020:
-          <span about='#test020' property='mf:name'>trim=start</span>
+          metadata-rdf#test020:
+          <span about='metadata-rdf#test020' property='mf:name'>trim=start</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test020' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test020' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1259,15 +1267,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test021:
-          <span about='#test021' property='mf:name'>trim=end</span>
+          metadata-rdf#test021:
+          <span about='metadata-rdf#test021' property='mf:name'>trim=end</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test021' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test021' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1287,15 +1295,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test022:
-          <span about='#test022' property='mf:name'>trim=true</span>
+          metadata-rdf#test022:
+          <span about='metadata-rdf#test022' property='mf:name'>trim=true</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test022' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test022' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1315,15 +1323,15 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test023:
-          <span about='#test023' property='mf:name'>dialect: header=false</span>
+          metadata-rdf#test023:
+          <span about='metadata-rdf#test023' property='mf:name'>dialect: header=false</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test023' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test023' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1343,17 +1351,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test023-user-metadata.json'>test023-user-metadata.json</span>
+              <a href='test023-user-metadata.json' property='csvt:metadata'>test023-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test024:
-          <span about='#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+          metadata-rdf#test024:
+          <span about='metadata-rdf#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test024' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test024' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1373,17 +1381,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test024-user-metadata.json'>test024-user-metadata.json</span>
+              <a href='test024-user-metadata.json' property='csvt:metadata'>test024-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test025:
-          <span about='#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+          metadata-rdf#test025:
+          <span about='metadata-rdf#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test025' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test025' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1403,17 +1411,17 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
               user metadata:
-              <span property='csvt:metadata' resource='test025-user-metadata.json'>test025-user-metadata.json</span>
+              <a href='test025-user-metadata.json' property='csvt:metadata'>test025-user-metadata.json</a>
             </dd>
           </dl>
         </dd>
         <dt>
-          manifest-rdf#test026:
-          <span about='#test026' property='mf:name'>tree-ops example with directory metadata</span>
+          metadata-rdf#test026:
+          <span about='metadata-rdf#test026' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='manifest-rdf#test026' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='metadata-rdf#test026' typeof='csvt:CSVtoRdfTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1434,7 +1442,7 @@
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
               noProv:
-              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              <span datatype='xsd:boolean' property='noProv'>true</span>
             </dd>
           </dl>
         </dd>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,1449 @@
+<!DOCTYPE html>
+<html lang='en' prefix='csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='http://www.w3.org/StyleSheets/TR/W3C-ED' rel='stylesheet' type='text/css'>
+    <style>
+      body: {bacground-image: none;}
+      dl.test-detail, dl.test-options {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt, dl.test-options>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after, dl.test-options>dt:after {content: ": "}
+      dl.test-detail>dd, dl.test-options>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      CSVW Test Cases
+    </title>
+  </head>
+  <body resource='' typeof='mf:Manifest'>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='rdfs:label'>CSVW Test Cases</h1>
+    <p property='rdfs:comment'>Includes manifests for different application profiles</p>
+    <p>See the <a href="vocab.html">CSVT Vocabulary</a> for the meaning of properties and options.</p>
+    <section class='contents'>
+      <h2>Contents</h2>
+      <ol>
+        <li>
+          <a href='#manifest-json'>CSVW JSON tests</a>
+        </li>
+        <li>
+          <a href='#manifest-rdf'>CSVW RDF tests</a>
+        </li>
+      </ol>
+    </section>
+    <section id='manifest-json' inlist property='mf:entry' resource='manifest-json' typeof='mf:Manifest'>
+      <h2>CSVW JSON tests</h2>
+      <p property='rdfs:comment'>Tests transformation of CSV to JSON</p>
+      <p>
+        Instructions specific to running JSON tests.
+      </p>
+      <dl class='test-description'>
+        <dt>
+          manifest-json#test001:
+          <span about='#test001' property='mf:name'>Simple table</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test001' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>The simplest possible table without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test001.csv' property='mf:action'>test001.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test001.json' property='mf:result'>test001.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test002:
+          <span about='#test002' property='mf:name'>Quoted field</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test002' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Table with one quoted field without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002.csv' property='mf:action'>test002.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002.json' property='mf:result'>test002.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test003:
+          <span about='#test003' property='mf:name'>Surrounding spaces</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test003' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test003.csv' property='mf:action'>test003.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test003.json' property='mf:result'>test003.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test005:
+          <span about='#test005' property='mf:name'>Identifier references</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test005' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test005.csv' property='mf:action'>test005.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test005.json' property='mf:result'>test005.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test006:
+          <span about='#test006' property='mf:name'>No identifiers</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test006' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test006.csv' property='mf:action'>test006.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test006.json' property='mf:result'>test006.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test007:
+          <span about='#test007' property='mf:name'>Joined table with unique identifiers</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test007' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Joined data with identified records without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test007.csv' property='mf:action'>test007.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test007.json' property='mf:result'>test007.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test008:
+          <span about='#test008' property='mf:name'>Microsyntax - internal field separator</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test008' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test008.csv' property='mf:action'>test008.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test008.json' property='mf:result'>test008.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test009:
+          <span about='#test009' property='mf:name'>Microsyntax - formatted time</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test009' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test009.csv' property='mf:action'>test009.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test009.json' property='mf:result'>test009.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test010:
+          <span about='#test010' property='mf:name'>Country-codes-and-names example</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test010' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Country-codes-and-names example</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test010.csv' property='mf:action'>test010.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test010.json' property='mf:result'>test010.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test011:
+          <span about='#test011' property='mf:name'>tree-ops example with metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test011' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test011.csv' property='mf:action'>test011.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test011.json' property='mf:result'>test011.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test011.csv-metadata.json'>test011.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test012:
+          <span about='#test012' property='mf:name'>tree-ops example with directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test012' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test012/action.csv' property='mf:action'>test012/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test012/result.json' property='mf:result'>test012/result.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test012/metadata.json'>test012/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test013:
+          <span about='#test013' property='mf:name'>tree-ops example from directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test013' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test013.csv' property='mf:action'>test013.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test013.json' property='mf:result'>test013.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test013-user-metadata.json'>test013-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test013-user-metadata.json'>test013-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test014:
+          <span about='#test014' property='mf:name'>tree-ops example with linked metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test014' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test014.csv' property='mf:action'>test014.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test014.json' property='mf:result'>test014.json</a>
+            </dd>
+            <dt>Link Header</dt>
+            <dd content='&lt;test014-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
+              <code>&lt;test014-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test014-linked-metadata.json'>test014-linked-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test015:
+          <span about='#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test015' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test015/action.csv' property='mf:action'>test015/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test015/result.json' property='mf:result'>test015/result.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test015/user-metadata.json'>test015/user-metadata.json</a>
+              <a href='test015/metadata.json'>test015/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test015/user-metadata.json'>test015/user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test016:
+          <span about='#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test016' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test016/action.csv' property='mf:action'>test016/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test016/result.json' property='mf:result'>test016/result.json</a>
+            </dd>
+            <dt>Link Header</dt>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test016/linked-metadata.json'>test016/linked-metadata.json</a>
+              <a href='test016/metadata.json'>test016/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test017:
+          <span about='#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test017' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test017/action.csv' property='mf:action'>test017/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test017/result.json' property='mf:result'>test017/result.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test017/action.csv-metadata.json'>test017/action.csv-metadata.json</a>
+              <a href='test017/metadata.json'>test017/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test018:
+          <span about='#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test018' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test018/action.csv' property='mf:action'>test018/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test018/result.json' property='mf:result'>test018/result.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test018/user-metadata.json'>test018/user-metadata.json</a>
+              <a href='test018/action.csv-metadata.json'>test018/action.csv-metadata.json</a>
+              <a href='test018/metadata.json'>test018/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test018/user-metadata.json'>test018/user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test019:
+          <span about='#test019' property='mf:name'>no header</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test019' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test019.csv' property='mf:action'>test019.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test019.json' property='mf:result'>test019.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test020:
+          <span about='#test020' property='mf:name'>trim=start</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test020' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test020.csv' property='mf:action'>test020.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test020.json' property='mf:result'>test020.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test020.csv-metadata.json'>test020.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test021:
+          <span about='#test021' property='mf:name'>trim=end</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test021' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test021.csv' property='mf:action'>test021.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test021.json' property='mf:result'>test021.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test021.csv-metadata.json'>test021.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test022:
+          <span about='#test022' property='mf:name'>trim=true</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test022' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test022.csv' property='mf:action'>test022.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test022.json' property='mf:result'>test022.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test022.csv-metadata.json'>test022.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test023:
+          <span about='#test023' property='mf:name'>dialect: header=false</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test023' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test023.csv' property='mf:action'>test023.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test023.json' property='mf:result'>test023.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test023-user-metadata.json'>test023-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test023-user-metadata.json'>test023-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test024:
+          <span about='#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test024' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test024.csv' property='mf:action'>test024.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test024.json' property='mf:result'>test024.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test024-user-metadata.json'>test024-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test024-user-metadata.json'>test024-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test025:
+          <span about='#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test025' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test025.csv' property='mf:action'>test025.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test025.json' property='mf:result'>test025.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test025-user-metadata.json'>test025-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test025-user-metadata.json'>test025-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-json#test026:
+          <span about='#test026' property='mf:name'>tree-ops example with directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-json#test026' typeof='csvt:CSVtoJsonTest'>
+          <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test026/metadata.json' property='mf:action'>test026/metadata.json</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test026/result.json' property='mf:result'>test026/result.json</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test026/action.csv'>test026/action.csv</a>
+              <a href='test026/metadata.json'>test026/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </section>
+    <section id='manifest-rdf' inlist property='mf:entry' resource='manifest-rdf' typeof='mf:Manifest'>
+      <h2>CSVW RDF tests</h2>
+      <p property='rdfs:comment'>Tests transformation of CSV to RDF</p>
+      <p>
+        Instructions specific to running RDF tests.
+      </p>
+      <dl class='test-description'>
+        <dt>
+          manifest-rdf#test001:
+          <span about='#test001' property='mf:name'>Simple table</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test001' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>The simplest possible table without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test001.csv' property='mf:action'>test001.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test001.rdf' property='mf:result'>test001.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test002:
+          <span about='#test002' property='mf:name'>Quoted field</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test002' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Table with one quoted field without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test002.csv' property='mf:action'>test002.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test002.rdf' property='mf:result'>test002.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test003:
+          <span about='#test003' property='mf:name'>Surrounding spaces</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test003' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test003.csv' property='mf:action'>test003.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test003.rdf' property='mf:result'>test003.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test005:
+          <span about='#test005' property='mf:name'>Identifier references</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test005' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test005.csv' property='mf:action'>test005.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test005.rdf' property='mf:result'>test005.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test006:
+          <span about='#test006' property='mf:name'>No identifiers</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test006' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test006.csv' property='mf:action'>test006.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test006.rdf' property='mf:result'>test006.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test007:
+          <span about='#test007' property='mf:name'>Joined table with unique identifiers</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test007' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Joined data with identified records without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test007.csv' property='mf:action'>test007.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test007.rdf' property='mf:result'>test007.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test008:
+          <span about='#test008' property='mf:name'>Microsyntax - internal field separator</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test008' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test008.csv' property='mf:action'>test008.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test008.rdf' property='mf:result'>test008.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test009:
+          <span about='#test009' property='mf:name'>Microsyntax - formatted time</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test009' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test009.csv' property='mf:action'>test009.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test009.rdf' property='mf:result'>test009.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test010:
+          <span about='#test010' property='mf:name'>Country-codes-and-names example</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test010' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Country-codes-and-names example</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test010.csv' property='mf:action'>test010.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test010.rdf' property='mf:result'>test010.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test011:
+          <span about='#test011' property='mf:name'>tree-ops example with metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test011' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test011.csv' property='mf:action'>test011.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test011.rdf' property='mf:result'>test011.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test011.csv-metadata.json'>test011.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test012:
+          <span about='#test012' property='mf:name'>tree-ops example with directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test012' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test012/action.csv' property='mf:action'>test012/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test012/result.rdf' property='mf:result'>test012/result.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test012/metadata.json'>test012/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test013:
+          <span about='#test013' property='mf:name'>tree-ops example from directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test013' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test013.csv' property='mf:action'>test013.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test013.rdf' property='mf:result'>test013.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test013-user-metadata.json'>test013-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test013-user-metadata.json'>test013-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test014:
+          <span about='#test014' property='mf:name'>tree-ops example with linked metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test014' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test014.csv' property='mf:action'>test014.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test014.rdf' property='mf:result'>test014.rdf</a>
+            </dd>
+            <dt>Link Header</dt>
+            <dd content='&lt;test014-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
+              <code>&lt;test014-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test014-linked-metadata.json'>test014-linked-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test015:
+          <span about='#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test015' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test015/action.csv' property='mf:action'>test015/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test015/result.rdf' property='mf:result'>test015/result.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test015/user-metadata.json'>test015/user-metadata.json</a>
+              <a href='test015/metadata.json'>test015/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test015/user-metadata.json'>test015/user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test016:
+          <span about='#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test016' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test016/action.csv' property='mf:action'>test016/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test016/result.rdf' property='mf:result'>test016/result.rdf</a>
+            </dd>
+            <dt>Link Header</dt>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test016/linked-metadata.json'>test016/linked-metadata.json</a>
+              <a href='test016/metadata.json'>test016/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test017:
+          <span about='#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test017' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test017/action.csv' property='mf:action'>test017/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test017/result.rdf' property='mf:result'>test017/result.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test017/action.csv-metadata.json'>test017/action.csv-metadata.json</a>
+              <a href='test017/metadata.json'>test017/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test018:
+          <span about='#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test018' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test018/action.csv' property='mf:action'>test018/action.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test018/result.rdf' property='mf:result'>test018/result.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test018/user-metadata.json'>test018/user-metadata.json</a>
+              <a href='test018/action.csv-metadata.json'>test018/action.csv-metadata.json</a>
+              <a href='test018/metadata.json'>test018/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test018/user-metadata.json'>test018/user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test019:
+          <span about='#test019' property='mf:name'>no header</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test019' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test019.csv' property='mf:action'>test019.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test019.rdf' property='mf:result'>test019.rdf</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test020:
+          <span about='#test020' property='mf:name'>trim=start</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test020' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test020.csv' property='mf:action'>test020.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test020.rdf' property='mf:result'>test020.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test020.csv-metadata.json'>test020.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test021:
+          <span about='#test021' property='mf:name'>trim=end</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test021' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test021.csv' property='mf:action'>test021.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test021.rdf' property='mf:result'>test021.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test021.csv-metadata.json'>test021.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test022:
+          <span about='#test022' property='mf:name'>trim=true</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test022' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test022.csv' property='mf:action'>test022.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test022.rdf' property='mf:result'>test022.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test022.csv-metadata.json'>test022.csv-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test023:
+          <span about='#test023' property='mf:name'>dialect: header=false</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test023' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test023.csv' property='mf:action'>test023.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test023.rdf' property='mf:result'>test023.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test023-user-metadata.json'>test023-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test023-user-metadata.json'>test023-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test024:
+          <span about='#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test024' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test024.csv' property='mf:action'>test024.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test024.rdf' property='mf:result'>test024.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test024-user-metadata.json'>test024-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test024-user-metadata.json'>test024-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test025:
+          <span about='#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test025' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test025.csv' property='mf:action'>test025.csv</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test025.rdf' property='mf:result'>test025.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test025-user-metadata.json'>test025-user-metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+              user metadata:
+              <span property='csvt:metadata' resource='test025-user-metadata.json'>test025-user-metadata.json</span>
+            </dd>
+          </dl>
+        </dd>
+        <dt>
+          manifest-rdf#test026:
+          <span about='#test026' property='mf:name'>tree-ops example with directory metadata</span>
+        </dt>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test026' typeof='csvt:CSVtoRdfTest'>
+          <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
+          <dl class='test-detail'>
+            <dt>approval</dt>
+            <dd property='mf:approval' resource='csvt:Proposed'>csvt:Proposed</dd>
+            <dt>action</dt>
+            <dd>
+              <a href='test026/metadata.json' property='mf:action'>test026/metadata.json</a>
+            </dd>
+            <dt>result</dt>
+            <dd>
+              <a href='test026/result.rdf' property='mf:result'>test026/result.rdf</a>
+            </dd>
+            <dt>Implicit</dt>
+            <dd rel='csvt:implicit'>
+              <a href='test026/action.csv'>test026/action.csv</a>
+              <a href='test026/metadata.json'>test026/metadata.json</a>
+            </dd>
+            <dt>options</dt>
+            <dd property='csvt:option' typeof=''>
+              noProv:
+              <span datatype='xsd:boolean' property='csvt:noProv'>true</span>
+            </dd>
+          </dl>
+        </dd>
+      </dl>
+    </section>
+    <footer>
+      <span property='dc:publisher'>
+        W3C CSV on the Web Working Group
+      </span>
+    </footer>
+  </body>
+</html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -58,10 +58,10 @@
       </p>
       <dl class='test-description'>
         <dt>
-          metadata-json#test001:
-          <span about='metadata-json#test001' property='mf:name'>Simple table</span>
+          manifest-json#test001:
+          <span about='manifest-json#test001' property='mf:name'>Simple table</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test001' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test001' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>The simplest possible table without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -82,10 +82,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test002:
-          <span about='metadata-json#test002' property='mf:name'>Quoted field</span>
+          manifest-json#test002:
+          <span about='manifest-json#test002' property='mf:name'>Quoted field</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test002' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test002' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Table with one quoted field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -106,10 +106,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test003:
-          <span about='metadata-json#test003' property='mf:name'>Surrounding spaces</span>
+          manifest-json#test003:
+          <span about='manifest-json#test003' property='mf:name'>Surrounding spaces</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test003' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test003' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -130,10 +130,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test005:
-          <span about='metadata-json#test005' property='mf:name'>Identifier references</span>
+          manifest-json#test005:
+          <span about='manifest-json#test005' property='mf:name'>Identifier references</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test005' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test005' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -154,10 +154,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test006:
-          <span about='metadata-json#test006' property='mf:name'>No identifiers</span>
+          manifest-json#test006:
+          <span about='manifest-json#test006' property='mf:name'>No identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test006' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test006' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -178,10 +178,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test007:
-          <span about='metadata-json#test007' property='mf:name'>Joined table with unique identifiers</span>
+          manifest-json#test007:
+          <span about='manifest-json#test007' property='mf:name'>Joined table with unique identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test007' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test007' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Joined data with identified records without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -202,10 +202,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test008:
-          <span about='metadata-json#test008' property='mf:name'>Microsyntax - internal field separator</span>
+          manifest-json#test008:
+          <span about='manifest-json#test008' property='mf:name'>Microsyntax - internal field separator</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test008' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test008' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -226,10 +226,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test009:
-          <span about='metadata-json#test009' property='mf:name'>Microsyntax - formatted time</span>
+          manifest-json#test009:
+          <span about='manifest-json#test009' property='mf:name'>Microsyntax - formatted time</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test009' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test009' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -250,10 +250,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test010:
-          <span about='metadata-json#test010' property='mf:name'>Country-codes-and-names example</span>
+          manifest-json#test010:
+          <span about='manifest-json#test010' property='mf:name'>Country-codes-and-names example</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test010' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test010' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Country-codes-and-names example</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -274,10 +274,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test011:
-          <span about='metadata-json#test011' property='mf:name'>tree-ops example with metadata</span>
+          manifest-json#test011:
+          <span about='manifest-json#test011' property='mf:name'>tree-ops example with metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test011' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test011' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -302,10 +302,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test012:
-          <span about='metadata-json#test012' property='mf:name'>tree-ops example with directory metadata</span>
+          manifest-json#test012:
+          <span about='manifest-json#test012' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test012' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test012' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -330,10 +330,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test013:
-          <span about='metadata-json#test013' property='mf:name'>tree-ops example from directory metadata</span>
+          manifest-json#test013:
+          <span about='manifest-json#test013' property='mf:name'>tree-ops example from directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test013' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test013' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -360,10 +360,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test014:
-          <span about='metadata-json#test014' property='mf:name'>tree-ops example with linked metadata</span>
+          manifest-json#test014:
+          <span about='manifest-json#test014' property='mf:name'>tree-ops example with linked metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test014' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test014' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -392,10 +392,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test015:
-          <span about='metadata-json#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+          manifest-json#test015:
+          <span about='manifest-json#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test015' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test015' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -423,10 +423,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test016:
-          <span about='metadata-json#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+          manifest-json#test016:
+          <span about='manifest-json#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test016' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test016' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -456,10 +456,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test017:
-          <span about='metadata-json#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+          manifest-json#test017:
+          <span about='manifest-json#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test017' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test017' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -485,10 +485,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test018:
-          <span about='metadata-json#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+          manifest-json#test018:
+          <span about='manifest-json#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test018' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test018' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -517,10 +517,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test019:
-          <span about='metadata-json#test019' property='mf:name'>no header</span>
+          manifest-json#test019:
+          <span about='manifest-json#test019' property='mf:name'>no header</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test019' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test019' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -545,10 +545,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test020:
-          <span about='metadata-json#test020' property='mf:name'>trim=start</span>
+          manifest-json#test020:
+          <span about='manifest-json#test020' property='mf:name'>trim=start</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test020' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test020' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -573,10 +573,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test021:
-          <span about='metadata-json#test021' property='mf:name'>trim=end</span>
+          manifest-json#test021:
+          <span about='manifest-json#test021' property='mf:name'>trim=end</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test021' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test021' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -601,10 +601,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test022:
-          <span about='metadata-json#test022' property='mf:name'>trim=true</span>
+          manifest-json#test022:
+          <span about='manifest-json#test022' property='mf:name'>trim=true</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test022' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test022' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -629,10 +629,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test023:
-          <span about='metadata-json#test023' property='mf:name'>dialect: header=false</span>
+          manifest-json#test023:
+          <span about='manifest-json#test023' property='mf:name'>dialect: header=false</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test023' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test023' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -659,10 +659,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test024:
-          <span about='metadata-json#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+          manifest-json#test024:
+          <span about='manifest-json#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test024' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test024' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -689,10 +689,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test025:
-          <span about='metadata-json#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+          manifest-json#test025:
+          <span about='manifest-json#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test025' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test025' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -719,10 +719,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-json#test026:
-          <span about='metadata-json#test026' property='mf:name'>tree-ops example with directory metadata</span>
+          manifest-json#test026:
+          <span about='manifest-json#test026' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-json#test026' typeof='csvt:CSVtoJsonTest'>
+        <dd inlist property='mf:entry' resource='manifest-json#test026' typeof='csvt:CsvToJsonTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -757,10 +757,10 @@
       </p>
       <dl class='test-description'>
         <dt>
-          metadata-rdf#test001:
-          <span about='metadata-rdf#test001' property='mf:name'>Simple table</span>
+          manifest-rdf#test001:
+          <span about='manifest-rdf#test001' property='mf:name'>Simple table</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test001' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test001' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>The simplest possible table without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -771,7 +771,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test001.rdf' property='mf:result'>test001.rdf</a>
+              <a href='test001.ttl' property='mf:result'>test001.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -781,10 +781,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test002:
-          <span about='metadata-rdf#test002' property='mf:name'>Quoted field</span>
+          manifest-rdf#test002:
+          <span about='manifest-rdf#test002' property='mf:name'>Quoted field</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test002' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test002' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Table with one quoted field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -795,7 +795,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test002.rdf' property='mf:result'>test002.rdf</a>
+              <a href='test002.ttl' property='mf:result'>test002.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -805,10 +805,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test003:
-          <span about='metadata-rdf#test003' property='mf:name'>Surrounding spaces</span>
+          manifest-rdf#test003:
+          <span about='manifest-rdf#test003' property='mf:name'>Surrounding spaces</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test003' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test003' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Table with whitespace before and after every field without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -819,7 +819,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test003.rdf' property='mf:result'>test003.rdf</a>
+              <a href='test003.ttl' property='mf:result'>test003.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -829,10 +829,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test005:
-          <span about='metadata-rdf#test005' property='mf:name'>Identifier references</span>
+          manifest-rdf#test005:
+          <span about='manifest-rdf#test005' property='mf:name'>Identifier references</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test005' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test005' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>A table with entity identifiers and references to other entities without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -843,7 +843,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test005.rdf' property='mf:result'>test005.rdf</a>
+              <a href='test005.ttl' property='mf:result'>test005.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -853,10 +853,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test006:
-          <span about='metadata-rdf#test006' property='mf:name'>No identifiers</span>
+          manifest-rdf#test006:
+          <span about='manifest-rdf#test006' property='mf:name'>No identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test006' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test006' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Records contain two entities with relationships which are duplicated without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -867,7 +867,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test006.rdf' property='mf:result'>test006.rdf</a>
+              <a href='test006.ttl' property='mf:result'>test006.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -877,10 +877,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test007:
-          <span about='metadata-rdf#test007' property='mf:name'>Joined table with unique identifiers</span>
+          manifest-rdf#test007:
+          <span about='manifest-rdf#test007' property='mf:name'>Joined table with unique identifiers</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test007' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test007' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Joined data with identified records without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -891,7 +891,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test007.rdf' property='mf:result'>test007.rdf</a>
+              <a href='test007.ttl' property='mf:result'>test007.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -901,10 +901,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test008:
-          <span about='metadata-rdf#test008' property='mf:name'>Microsyntax - internal field separator</span>
+          manifest-rdf#test008:
+          <span about='manifest-rdf#test008' property='mf:name'>Microsyntax - internal field separator</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test008' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test008' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>One field has comma-separated values without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -915,7 +915,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test008.rdf' property='mf:result'>test008.rdf</a>
+              <a href='test008.ttl' property='mf:result'>test008.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -925,10 +925,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test009:
-          <span about='metadata-rdf#test009' property='mf:name'>Microsyntax - formatted time</span>
+          manifest-rdf#test009:
+          <span about='manifest-rdf#test009' property='mf:name'>Microsyntax - formatted time</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test009' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test009' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Field with parseable human formatted time without metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -939,7 +939,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test009.rdf' property='mf:result'>test009.rdf</a>
+              <a href='test009.ttl' property='mf:result'>test009.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -949,10 +949,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test010:
-          <span about='metadata-rdf#test010' property='mf:name'>Country-codes-and-names example</span>
+          manifest-rdf#test010:
+          <span about='manifest-rdf#test010' property='mf:name'>Country-codes-and-names example</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test010' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test010' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Country-codes-and-names example</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -963,7 +963,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test010.rdf' property='mf:result'>test010.rdf</a>
+              <a href='test010.ttl' property='mf:result'>test010.ttl</a>
             </dd>
             <dt>options</dt>
             <dd property='csvt:option' typeof=''>
@@ -973,10 +973,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test011:
-          <span about='metadata-rdf#test011' property='mf:name'>tree-ops example with metadata</span>
+          manifest-rdf#test011:
+          <span about='manifest-rdf#test011' property='mf:name'>tree-ops example with metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test011' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test011' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with metadata. Processors should load metadata based on action URL.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -987,7 +987,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test011.rdf' property='mf:result'>test011.rdf</a>
+              <a href='test011.ttl' property='mf:result'>test011.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1001,10 +1001,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test012:
-          <span about='metadata-rdf#test012' property='mf:name'>tree-ops example with directory metadata</span>
+          manifest-rdf#test012:
+          <span about='manifest-rdf#test012' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test012' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test012' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1015,7 +1015,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test012/result.rdf' property='mf:result'>test012/result.rdf</a>
+              <a href='test012/result.ttl' property='mf:result'>test012/result.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1029,10 +1029,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test013:
-          <span about='metadata-rdf#test013' property='mf:name'>tree-ops example from directory metadata</span>
+          manifest-rdf#test013:
+          <span about='manifest-rdf#test013' property='mf:name'>tree-ops example from directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test013' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test013' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example from directory metadata. Processors should find CSV from metadata action file.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1043,7 +1043,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test013.rdf' property='mf:result'>test013.rdf</a>
+              <a href='test013.ttl' property='mf:result'>test013.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1059,10 +1059,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test014:
-          <span about='metadata-rdf#test014' property='mf:name'>tree-ops example with linked metadata</span>
+          manifest-rdf#test014:
+          <span about='manifest-rdf#test014' property='mf:name'>tree-ops example with linked metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test014' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test014' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with linked metadata. Processors load metadata from link header.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1073,7 +1073,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test014.rdf' property='mf:result'>test014.rdf</a>
+              <a href='test014.ttl' property='mf:result'>test014.ttl</a>
             </dd>
             <dt>Link Header</dt>
             <dd content='&lt;test014-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
@@ -1091,10 +1091,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test015:
-          <span about='metadata-rdf#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
+          manifest-rdf#test015:
+          <span about='manifest-rdf#test015' property='mf:name'>tree-ops example with user and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test015' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test015' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with user and directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1105,7 +1105,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test015/result.rdf' property='mf:result'>test015/result.rdf</a>
+              <a href='test015/result.ttl' property='mf:result'>test015/result.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1122,10 +1122,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test016:
-          <span about='metadata-rdf#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
+          manifest-rdf#test016:
+          <span about='manifest-rdf#test016' property='mf:name'>tree-ops example with linked and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test016' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test016' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1136,7 +1136,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test016/result.rdf' property='mf:result'>test016/result.rdf</a>
+              <a href='test016/result.ttl' property='mf:result'>test016/result.ttl</a>
             </dd>
             <dt>Link Header</dt>
             <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
@@ -1155,10 +1155,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test017:
-          <span about='metadata-rdf#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
+          manifest-rdf#test017:
+          <span about='manifest-rdf#test017' property='mf:name'>tree-ops example with file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test017' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test017' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1169,7 +1169,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test017/result.rdf' property='mf:result'>test017/result.rdf</a>
+              <a href='test017/result.ttl' property='mf:result'>test017/result.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1184,10 +1184,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test018:
-          <span about='metadata-rdf#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
+          manifest-rdf#test018:
+          <span about='manifest-rdf#test018' property='mf:name'>tree-ops example with user, file and directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test018' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test018' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1198,7 +1198,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test018/result.rdf' property='mf:result'>test018/result.rdf</a>
+              <a href='test018/result.ttl' property='mf:result'>test018/result.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1216,10 +1216,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test019:
-          <span about='metadata-rdf#test019' property='mf:name'>no header</span>
+          manifest-rdf#test019:
+          <span about='manifest-rdf#test019' property='mf:name'>no header</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test019' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test019' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>If a CSV+ file does not include a header line, this MUST be specified using the header parameter.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1230,7 +1230,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test019.rdf' property='mf:result'>test019.rdf</a>
+              <a href='test019.ttl' property='mf:result'>test019.ttl</a>
             </dd>
             <dt>Content Type</dt>
             <dd content='text/csv;header=absent' property='csvt:contentType'>
@@ -1244,10 +1244,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test020:
-          <span about='metadata-rdf#test020' property='mf:name'>trim=start</span>
+          manifest-rdf#test020:
+          <span about='manifest-rdf#test020' property='mf:name'>trim=start</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test020' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test020' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1258,7 +1258,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test020.rdf' property='mf:result'>test020.rdf</a>
+              <a href='test020.ttl' property='mf:result'>test020.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1272,10 +1272,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test021:
-          <span about='metadata-rdf#test021' property='mf:name'>trim=end</span>
+          manifest-rdf#test021:
+          <span about='manifest-rdf#test021' property='mf:name'>trim=end</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test021' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test021' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1286,7 +1286,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test021.rdf' property='mf:result'>test021.rdf</a>
+              <a href='test021.ttl' property='mf:result'>test021.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1300,10 +1300,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test022:
-          <span about='metadata-rdf#test022' property='mf:name'>trim=true</span>
+          manifest-rdf#test022:
+          <span about='manifest-rdf#test022' property='mf:name'>trim=true</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test022' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test022' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1314,7 +1314,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test022.rdf' property='mf:result'>test022.rdf</a>
+              <a href='test022.ttl' property='mf:result'>test022.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1328,10 +1328,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test023:
-          <span about='metadata-rdf#test023' property='mf:name'>dialect: header=false</span>
+          manifest-rdf#test023:
+          <span about='manifest-rdf#test023' property='mf:name'>dialect: header=false</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test023' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test023' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1342,7 +1342,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test023.rdf' property='mf:result'>test023.rdf</a>
+              <a href='test023.ttl' property='mf:result'>test023.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1358,10 +1358,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test024:
-          <span about='metadata-rdf#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
+          manifest-rdf#test024:
+          <span about='manifest-rdf#test024' property='mf:name'>dialect: header=false and headerRowCount=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test024' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test024' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1372,7 +1372,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test024.rdf' property='mf:result'>test024.rdf</a>
+              <a href='test024.ttl' property='mf:result'>test024.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1388,10 +1388,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test025:
-          <span about='metadata-rdf#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
+          manifest-rdf#test025:
+          <span about='manifest-rdf#test025' property='mf:name'>dialect: header=false and skipRows=1</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test025' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test025' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>Ignore header uses column definitions from metadata</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1402,7 +1402,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test025.rdf' property='mf:result'>test025.rdf</a>
+              <a href='test025.ttl' property='mf:result'>test025.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -1418,10 +1418,10 @@
           </dl>
         </dd>
         <dt>
-          metadata-rdf#test026:
-          <span about='metadata-rdf#test026' property='mf:name'>tree-ops example with directory metadata</span>
+          manifest-rdf#test026:
+          <span about='manifest-rdf#test026' property='mf:name'>tree-ops example with directory metadata</span>
         </dt>
-        <dd inlist property='mf:entry' resource='metadata-rdf#test026' typeof='csvt:CSVtoRdfTest'>
+        <dd inlist property='mf:entry' resource='manifest-rdf#test026' typeof='csvt:CsvToRdfTest'>
           <p property='rdfs:comment'>tree-ops example with directory metadata. Processors should find directory-based metadata.</p>
           <dl class='test-detail'>
             <dt>approval</dt>
@@ -1432,7 +1432,7 @@
             </dd>
             <dt>result</dt>
             <dd>
-              <a href='test026/result.rdf' property='mf:result'>test026/result.rdf</a>
+              <a href='test026/result.ttl' property='mf:result'>test026/result.ttl</a>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>

--- a/tests/manifest-json.jsonld
+++ b/tests/manifest-json.jsonld
@@ -16,145 +16,153 @@
       "@type": "@id"
     },
     "comment": "rdfs:comment",
+    "contentType": "csvt:contentType",
     "entries": {
       "@id": "mf:entries",
       "@type": "@id",
       "@container": "@list"
     },
-    "label": "rdfs:label",
     "httpLink": "csvt:httpLink",
+    "implicit": {
+      "@id": "mf:implicit",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "label": "rdfs:label",
+    "metadata": {
+      "@id": "csvt:metadata",
+      "@type": "@id"
+    },
+    "minimal": "csvt:minimal",
     "name": "mf:name",
+    "noProv": "csvt:noProv",
     "option": "csvt:option",
     "result": {
       "@id": "mf:result",
       "@type": "@id"
-    },
-    "user_metadata": {
-      "@id": "csvt:metadata",
-      "@type": "@id"
     }
   },
-  "id": "",
+  "id": "metadata-json",
   "type": "mf:Manifest",
   "label": "CSVW JSON tests",
-  "comment": "Tests transformation of CSV to JSON",
+  "comment": "Tests transformation of CSV to JSON.",
   "entries": [
     {
-      "id": "#test001",
+      "id": "metadata-json#test001",
       "type": "csvt:CSVtoJsonTest",
       "name": "Simple table",
       "comment": "The simplest possible table without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test001.csv",
       "result": "test001.json"
     },
     {
-      "id": "#test002",
+      "id": "metadata-json#test002",
       "type": "csvt:CSVtoJsonTest",
       "name": "Quoted field",
       "comment": "Table with one quoted field without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test002.csv",
       "result": "test002.json"
     },
     {
-      "id": "#test003",
+      "id": "metadata-json#test003",
       "type": "csvt:CSVtoJsonTest",
       "name": "Surrounding spaces",
       "comment": "Table with whitespace before and after every field without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test003.csv",
       "result": "test003.json"
     },
     {
-      "id": "#test005",
+      "id": "metadata-json#test005",
       "type": "csvt:CSVtoJsonTest",
       "name": "Identifier references",
       "comment": "A table with entity identifiers and references to other entities without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test005.csv",
       "result": "test005.json"
     },
     {
-      "id": "#test006",
+      "id": "metadata-json#test006",
       "type": "csvt:CSVtoJsonTest",
       "name": "No identifiers",
       "comment": "Records contain two entities with relationships which are duplicated without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test006.csv",
       "result": "test006.json"
     },
     {
-      "id": "#test007",
+      "id": "metadata-json#test007",
       "type": "csvt:CSVtoJsonTest",
       "name": "Joined table with unique identifiers",
       "comment": "Joined data with identified records without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test007.csv",
       "result": "test007.json"
     },
     {
-      "id": "#test008",
+      "id": "metadata-json#test008",
       "type": "csvt:CSVtoJsonTest",
       "name": "Microsyntax - internal field separator",
       "comment": "One field has comma-separated values without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test008.csv",
       "result": "test008.json"
     },
     {
-      "id": "#test009",
+      "id": "metadata-json#test009",
       "type": "csvt:CSVtoJsonTest",
       "name": "Microsyntax - formatted time",
       "comment": "Field with parseable human formatted time without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test009.csv",
       "result": "test009.json"
     },
     {
-      "id": "#test010",
+      "id": "metadata-json#test010",
       "type": "csvt:CSVtoJsonTest",
       "name": "Country-codes-and-names example",
       "comment": "Country-codes-and-names example",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test010.csv",
       "result": "test010.json"
     },
     {
-      "id": "#test011",
+      "id": "metadata-json#test011",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with metadata",
       "comment": "tree-ops example with metadata. Processors should load metadata based on action URL.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test011.csv",
       "result": "test011.json",
@@ -163,13 +171,13 @@
       ]
     },
     {
-      "id": "#test012",
+      "id": "metadata-json#test012",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test012/action.csv",
       "result": "test012/result.json",
@@ -178,14 +186,14 @@
       ]
     },
     {
-      "id": "#test013",
+      "id": "metadata-json#test013",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example from directory metadata",
       "comment": "tree-ops example from directory metadata. Processors should find CSV from metadata action file.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test013-user-metadata.json"
+        "noProv": true,
+        "metadata": "test013-user-metadata.json"
       },
       "action": "test013.csv",
       "result": "test013.json",
@@ -194,13 +202,13 @@
       ]
     },
     {
-      "id": "#test014",
+      "id": "metadata-json#test014",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with linked metadata",
       "comment": "tree-ops example with linked metadata. Processors load metadata from link header.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test014.csv",
       "result": "test014.json",
@@ -210,14 +218,14 @@
       "httpLink": "<test014-linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "#test015",
+      "id": "metadata-json#test015",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with user and directory metadata",
       "comment": "tree-ops example with user and directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test015/user-metadata.json"
+        "noProv": true,
+        "metadata": "test015/user-metadata.json"
       },
       "action": "test015/action.csv",
       "result": "test015/result.json",
@@ -227,13 +235,13 @@
       ]
     },
     {
-      "id": "#test016",
+      "id": "metadata-json#test016",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with linked and directory metadata",
       "comment": "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test016/action.csv",
       "result": "test016/result.json",
@@ -244,13 +252,13 @@
       "httpLink": "<linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "#test017",
+      "id": "metadata-json#test017",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with file and directory metadata",
       "comment": "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test017/action.csv",
       "result": "test017/result.json",
@@ -260,14 +268,14 @@
       ]
     },
     {
-      "id": "#test018",
+      "id": "metadata-json#test018",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with user, file and directory metadata",
       "comment": "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test018/user-metadata.json"
+        "noProv": true,
+        "metadata": "test018/user-metadata.json"
       },
       "action": "test018/action.csv",
       "result": "test018/result.json",
@@ -278,26 +286,26 @@
       ]
     },
     {
-      "id": "#test019",
+      "id": "metadata-json#test019",
       "type": "csvt:CSVtoJsonTest",
       "name": "no header",
       "comment": "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test019.csv",
       "result": "test019.json",
-      "csvt:contentType": "text/csv;header=absent"
+      "contentType": "text/csv;header=absent"
     },
     {
-      "id": "#test020",
+      "id": "metadata-json#test020",
       "type": "csvt:CSVtoJsonTest",
       "name": "trim=start",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test020.csv",
       "result": "test020.json",
@@ -306,13 +314,13 @@
       ]
     },
     {
-      "id": "#test021",
+      "id": "metadata-json#test021",
       "type": "csvt:CSVtoJsonTest",
       "name": "trim=end",
       "comment": "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test021.csv",
       "result": "test021.json",
@@ -321,13 +329,13 @@
       ]
     },
     {
-      "id": "#test022",
+      "id": "metadata-json#test022",
       "type": "csvt:CSVtoJsonTest",
       "name": "trim=true",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test022.csv",
       "result": "test022.json",
@@ -336,14 +344,14 @@
       ]
     },
     {
-      "id": "#test023",
+      "id": "metadata-json#test023",
       "type": "csvt:CSVtoJsonTest",
       "name": "dialect: header=false",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test023-user-metadata.json"
+        "noProv": true,
+        "metadata": "test023-user-metadata.json"
       },
       "action": "test023.csv",
       "result": "test023.json",
@@ -352,14 +360,14 @@
       ]
     },
     {
-      "id": "#test024",
+      "id": "metadata-json#test024",
       "type": "csvt:CSVtoJsonTest",
       "name": "dialect: header=false and headerRowCount=1",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test024-user-metadata.json"
+        "noProv": true,
+        "metadata": "test024-user-metadata.json"
       },
       "action": "test024.csv",
       "result": "test024.json",
@@ -368,14 +376,14 @@
       ]
     },
     {
-      "id": "#test025",
+      "id": "metadata-json#test025",
       "type": "csvt:CSVtoJsonTest",
       "name": "dialect: header=false and skipRows=1",
       "comment": "Ignore header uses column definitions from metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test025-user-metadata.json"
+        "noProv": true,
+        "metadata": "test025-user-metadata.json"
       },
       "action": "test025.csv",
       "result": "test025.json",
@@ -384,13 +392,13 @@
       ]
     },
     {
-      "id": "#test026",
+      "id": "metadata-json#test026",
       "type": "csvt:CSVtoJsonTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test026/metadata.json",
       "result": "test026/result.json",

--- a/tests/manifest-json.jsonld
+++ b/tests/manifest-json.jsonld
@@ -42,14 +42,14 @@
       "@type": "@id"
     }
   },
-  "id": "metadata-json",
+  "id": "manifest-json",
   "type": "mf:Manifest",
   "label": "CSVW JSON tests",
   "comment": "Tests transformation of CSV to JSON.",
   "entries": [
     {
-      "id": "metadata-json#test001",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test001",
+      "type": "csvt:CsvToJsonTest",
       "name": "Simple table",
       "comment": "The simplest possible table without metadata",
       "approval": "csvt:Proposed",
@@ -60,8 +60,8 @@
       "result": "test001.json"
     },
     {
-      "id": "metadata-json#test002",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test002",
+      "type": "csvt:CsvToJsonTest",
       "name": "Quoted field",
       "comment": "Table with one quoted field without metadata",
       "approval": "csvt:Proposed",
@@ -72,8 +72,8 @@
       "result": "test002.json"
     },
     {
-      "id": "metadata-json#test003",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test003",
+      "type": "csvt:CsvToJsonTest",
       "name": "Surrounding spaces",
       "comment": "Table with whitespace before and after every field without metadata",
       "approval": "csvt:Proposed",
@@ -84,8 +84,8 @@
       "result": "test003.json"
     },
     {
-      "id": "metadata-json#test005",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test005",
+      "type": "csvt:CsvToJsonTest",
       "name": "Identifier references",
       "comment": "A table with entity identifiers and references to other entities without metadata",
       "approval": "csvt:Proposed",
@@ -96,8 +96,8 @@
       "result": "test005.json"
     },
     {
-      "id": "metadata-json#test006",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test006",
+      "type": "csvt:CsvToJsonTest",
       "name": "No identifiers",
       "comment": "Records contain two entities with relationships which are duplicated without metadata",
       "approval": "csvt:Proposed",
@@ -108,8 +108,8 @@
       "result": "test006.json"
     },
     {
-      "id": "metadata-json#test007",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test007",
+      "type": "csvt:CsvToJsonTest",
       "name": "Joined table with unique identifiers",
       "comment": "Joined data with identified records without metadata",
       "approval": "csvt:Proposed",
@@ -120,8 +120,8 @@
       "result": "test007.json"
     },
     {
-      "id": "metadata-json#test008",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test008",
+      "type": "csvt:CsvToJsonTest",
       "name": "Microsyntax - internal field separator",
       "comment": "One field has comma-separated values without metadata",
       "approval": "csvt:Proposed",
@@ -132,8 +132,8 @@
       "result": "test008.json"
     },
     {
-      "id": "metadata-json#test009",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test009",
+      "type": "csvt:CsvToJsonTest",
       "name": "Microsyntax - formatted time",
       "comment": "Field with parseable human formatted time without metadata",
       "approval": "csvt:Proposed",
@@ -144,8 +144,8 @@
       "result": "test009.json"
     },
     {
-      "id": "metadata-json#test010",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test010",
+      "type": "csvt:CsvToJsonTest",
       "name": "Country-codes-and-names example",
       "comment": "Country-codes-and-names example",
       "approval": "csvt:Proposed",
@@ -156,8 +156,8 @@
       "result": "test010.json"
     },
     {
-      "id": "metadata-json#test011",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test011",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with metadata",
       "comment": "tree-ops example with metadata. Processors should load metadata based on action URL.",
       "approval": "csvt:Proposed",
@@ -171,8 +171,8 @@
       ]
     },
     {
-      "id": "metadata-json#test012",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test012",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -186,8 +186,8 @@
       ]
     },
     {
-      "id": "metadata-json#test013",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test013",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example from directory metadata",
       "comment": "tree-ops example from directory metadata. Processors should find CSV from metadata action file.",
       "approval": "csvt:Proposed",
@@ -202,8 +202,8 @@
       ]
     },
     {
-      "id": "metadata-json#test014",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test014",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with linked metadata",
       "comment": "tree-ops example with linked metadata. Processors load metadata from link header.",
       "approval": "csvt:Proposed",
@@ -218,8 +218,8 @@
       "httpLink": "<test014-linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "metadata-json#test015",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test015",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with user and directory metadata",
       "comment": "tree-ops example with user and directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -235,8 +235,8 @@
       ]
     },
     {
-      "id": "metadata-json#test016",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test016",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with linked and directory metadata",
       "comment": "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -252,8 +252,8 @@
       "httpLink": "<linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "metadata-json#test017",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test017",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with file and directory metadata",
       "comment": "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -268,8 +268,8 @@
       ]
     },
     {
-      "id": "metadata-json#test018",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test018",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with user, file and directory metadata",
       "comment": "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -286,8 +286,8 @@
       ]
     },
     {
-      "id": "metadata-json#test019",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test019",
+      "type": "csvt:CsvToJsonTest",
       "name": "no header",
       "comment": "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.",
       "approval": "csvt:Proposed",
@@ -299,8 +299,8 @@
       "contentType": "text/csv;header=absent"
     },
     {
-      "id": "metadata-json#test020",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test020",
+      "type": "csvt:CsvToJsonTest",
       "name": "trim=start",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -314,8 +314,8 @@
       ]
     },
     {
-      "id": "metadata-json#test021",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test021",
+      "type": "csvt:CsvToJsonTest",
       "name": "trim=end",
       "comment": "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -329,8 +329,8 @@
       ]
     },
     {
-      "id": "metadata-json#test022",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test022",
+      "type": "csvt:CsvToJsonTest",
       "name": "trim=true",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -344,8 +344,8 @@
       ]
     },
     {
-      "id": "metadata-json#test023",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test023",
+      "type": "csvt:CsvToJsonTest",
       "name": "dialect: header=false",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
@@ -360,8 +360,8 @@
       ]
     },
     {
-      "id": "metadata-json#test024",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test024",
+      "type": "csvt:CsvToJsonTest",
       "name": "dialect: header=false and headerRowCount=1",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
@@ -376,8 +376,8 @@
       ]
     },
     {
-      "id": "metadata-json#test025",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test025",
+      "type": "csvt:CsvToJsonTest",
       "name": "dialect: header=false and skipRows=1",
       "comment": "Ignore header uses column definitions from metadata",
       "approval": "csvt:Proposed",
@@ -392,8 +392,8 @@
       ]
     },
     {
-      "id": "metadata-json#test026",
-      "type": "csvt:CSVtoJsonTest",
+      "id": "manifest-json#test026",
+      "type": "csvt:CsvToJsonTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",

--- a/tests/manifest-json.ttl
+++ b/tests/manifest-json.ttl
@@ -12,13 +12,13 @@
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <metadata-json#> .
+@prefix : <manifest-json#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<metadata-json>  a mf:Manifest ;
+<manifest-json>  a mf:Manifest ;
 
   rdfs:label "CSVW JSON tests";
   rdfs:comment "Tests transformation of CSV to JSON.";
@@ -28,7 +28,7 @@
     :test022 :test023 :test024 :test025 :test026
   ) .
 
-:test001 a csvt:CSVtoJsonTest;
+:test001 a csvt:CsvToJsonTest;
   mf:name "Simple table";
   rdfs:comment "The simplest possible table without metadata";
   csvt:approval csvt:Proposed;
@@ -39,7 +39,7 @@
   mf:result <test001.json>;
   .
 
-:test002 a csvt:CSVtoJsonTest;
+:test002 a csvt:CsvToJsonTest;
   mf:name "Quoted field";
   rdfs:comment "Table with one quoted field without metadata";
   csvt:approval csvt:Proposed;
@@ -50,7 +50,7 @@
   mf:result <test002.json>;
   .
 
-:test003 a csvt:CSVtoJsonTest;
+:test003 a csvt:CsvToJsonTest;
   mf:name "Surrounding spaces";
   rdfs:comment "Table with whitespace before and after every field without metadata";
   csvt:approval csvt:Proposed;
@@ -61,7 +61,7 @@
   mf:result <test003.json>;
   .
 
-:test005 a csvt:CSVtoJsonTest;
+:test005 a csvt:CsvToJsonTest;
   mf:name "Identifier references";
   rdfs:comment "A table with entity identifiers and references to other entities without metadata";
   csvt:approval csvt:Proposed;
@@ -72,7 +72,7 @@
   mf:result <test005.json>;
   .
 
-:test006 a csvt:CSVtoJsonTest;
+:test006 a csvt:CsvToJsonTest;
   mf:name "No identifiers";
   rdfs:comment "Records contain two entities with relationships which are duplicated without metadata";
   csvt:approval csvt:Proposed;
@@ -83,7 +83,7 @@
   mf:result <test006.json>;
   .
 
-:test007 a csvt:CSVtoJsonTest;
+:test007 a csvt:CsvToJsonTest;
   mf:name "Joined table with unique identifiers";
   rdfs:comment "Joined data with identified records without metadata";
   csvt:approval csvt:Proposed;
@@ -94,7 +94,7 @@
   mf:result <test007.json>;
   .
 
-:test008 a csvt:CSVtoJsonTest;
+:test008 a csvt:CsvToJsonTest;
   mf:name "Microsyntax - internal field separator";
   rdfs:comment "One field has comma-separated values without metadata";
   csvt:approval csvt:Proposed;
@@ -105,7 +105,7 @@
   mf:result <test008.json>;
   .
 
-:test009 a csvt:CSVtoJsonTest;
+:test009 a csvt:CsvToJsonTest;
   mf:name "Microsyntax - formatted time";
   rdfs:comment "Field with parseable human formatted time without metadata";
   csvt:approval csvt:Proposed;
@@ -116,7 +116,7 @@
   mf:result <test009.json>;
   .
 
-:test010 a csvt:CSVtoJsonTest;
+:test010 a csvt:CsvToJsonTest;
   mf:name "Country-codes-and-names example";
   rdfs:comment "Country-codes-and-names example";
   csvt:approval csvt:Proposed;
@@ -127,7 +127,7 @@
   mf:result <test010.json>;
   .
 
-:test011 a csvt:CSVtoJsonTest;
+:test011 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with metadata";
   rdfs:comment "tree-ops example with metadata. Processors should load metadata based on action URL.";
   csvt:approval csvt:Proposed;
@@ -139,7 +139,7 @@
   csvt:implicit <test011.csv-metadata.json>;
   .
 
-:test012 a csvt:CSVtoJsonTest;
+:test012 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with directory metadata";
   rdfs:comment "tree-ops example with directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -151,7 +151,7 @@
   csvt:implicit <test012/metadata.json>;
   .
 
-:test013 a csvt:CSVtoJsonTest;
+:test013 a csvt:CsvToJsonTest;
   mf:name "tree-ops example from directory metadata";
   rdfs:comment "tree-ops example from directory metadata. Processors should find CSV from metadata action file.";
   csvt:approval csvt:Proposed;
@@ -164,7 +164,7 @@
   csvt:implicit <test013-user-metadata.json>;
   .
 
-:test014 a csvt:CSVtoJsonTest;
+:test014 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with linked metadata";
   rdfs:comment "tree-ops example with linked metadata. Processors load metadata from link header.";
   csvt:approval csvt:Proposed;
@@ -177,7 +177,7 @@
   csvt:implicit <test014-linked-metadata.json>;
   .
 
-:test015 a csvt:CSVtoJsonTest;
+:test015 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with user and directory metadata";
   rdfs:comment "tree-ops example with user and directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -191,7 +191,7 @@
     <test015/metadata.json>;
   .
 
-:test016 a csvt:CSVtoJsonTest;
+:test016 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with linked and directory metadata";
   rdfs:comment "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -205,7 +205,7 @@
     <test016/metadata.json>;
   .
 
-:test017 a csvt:CSVtoJsonTest;
+:test017 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with file and directory metadata";
   rdfs:comment "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -218,7 +218,7 @@
     <test017/metadata.json>;
   .
 
-:test018 a csvt:CSVtoJsonTest;
+:test018 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with user, file and directory metadata";
   rdfs:comment "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -233,7 +233,7 @@
     <test018/metadata.json>;
   .
 
-:test019 a csvt:CSVtoJsonTest;
+:test019 a csvt:CsvToJsonTest;
   mf:name "no header";
   rdfs:comment "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.";
   csvt:approval csvt:Proposed;
@@ -245,7 +245,7 @@
   csvt:contentType "text/csv;header=absent";
   .
 
-:test020 a csvt:CSVtoJsonTest;
+:test020 a csvt:CsvToJsonTest;
   mf:name "trim=start";
   rdfs:comment "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -257,7 +257,7 @@
   csvt:implicit <test020.csv-metadata.json>;
   .
 
-:test021 a csvt:CSVtoJsonTest;
+:test021 a csvt:CsvToJsonTest;
   mf:name "trim=end";
   rdfs:comment "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -269,7 +269,7 @@
   csvt:implicit <test021.csv-metadata.json>;
   .
 
-:test022 a csvt:CSVtoJsonTest;
+:test022 a csvt:CsvToJsonTest;
   mf:name "trim=true";
   rdfs:comment "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -281,7 +281,7 @@
   csvt:implicit <test022.csv-metadata.json>;
   .
 
-:test023 a csvt:CSVtoJsonTest;
+:test023 a csvt:CsvToJsonTest;
   mf:name "dialect: header=false";
   rdfs:comment "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.";
   csvt:approval csvt:Proposed;
@@ -294,7 +294,7 @@
   csvt:implicit <test023-user-metadata.json>;
   .
 
-:test024 a csvt:CSVtoJsonTest;
+:test024 a csvt:CsvToJsonTest;
   mf:name "dialect: header=false and headerRowCount=1";
   rdfs:comment "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.";
   csvt:approval csvt:Proposed;
@@ -307,7 +307,7 @@
   csvt:implicit <test024-user-metadata.json>;
   .
 
-:test025 a csvt:CSVtoJsonTest;
+:test025 a csvt:CsvToJsonTest;
   mf:name "dialect: header=false and skipRows=1";
   rdfs:comment "Ignore header uses column definitions from metadata";
   csvt:approval csvt:Proposed;
@@ -320,7 +320,7 @@
   csvt:implicit <test025-user-metadata.json>;
   .
 
-:test026 a csvt:CSVtoJsonTest;
+:test026 a csvt:CsvToJsonTest;
   mf:name "tree-ops example with directory metadata";
   rdfs:comment "tree-ops example with directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;

--- a/tests/manifest-json.ttl
+++ b/tests/manifest-json.ttl
@@ -12,16 +12,16 @@
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <#> .
+@prefix : <metadata-json#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<>  a mf:Manifest ;
+<metadata-json>  a mf:Manifest ;
 
   rdfs:label "CSVW JSON tests";
-  rdfs:comment "Tests transformation of CSV to JSON";
+  rdfs:comment "Tests transformation of CSV to JSON.";
   mf:entries (
     :test001 :test002 :test003 :test005 :test006 :test007 :test008 :test009 :test010 :test011
     :test012 :test013 :test014 :test015 :test016 :test017 :test018 :test019 :test020 :test021

--- a/tests/manifest-rdf.jsonld
+++ b/tests/manifest-rdf.jsonld
@@ -16,145 +16,153 @@
       "@type": "@id"
     },
     "comment": "rdfs:comment",
+    "contentType": "csvt:contentType",
     "entries": {
       "@id": "mf:entries",
       "@type": "@id",
       "@container": "@list"
     },
-    "label": "rdfs:label",
     "httpLink": "csvt:httpLink",
+    "implicit": {
+      "@id": "mf:implicit",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "label": "rdfs:label",
+    "metadata": {
+      "@id": "csvt:metadata",
+      "@type": "@id"
+    },
+    "minimal": "csvt:minimal",
     "name": "mf:name",
+    "noProv": "csvt:noProv",
     "option": "csvt:option",
     "result": {
       "@id": "mf:result",
       "@type": "@id"
-    },
-    "user_metadata": {
-      "@id": "csvt:metadata",
-      "@type": "@id"
     }
   },
-  "id": "",
+  "id": "metadata-rdf",
   "type": "mf:Manifest",
-  "label": "CSVW RDF tests",
-  "comment": "Tests transformation of CSV to RDF",
+  "label": "CSVW RDF Tests",
+  "comment": "Tests transformation of CSV to RDF.",
   "entries": [
     {
-      "id": "#test001",
+      "id": "metadata-rdf#test001",
       "type": "csvt:CSVtoRdfTest",
       "name": "Simple table",
       "comment": "The simplest possible table without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test001.csv",
       "result": "test001.rdf"
     },
     {
-      "id": "#test002",
+      "id": "metadata-rdf#test002",
       "type": "csvt:CSVtoRdfTest",
       "name": "Quoted field",
       "comment": "Table with one quoted field without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test002.csv",
       "result": "test002.rdf"
     },
     {
-      "id": "#test003",
+      "id": "metadata-rdf#test003",
       "type": "csvt:CSVtoRdfTest",
       "name": "Surrounding spaces",
       "comment": "Table with whitespace before and after every field without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test003.csv",
       "result": "test003.rdf"
     },
     {
-      "id": "#test005",
+      "id": "metadata-rdf#test005",
       "type": "csvt:CSVtoRdfTest",
       "name": "Identifier references",
       "comment": "A table with entity identifiers and references to other entities without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test005.csv",
       "result": "test005.rdf"
     },
     {
-      "id": "#test006",
+      "id": "metadata-rdf#test006",
       "type": "csvt:CSVtoRdfTest",
       "name": "No identifiers",
       "comment": "Records contain two entities with relationships which are duplicated without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test006.csv",
       "result": "test006.rdf"
     },
     {
-      "id": "#test007",
+      "id": "metadata-rdf#test007",
       "type": "csvt:CSVtoRdfTest",
       "name": "Joined table with unique identifiers",
       "comment": "Joined data with identified records without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test007.csv",
       "result": "test007.rdf"
     },
     {
-      "id": "#test008",
+      "id": "metadata-rdf#test008",
       "type": "csvt:CSVtoRdfTest",
       "name": "Microsyntax - internal field separator",
       "comment": "One field has comma-separated values without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test008.csv",
       "result": "test008.rdf"
     },
     {
-      "id": "#test009",
+      "id": "metadata-rdf#test009",
       "type": "csvt:CSVtoRdfTest",
       "name": "Microsyntax - formatted time",
       "comment": "Field with parseable human formatted time without metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test009.csv",
       "result": "test009.rdf"
     },
     {
-      "id": "#test010",
+      "id": "metadata-rdf#test010",
       "type": "csvt:CSVtoRdfTest",
       "name": "Country-codes-and-names example",
       "comment": "Country-codes-and-names example",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test010.csv",
       "result": "test010.rdf"
     },
     {
-      "id": "#test011",
+      "id": "metadata-rdf#test011",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with metadata",
       "comment": "tree-ops example with metadata. Processors should load metadata based on action URL.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test011.csv",
       "result": "test011.rdf",
@@ -163,13 +171,13 @@
       ]
     },
     {
-      "id": "#test012",
+      "id": "metadata-rdf#test012",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test012/action.csv",
       "result": "test012/result.rdf",
@@ -178,14 +186,14 @@
       ]
     },
     {
-      "id": "#test013",
+      "id": "metadata-rdf#test013",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example from directory metadata",
       "comment": "tree-ops example from directory metadata. Processors should find CSV from metadata action file.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test013-user-metadata.json"
+        "noProv": true,
+        "metadata": "test013-user-metadata.json"
       },
       "action": "test013.csv",
       "result": "test013.rdf",
@@ -194,13 +202,13 @@
       ]
     },
     {
-      "id": "#test014",
+      "id": "metadata-rdf#test014",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with linked metadata",
       "comment": "tree-ops example with linked metadata. Processors load metadata from link header.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test014.csv",
       "result": "test014.rdf",
@@ -210,14 +218,14 @@
       "httpLink": "<test014-linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "#test015",
+      "id": "metadata-rdf#test015",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with user and directory metadata",
       "comment": "tree-ops example with user and directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test015/user-metadata.json"
+        "noProv": true,
+        "metadata": "test015/user-metadata.json"
       },
       "action": "test015/action.csv",
       "result": "test015/result.rdf",
@@ -227,13 +235,13 @@
       ]
     },
     {
-      "id": "#test016",
+      "id": "metadata-rdf#test016",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with linked and directory metadata",
       "comment": "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test016/action.csv",
       "result": "test016/result.rdf",
@@ -244,13 +252,13 @@
       "httpLink": "<linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "#test017",
+      "id": "metadata-rdf#test017",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with file and directory metadata",
       "comment": "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test017/action.csv",
       "result": "test017/result.rdf",
@@ -260,14 +268,14 @@
       ]
     },
     {
-      "id": "#test018",
+      "id": "metadata-rdf#test018",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with user, file and directory metadata",
       "comment": "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test018/user-metadata.json"
+        "noProv": true,
+        "metadata": "test018/user-metadata.json"
       },
       "action": "test018/action.csv",
       "result": "test018/result.rdf",
@@ -278,26 +286,26 @@
       ]
     },
     {
-      "id": "#test019",
+      "id": "metadata-rdf#test019",
       "type": "csvt:CSVtoRdfTest",
       "name": "no header",
       "comment": "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test019.csv",
       "result": "test019.rdf",
-      "csvt:contentType": "text/csv;header=absent"
+      "contentType": "text/csv;header=absent"
     },
     {
-      "id": "#test020",
+      "id": "metadata-rdf#test020",
       "type": "csvt:CSVtoRdfTest",
       "name": "trim=start",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test020.csv",
       "result": "test020.rdf",
@@ -306,13 +314,13 @@
       ]
     },
     {
-      "id": "#test021",
+      "id": "metadata-rdf#test021",
       "type": "csvt:CSVtoRdfTest",
       "name": "trim=end",
       "comment": "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test021.csv",
       "result": "test021.rdf",
@@ -321,13 +329,13 @@
       ]
     },
     {
-      "id": "#test022",
+      "id": "metadata-rdf#test022",
       "type": "csvt:CSVtoRdfTest",
       "name": "trim=true",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test022.csv",
       "result": "test022.rdf",
@@ -336,14 +344,14 @@
       ]
     },
     {
-      "id": "#test023",
+      "id": "metadata-rdf#test023",
       "type": "csvt:CSVtoRdfTest",
       "name": "dialect: header=false",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test023-user-metadata.json"
+        "noProv": true,
+        "metadata": "test023-user-metadata.json"
       },
       "action": "test023.csv",
       "result": "test023.rdf",
@@ -352,14 +360,14 @@
       ]
     },
     {
-      "id": "#test024",
+      "id": "metadata-rdf#test024",
       "type": "csvt:CSVtoRdfTest",
       "name": "dialect: header=false and headerRowCount=1",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test024-user-metadata.json"
+        "noProv": true,
+        "metadata": "test024-user-metadata.json"
       },
       "action": "test024.csv",
       "result": "test024.rdf",
@@ -368,14 +376,14 @@
       ]
     },
     {
-      "id": "#test025",
+      "id": "metadata-rdf#test025",
       "type": "csvt:CSVtoRdfTest",
       "name": "dialect: header=false and skipRows=1",
       "comment": "Ignore header uses column definitions from metadata",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true,
-        "user_metadata": "test025-user-metadata.json"
+        "noProv": true,
+        "metadata": "test025-user-metadata.json"
       },
       "action": "test025.csv",
       "result": "test025.rdf",
@@ -384,13 +392,13 @@
       ]
     },
     {
-      "id": "#test026",
+      "id": "metadata-rdf#test026",
       "type": "csvt:CSVtoRdfTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
       "option": {
-        "csvt:noProv": true
+        "noProv": true
       },
       "action": "test026/metadata.json",
       "result": "test026/result.rdf",

--- a/tests/manifest-rdf.jsonld
+++ b/tests/manifest-rdf.jsonld
@@ -42,14 +42,14 @@
       "@type": "@id"
     }
   },
-  "id": "metadata-rdf",
+  "id": "manifest-rdf",
   "type": "mf:Manifest",
   "label": "CSVW RDF Tests",
   "comment": "Tests transformation of CSV to RDF.",
   "entries": [
     {
-      "id": "metadata-rdf#test001",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test001",
+      "type": "csvt:CsvToRdfTest",
       "name": "Simple table",
       "comment": "The simplest possible table without metadata",
       "approval": "csvt:Proposed",
@@ -57,11 +57,11 @@
         "noProv": true
       },
       "action": "test001.csv",
-      "result": "test001.rdf"
+      "result": "test001.ttl"
     },
     {
-      "id": "metadata-rdf#test002",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test002",
+      "type": "csvt:CsvToRdfTest",
       "name": "Quoted field",
       "comment": "Table with one quoted field without metadata",
       "approval": "csvt:Proposed",
@@ -69,11 +69,11 @@
         "noProv": true
       },
       "action": "test002.csv",
-      "result": "test002.rdf"
+      "result": "test002.ttl"
     },
     {
-      "id": "metadata-rdf#test003",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test003",
+      "type": "csvt:CsvToRdfTest",
       "name": "Surrounding spaces",
       "comment": "Table with whitespace before and after every field without metadata",
       "approval": "csvt:Proposed",
@@ -81,11 +81,11 @@
         "noProv": true
       },
       "action": "test003.csv",
-      "result": "test003.rdf"
+      "result": "test003.ttl"
     },
     {
-      "id": "metadata-rdf#test005",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test005",
+      "type": "csvt:CsvToRdfTest",
       "name": "Identifier references",
       "comment": "A table with entity identifiers and references to other entities without metadata",
       "approval": "csvt:Proposed",
@@ -93,11 +93,11 @@
         "noProv": true
       },
       "action": "test005.csv",
-      "result": "test005.rdf"
+      "result": "test005.ttl"
     },
     {
-      "id": "metadata-rdf#test006",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test006",
+      "type": "csvt:CsvToRdfTest",
       "name": "No identifiers",
       "comment": "Records contain two entities with relationships which are duplicated without metadata",
       "approval": "csvt:Proposed",
@@ -105,11 +105,11 @@
         "noProv": true
       },
       "action": "test006.csv",
-      "result": "test006.rdf"
+      "result": "test006.ttl"
     },
     {
-      "id": "metadata-rdf#test007",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test007",
+      "type": "csvt:CsvToRdfTest",
       "name": "Joined table with unique identifiers",
       "comment": "Joined data with identified records without metadata",
       "approval": "csvt:Proposed",
@@ -117,11 +117,11 @@
         "noProv": true
       },
       "action": "test007.csv",
-      "result": "test007.rdf"
+      "result": "test007.ttl"
     },
     {
-      "id": "metadata-rdf#test008",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test008",
+      "type": "csvt:CsvToRdfTest",
       "name": "Microsyntax - internal field separator",
       "comment": "One field has comma-separated values without metadata",
       "approval": "csvt:Proposed",
@@ -129,11 +129,11 @@
         "noProv": true
       },
       "action": "test008.csv",
-      "result": "test008.rdf"
+      "result": "test008.ttl"
     },
     {
-      "id": "metadata-rdf#test009",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test009",
+      "type": "csvt:CsvToRdfTest",
       "name": "Microsyntax - formatted time",
       "comment": "Field with parseable human formatted time without metadata",
       "approval": "csvt:Proposed",
@@ -141,11 +141,11 @@
         "noProv": true
       },
       "action": "test009.csv",
-      "result": "test009.rdf"
+      "result": "test009.ttl"
     },
     {
-      "id": "metadata-rdf#test010",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test010",
+      "type": "csvt:CsvToRdfTest",
       "name": "Country-codes-and-names example",
       "comment": "Country-codes-and-names example",
       "approval": "csvt:Proposed",
@@ -153,11 +153,11 @@
         "noProv": true
       },
       "action": "test010.csv",
-      "result": "test010.rdf"
+      "result": "test010.ttl"
     },
     {
-      "id": "metadata-rdf#test011",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test011",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with metadata",
       "comment": "tree-ops example with metadata. Processors should load metadata based on action URL.",
       "approval": "csvt:Proposed",
@@ -165,14 +165,14 @@
         "noProv": true
       },
       "action": "test011.csv",
-      "result": "test011.rdf",
+      "result": "test011.ttl",
       "implicit": [
         "test011.csv-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test012",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test012",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -180,14 +180,14 @@
         "noProv": true
       },
       "action": "test012/action.csv",
-      "result": "test012/result.rdf",
+      "result": "test012/result.ttl",
       "implicit": [
         "test012/metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test013",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test013",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example from directory metadata",
       "comment": "tree-ops example from directory metadata. Processors should find CSV from metadata action file.",
       "approval": "csvt:Proposed",
@@ -196,14 +196,14 @@
         "metadata": "test013-user-metadata.json"
       },
       "action": "test013.csv",
-      "result": "test013.rdf",
+      "result": "test013.ttl",
       "implicit": [
         "test013-user-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test014",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test014",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with linked metadata",
       "comment": "tree-ops example with linked metadata. Processors load metadata from link header.",
       "approval": "csvt:Proposed",
@@ -211,15 +211,15 @@
         "noProv": true
       },
       "action": "test014.csv",
-      "result": "test014.rdf",
+      "result": "test014.ttl",
       "implicit": [
         "test014-linked-metadata.json"
       ],
       "httpLink": "<test014-linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "metadata-rdf#test015",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test015",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with user and directory metadata",
       "comment": "tree-ops example with user and directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -228,15 +228,15 @@
         "metadata": "test015/user-metadata.json"
       },
       "action": "test015/action.csv",
-      "result": "test015/result.rdf",
+      "result": "test015/result.ttl",
       "implicit": [
         "test015/user-metadata.json",
         "test015/metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test016",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test016",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with linked and directory metadata",
       "comment": "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -244,7 +244,7 @@
         "noProv": true
       },
       "action": "test016/action.csv",
-      "result": "test016/result.rdf",
+      "result": "test016/result.ttl",
       "implicit": [
         "test016/linked-metadata.json",
         "test016/metadata.json"
@@ -252,8 +252,8 @@
       "httpLink": "<linked-metadata.json>; rel=\"describedby\""
     },
     {
-      "id": "metadata-rdf#test017",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test017",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with file and directory metadata",
       "comment": "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -261,15 +261,15 @@
         "noProv": true
       },
       "action": "test017/action.csv",
-      "result": "test017/result.rdf",
+      "result": "test017/result.ttl",
       "implicit": [
         "test017/action.csv-metadata.json",
         "test017/metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test018",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test018",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with user, file and directory metadata",
       "comment": "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -278,7 +278,7 @@
         "metadata": "test018/user-metadata.json"
       },
       "action": "test018/action.csv",
-      "result": "test018/result.rdf",
+      "result": "test018/result.ttl",
       "implicit": [
         "test018/user-metadata.json",
         "test018/action.csv-metadata.json",
@@ -286,8 +286,8 @@
       ]
     },
     {
-      "id": "metadata-rdf#test019",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test019",
+      "type": "csvt:CsvToRdfTest",
       "name": "no header",
       "comment": "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.",
       "approval": "csvt:Proposed",
@@ -295,12 +295,12 @@
         "noProv": true
       },
       "action": "test019.csv",
-      "result": "test019.rdf",
+      "result": "test019.ttl",
       "contentType": "text/csv;header=absent"
     },
     {
-      "id": "metadata-rdf#test020",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test020",
+      "type": "csvt:CsvToRdfTest",
       "name": "trim=start",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -308,14 +308,14 @@
         "noProv": true
       },
       "action": "test020.csv",
-      "result": "test020.rdf",
+      "result": "test020.ttl",
       "implicit": [
         "test020.csv-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test021",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test021",
+      "type": "csvt:CsvToRdfTest",
       "name": "trim=end",
       "comment": "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -323,14 +323,14 @@
         "noProv": true
       },
       "action": "test021.csv",
-      "result": "test021.rdf",
+      "result": "test021.ttl",
       "implicit": [
         "test021.csv-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test022",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test022",
+      "type": "csvt:CsvToRdfTest",
       "name": "trim=true",
       "comment": "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.",
       "approval": "csvt:Proposed",
@@ -338,14 +338,14 @@
         "noProv": true
       },
       "action": "test022.csv",
-      "result": "test022.rdf",
+      "result": "test022.ttl",
       "implicit": [
         "test022.csv-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test023",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test023",
+      "type": "csvt:CsvToRdfTest",
       "name": "dialect: header=false",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
@@ -354,14 +354,14 @@
         "metadata": "test023-user-metadata.json"
       },
       "action": "test023.csv",
-      "result": "test023.rdf",
+      "result": "test023.ttl",
       "implicit": [
         "test023-user-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test024",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test024",
+      "type": "csvt:CsvToRdfTest",
       "name": "dialect: header=false and headerRowCount=1",
       "comment": "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.",
       "approval": "csvt:Proposed",
@@ -370,14 +370,14 @@
         "metadata": "test024-user-metadata.json"
       },
       "action": "test024.csv",
-      "result": "test024.rdf",
+      "result": "test024.ttl",
       "implicit": [
         "test024-user-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test025",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test025",
+      "type": "csvt:CsvToRdfTest",
       "name": "dialect: header=false and skipRows=1",
       "comment": "Ignore header uses column definitions from metadata",
       "approval": "csvt:Proposed",
@@ -386,14 +386,14 @@
         "metadata": "test025-user-metadata.json"
       },
       "action": "test025.csv",
-      "result": "test025.rdf",
+      "result": "test025.ttl",
       "implicit": [
         "test025-user-metadata.json"
       ]
     },
     {
-      "id": "metadata-rdf#test026",
-      "type": "csvt:CSVtoRdfTest",
+      "id": "manifest-rdf#test026",
+      "type": "csvt:CsvToRdfTest",
       "name": "tree-ops example with directory metadata",
       "comment": "tree-ops example with directory metadata. Processors should find directory-based metadata.",
       "approval": "csvt:Proposed",
@@ -401,7 +401,7 @@
         "noProv": true
       },
       "action": "test026/metadata.json",
-      "result": "test026/result.rdf",
+      "result": "test026/result.ttl",
       "implicit": [
         "test026/action.csv",
         "test026/metadata.json"

--- a/tests/manifest-rdf.ttl
+++ b/tests/manifest-rdf.ttl
@@ -12,16 +12,16 @@
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <#> .
+@prefix : <metadata-rdf#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<>  a mf:Manifest ;
+<metadata-rdf>  a mf:Manifest ;
 
-  rdfs:label "CSVW RDF tests";
-  rdfs:comment "Tests transformation of CSV to RDF";
+  rdfs:label "CSVW RDF Tests";
+  rdfs:comment "Tests transformation of CSV to RDF.";
   mf:entries (
     :test001 :test002 :test003 :test005 :test006 :test007 :test008 :test009 :test010 :test011
     :test012 :test013 :test014 :test015 :test016 :test017 :test018 :test019 :test020 :test021

--- a/tests/manifest-rdf.ttl
+++ b/tests/manifest-rdf.ttl
@@ -12,13 +12,13 @@
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <metadata-rdf#> .
+@prefix : <manifest-rdf#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<metadata-rdf>  a mf:Manifest ;
+<manifest-rdf>  a mf:Manifest ;
 
   rdfs:label "CSVW RDF Tests";
   rdfs:comment "Tests transformation of CSV to RDF.";
@@ -28,7 +28,7 @@
     :test022 :test023 :test024 :test025 :test026
   ) .
 
-:test001 a csvt:CSVtoRdfTest;
+:test001 a csvt:CsvToRdfTest;
   mf:name "Simple table";
   rdfs:comment "The simplest possible table without metadata";
   csvt:approval csvt:Proposed;
@@ -36,10 +36,10 @@
     csvt:noProv true;
   ];
   mf:action <test001.csv>;
-  mf:result <test001.rdf>;
+  mf:result <test001.ttl>;
   .
 
-:test002 a csvt:CSVtoRdfTest;
+:test002 a csvt:CsvToRdfTest;
   mf:name "Quoted field";
   rdfs:comment "Table with one quoted field without metadata";
   csvt:approval csvt:Proposed;
@@ -47,10 +47,10 @@
     csvt:noProv true;
   ];
   mf:action <test002.csv>;
-  mf:result <test002.rdf>;
+  mf:result <test002.ttl>;
   .
 
-:test003 a csvt:CSVtoRdfTest;
+:test003 a csvt:CsvToRdfTest;
   mf:name "Surrounding spaces";
   rdfs:comment "Table with whitespace before and after every field without metadata";
   csvt:approval csvt:Proposed;
@@ -58,10 +58,10 @@
     csvt:noProv true;
   ];
   mf:action <test003.csv>;
-  mf:result <test003.rdf>;
+  mf:result <test003.ttl>;
   .
 
-:test005 a csvt:CSVtoRdfTest;
+:test005 a csvt:CsvToRdfTest;
   mf:name "Identifier references";
   rdfs:comment "A table with entity identifiers and references to other entities without metadata";
   csvt:approval csvt:Proposed;
@@ -69,10 +69,10 @@
     csvt:noProv true;
   ];
   mf:action <test005.csv>;
-  mf:result <test005.rdf>;
+  mf:result <test005.ttl>;
   .
 
-:test006 a csvt:CSVtoRdfTest;
+:test006 a csvt:CsvToRdfTest;
   mf:name "No identifiers";
   rdfs:comment "Records contain two entities with relationships which are duplicated without metadata";
   csvt:approval csvt:Proposed;
@@ -80,10 +80,10 @@
     csvt:noProv true;
   ];
   mf:action <test006.csv>;
-  mf:result <test006.rdf>;
+  mf:result <test006.ttl>;
   .
 
-:test007 a csvt:CSVtoRdfTest;
+:test007 a csvt:CsvToRdfTest;
   mf:name "Joined table with unique identifiers";
   rdfs:comment "Joined data with identified records without metadata";
   csvt:approval csvt:Proposed;
@@ -91,10 +91,10 @@
     csvt:noProv true;
   ];
   mf:action <test007.csv>;
-  mf:result <test007.rdf>;
+  mf:result <test007.ttl>;
   .
 
-:test008 a csvt:CSVtoRdfTest;
+:test008 a csvt:CsvToRdfTest;
   mf:name "Microsyntax - internal field separator";
   rdfs:comment "One field has comma-separated values without metadata";
   csvt:approval csvt:Proposed;
@@ -102,10 +102,10 @@
     csvt:noProv true;
   ];
   mf:action <test008.csv>;
-  mf:result <test008.rdf>;
+  mf:result <test008.ttl>;
   .
 
-:test009 a csvt:CSVtoRdfTest;
+:test009 a csvt:CsvToRdfTest;
   mf:name "Microsyntax - formatted time";
   rdfs:comment "Field with parseable human formatted time without metadata";
   csvt:approval csvt:Proposed;
@@ -113,10 +113,10 @@
     csvt:noProv true;
   ];
   mf:action <test009.csv>;
-  mf:result <test009.rdf>;
+  mf:result <test009.ttl>;
   .
 
-:test010 a csvt:CSVtoRdfTest;
+:test010 a csvt:CsvToRdfTest;
   mf:name "Country-codes-and-names example";
   rdfs:comment "Country-codes-and-names example";
   csvt:approval csvt:Proposed;
@@ -124,10 +124,10 @@
     csvt:noProv true;
   ];
   mf:action <test010.csv>;
-  mf:result <test010.rdf>;
+  mf:result <test010.ttl>;
   .
 
-:test011 a csvt:CSVtoRdfTest;
+:test011 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with metadata";
   rdfs:comment "tree-ops example with metadata. Processors should load metadata based on action URL.";
   csvt:approval csvt:Proposed;
@@ -135,11 +135,11 @@
     csvt:noProv true;
   ];
   mf:action <test011.csv>;
-  mf:result <test011.rdf>;
+  mf:result <test011.ttl>;
   csvt:implicit <test011.csv-metadata.json>;
   .
 
-:test012 a csvt:CSVtoRdfTest;
+:test012 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with directory metadata";
   rdfs:comment "tree-ops example with directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -147,11 +147,11 @@
     csvt:noProv true;
   ];
   mf:action <test012/action.csv>;
-  mf:result <test012/result.rdf>;
+  mf:result <test012/result.ttl>;
   csvt:implicit <test012/metadata.json>;
   .
 
-:test013 a csvt:CSVtoRdfTest;
+:test013 a csvt:CsvToRdfTest;
   mf:name "tree-ops example from directory metadata";
   rdfs:comment "tree-ops example from directory metadata. Processors should find CSV from metadata action file.";
   csvt:approval csvt:Proposed;
@@ -160,11 +160,11 @@
     csvt:metadata <test013-user-metadata.json>;
   ];
   mf:action <test013.csv>;
-  mf:result <test013.rdf>;
+  mf:result <test013.ttl>;
   csvt:implicit <test013-user-metadata.json>;
   .
 
-:test014 a csvt:CSVtoRdfTest;
+:test014 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with linked metadata";
   rdfs:comment "tree-ops example with linked metadata. Processors load metadata from link header.";
   csvt:approval csvt:Proposed;
@@ -173,11 +173,11 @@
   ];
   csvt:httpLink "<test014-linked-metadata.json>; rel=\"describedby\"";
   mf:action <test014.csv>;
-  mf:result <test014.rdf>;
+  mf:result <test014.ttl>;
   csvt:implicit <test014-linked-metadata.json>;
   .
 
-:test015 a csvt:CSVtoRdfTest;
+:test015 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with user and directory metadata";
   rdfs:comment "tree-ops example with user and directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -186,12 +186,12 @@
     csvt:metadata <test015/user-metadata.json>;
   ];
   mf:action <test015/action.csv>;
-  mf:result <test015/result.rdf>;
+  mf:result <test015/result.ttl>;
   csvt:implicit <test015/user-metadata.json>,
     <test015/metadata.json>;
   .
 
-:test016 a csvt:CSVtoRdfTest;
+:test016 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with linked and directory metadata";
   rdfs:comment "tree-ops example with linked and directory metadata. Processors should find link- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -200,12 +200,12 @@
   ];
   csvt:httpLink "<linked-metadata.json>; rel=\"describedby\"";
   mf:action <test016/action.csv>;
-  mf:result <test016/result.rdf>;
+  mf:result <test016/result.ttl>;
   csvt:implicit <test016/linked-metadata.json>,
     <test016/metadata.json>;
   .
 
-:test017 a csvt:CSVtoRdfTest;
+:test017 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with file and directory metadata";
   rdfs:comment "tree-ops example with file and directory metadata. Processors should find file- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -213,12 +213,12 @@
     csvt:noProv true;
   ];
   mf:action <test017/action.csv>;
-  mf:result <test017/result.rdf>;
+  mf:result <test017/result.ttl>;
   csvt:implicit <test017/action.csv-metadata.json>,
     <test017/metadata.json>;
   .
 
-:test018 a csvt:CSVtoRdfTest;
+:test018 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with user, file and directory metadata";
   rdfs:comment "tree-ops example with user, file and directory metadata. Processors should find user-, file- and directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -227,13 +227,13 @@
     csvt:metadata <test018/user-metadata.json>;
   ];
   mf:action <test018/action.csv>;
-  mf:result <test018/result.rdf>;
+  mf:result <test018/result.ttl>;
   csvt:implicit <test018/user-metadata.json>,
     <test018/action.csv-metadata.json>,
     <test018/metadata.json>;
   .
 
-:test019 a csvt:CSVtoRdfTest;
+:test019 a csvt:CsvToRdfTest;
   mf:name "no header";
   rdfs:comment "If a CSV+ file does not include a header line, this MUST be specified using the header parameter.";
   csvt:approval csvt:Proposed;
@@ -241,11 +241,11 @@
     csvt:noProv true;
   ];
   mf:action <test019.csv>;
-  mf:result <test019.rdf>;
+  mf:result <test019.ttl>;
   csvt:contentType "text/csv;header=absent";
   .
 
-:test020 a csvt:CSVtoRdfTest;
+:test020 a csvt:CsvToRdfTest;
   mf:name "trim=start";
   rdfs:comment "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -253,11 +253,11 @@
     csvt:noProv true;
   ];
   mf:action <test020.csv>;
-  mf:result <test020.rdf>;
+  mf:result <test020.ttl>;
   csvt:implicit <test020.csv-metadata.json>;
   .
 
-:test021 a csvt:CSVtoRdfTest;
+:test021 a csvt:CsvToRdfTest;
   mf:name "trim=end";
   rdfs:comment "If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -265,11 +265,11 @@
     csvt:noProv true;
   ];
   mf:action <test021.csv>;
-  mf:result <test021.rdf>;
+  mf:result <test021.ttl>;
   csvt:implicit <test021.csv-metadata.json>;
   .
 
-:test022 a csvt:CSVtoRdfTest;
+:test022 a csvt:CsvToRdfTest;
   mf:name "trim=true";
   rdfs:comment "If trim is true or start then whitespace from the start of values that are not enclosed MUST be removed from the value. If trim is true or end then whitespace from the end of values that are not enclosed MUST be removed from the value.";
   csvt:approval csvt:Proposed;
@@ -277,11 +277,11 @@
     csvt:noProv true;
   ];
   mf:action <test022.csv>;
-  mf:result <test022.rdf>;
+  mf:result <test022.ttl>;
   csvt:implicit <test022.csv-metadata.json>;
   .
 
-:test023 a csvt:CSVtoRdfTest;
+:test023 a csvt:CsvToRdfTest;
   mf:name "dialect: header=false";
   rdfs:comment "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.";
   csvt:approval csvt:Proposed;
@@ -290,11 +290,11 @@
     csvt:metadata <test023-user-metadata.json>;
   ];
   mf:action <test023.csv>;
-  mf:result <test023.rdf>;
+  mf:result <test023.ttl>;
   csvt:implicit <test023-user-metadata.json>;
   .
 
-:test024 a csvt:CSVtoRdfTest;
+:test024 a csvt:CsvToRdfTest;
   mf:name "dialect: header=false and headerRowCount=1";
   rdfs:comment "A single boolean atomic property that, if true, sets the header row count flag to 1, and if false to 0, unless headerRowCount is provided, in which case the value provided for the header property is ignored.";
   csvt:approval csvt:Proposed;
@@ -303,11 +303,11 @@
     csvt:metadata <test024-user-metadata.json>;
   ];
   mf:action <test024.csv>;
-  mf:result <test024.rdf>;
+  mf:result <test024.ttl>;
   csvt:implicit <test024-user-metadata.json>;
   .
 
-:test025 a csvt:CSVtoRdfTest;
+:test025 a csvt:CsvToRdfTest;
   mf:name "dialect: header=false and skipRows=1";
   rdfs:comment "Ignore header uses column definitions from metadata";
   csvt:approval csvt:Proposed;
@@ -316,11 +316,11 @@
     csvt:metadata <test025-user-metadata.json>;
   ];
   mf:action <test025.csv>;
-  mf:result <test025.rdf>;
+  mf:result <test025.ttl>;
   csvt:implicit <test025-user-metadata.json>;
   .
 
-:test026 a csvt:CSVtoRdfTest;
+:test026 a csvt:CsvToRdfTest;
   mf:name "tree-ops example with directory metadata";
   rdfs:comment "tree-ops example with directory metadata. Processors should find directory-based metadata.";
   csvt:approval csvt:Proposed;
@@ -328,7 +328,7 @@
     csvt:noProv true;
   ];
   mf:action <test026/metadata.json>;
-  mf:result <test026/result.rdf>;
+  mf:result <test026/result.ttl>;
   csvt:implicit <test026/action.csv>,
     <test026/metadata.json>;
   .

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -18,7 +18,7 @@
   },
   "id": "",
   "type": "mf:Manifest",
-  "label": "CSV+ tests",
+  "label": "CSVW Test Cases",
   "comment": "Includes manifests for different application profiles",
   "include": ["manifest-json.jsonld", "manifest-rdf.jsonld"]
 }

--- a/tests/manifest.jsonld
+++ b/tests/manifest.jsonld
@@ -8,11 +8,7 @@
     "id": "@id",
     "type": "@type",
     "comment": "rdfs:comment",
-    "include": {
-      "@id": "mf:include",
-      "@type": "@id",
-      "@container": "@list"
-    },
+    "include": {"@id": "mf:include", "@type": "@id", "@container": "@list"},
     "label": "rdfs:label",
     "name": "mf:name"
   },
@@ -20,5 +16,5 @@
   "type": "mf:Manifest",
   "label": "CSVW Test Cases",
   "comment": "Includes manifests for different application profiles",
-  "include": ["manifest-json.jsonld", "manifest-rdf.jsonld"]
+  "include": ["manifest-json", "manifest-rdf"]
 }

--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -21,4 +21,4 @@
 <>  a mf:Manifest ;
     rdfs:label "CSVW Test Cases" ;
     rdfs:comment "Includes manifests for different application profiles"
-    mf:include (<manifest-json.ttl> <manifest-rdf.ttl>).
+    mf:include (<manifest-json> <manifest-rdf>).

--- a/tests/manifest.ttl
+++ b/tests/manifest.ttl
@@ -19,6 +19,6 @@
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
 <>  a mf:Manifest ;
-    rdfs:label "CSV+ tests" ;
+    rdfs:label "CSVW Test Cases" ;
     rdfs:comment "Includes manifests for different application profiles"
     mf:include (<manifest-json.ttl> <manifest-rdf.ttl>).

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -4,7 +4,7 @@
 require 'getoptlong'
 require 'csv'
 require 'json'
-require 'erubis'
+require 'haml'
 
 class Manifest
   JSON_STATE = JSON::State.new(
@@ -18,10 +18,12 @@ class Manifest
   TITLE = {
     json: "CSVW JSON tests",
     rdf: "CSVW RDF tests",
+    validation: "CSVW validation tests"
   }
   DESCRIPTION = {
     json: "Tests transformation of CSV to JSON",
     rdf: "Tests transformation of CSV to RDF",
+    validation: "Tests CSV validation using metadata"
   }
   attr_accessor :prefixes, :terms, :properties, :classes, :instances, :datatypes
 
@@ -139,6 +141,10 @@ class Manifest
   end
 
   def to_html(variant)
+    Haml::Engine.new(template, :format => :html5).render(self,
+      man: "",
+      manifests: ""
+    )
     json = JSON.parse(to_jsonld(variant))
     eruby = Erubis::Eruby.new(File.read("template.html"))
     eruby.result(ont: json['@graph'], context: json['@context'])

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -25,6 +25,10 @@ class Manifest
     rdf: "Tests transformation of CSV to RDF.",
     validation: "Tests CSV validation using metadata."
   }
+  EXTENTIONS = {
+    json: 'json',
+    rdf: 'ttl'
+  }
   attr_accessor :prefixes, :terms, :properties, :classes, :instances, :datatypes
 
   Test = Struct.new(:id, :type, :name, :comment, :approval, :option, :action, :result, :user_metadata, :link_metadata, :file_metadata, :directory_metadata)
@@ -100,7 +104,7 @@ class Manifest
 
     manifest = {
       "@context" => context,
-      "id" => "metadata-#{variant}",
+      "id" => "manifest-#{variant}",
       "type" => "mf:Manifest",
       "label" => TITLE[variant],
       "comment" => DESCRIPTION[variant],
@@ -108,22 +112,22 @@ class Manifest
     }
 
     test_type = case variant
-    when :rdf then "csvt:CSVtoRdfTest"
-    when :json then "csvt:CSVtoJsonTest"
+    when :rdf then "csvt:CsvToRdfTest"
+    when :json then "csvt:CsvToJsonTest"
     end
 
     tests.each do |test|
       next unless test.option[variant.to_sym]
 
       entry = {
-        "id" => "metadata-#{variant}##{test.id}",
+        "id" => "manifest-#{variant}##{test.id}",
         "type" => test_type,
         "name" => test.name,
         "comment" => test.comment,
         "approval" => (test.approval ? "csvt:#{test.approval}" : "csvt:Proposed"),
         "option" => {"noProv" => true},
         "action" => test.action,
-        "result" => "#{test.result}#{variant}",
+        "result" => "#{test.result}#{EXTENTIONS[variant]}",
         "implicit" => []
       }
 
@@ -174,13 +178,13 @@ class Manifest
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <metadata-#{variant}#> .
+@prefix : <manifest-#{variant}#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<metadata-#{variant}>  a mf:Manifest ;
+<manifest-#{variant}>  a mf:Manifest ;
 )
     output << %(  rdfs:label "#{TITLE[variant]}";)
     output << %(  rdfs:comment "#{DESCRIPTION[variant]}";)
@@ -192,8 +196,8 @@ class Manifest
     output << %(  \) .)
 
     test_type = case variant
-    when :rdf then "csvt:CSVtoRdfTest"
-    when :json then "csvt:CSVtoJsonTest"
+    when :rdf then "csvt:CsvToRdfTest"
+    when :json then "csvt:CsvToJsonTest"
     end
 
     tests.select {|t| t.option[variant]}.each do |test|
@@ -207,7 +211,7 @@ class Manifest
       output << %(  ];)
       output << %(  csvt:httpLink "<#{test.link_metadata.split('/').last}>; rel=\\"describedby\\"";) if test.link_metadata
       output << %(  mf:action <#{test.action}>;)
-      output << %(  mf:result <#{test.result}#{variant}>;)
+      output << %(  mf:result <#{test.result}#{EXTENTIONS[variant]}>;)
       output << %(  csvt:contentType "#{test.option[:contentType]}";) if test.option[:contentType]
 
       implicit = [test.option[:implicit], test.user_metadata, test.link_metadata, test.file_metadata, test.directory_metadata].

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -85,18 +85,22 @@ class Manifest
       "action": {"@id": "mf:action",  "@type": "@id"},
       "approval": {"@id": "csvt:approval", "@type": "@id"},
       "comment": "rdfs:comment",
+      "contentType": "csvt:contentType",
       "entries": {"@id": "mf:entries", "@type": "@id", "@container": "@list"},
-      "label": "rdfs:label",
       "httpLink": "csvt:httpLink",
+      "implicit": {"@id": "mf:implicit", "@type": "@id", "@container": "@set"},
+      "label": "rdfs:label",
+      "metadata": {"@id": "csvt:metadata", "@type": "@id"},
+      "minimal": "csvt:minimal",
       "name": "mf:name",
+      "noProv": "csvt:noProv",
       "option": "csvt:option",
-      "result": {"@id": "mf:result", "@type": "@id"},
-      "user_metadata": {"@id": "csvt:metadata", "@type": "@id"}
+      "result": {"@id": "mf:result", "@type": "@id"}
     })
 
     manifest = {
       "@context" => context,
-      "id" => "",
+      "id" => "metadata-#{variant}",
       "type" => "mf:Manifest",
       "label" => TITLE[variant],
       "comment" => DESCRIPTION[variant],
@@ -112,19 +116,19 @@ class Manifest
       next unless test.option[variant.to_sym]
 
       entry = {
-        "id" => "##{test.id}",
+        "id" => "metadata-#{variant}##{test.id}",
         "type" => test_type,
         "name" => test.name,
         "comment" => test.comment,
         "approval" => (test.approval ? "csvt:#{test.approval}" : "csvt:Proposed"),
-        "option" => {"csvt:noProv" => true},
+        "option" => {"noProv" => true},
         "action" => test.action,
         "result" => "#{test.result}#{variant}",
         "implicit" => []
       }
 
       entry["implicit"] << test.option[:implicit] if test.option[:implicit]
-      entry["implicit"] << (entry["option"]["user_metadata"] = test.user_metadata) if test.user_metadata
+      entry["implicit"] << (entry["option"]["metadata"] = test.user_metadata) if test.user_metadata
       if test.link_metadata
         entry["implicit"] << test.link_metadata
         entry["httpLink"] = %(<#{test.link_metadata.split('/').last}>; rel="describedby")
@@ -133,7 +137,7 @@ class Manifest
       entry["implicit"] << test.directory_metadata if test.directory_metadata
       entry.delete("implicit") if entry["implicit"].empty?
 
-      entry["csvt:contentType"] = test.option[:contentType] if test.option[:contentType]
+      entry["contentType"] = test.option[:contentType] if test.option[:contentType]
       manifest["entries"] << entry
     end
 
@@ -170,13 +174,13 @@ class Manifest
 ## * CsvToRdfTest   - tests CSV evaluation to RDF using graph isomorphism
 ## * CsvSparqlTest - tests CSV evaulation to RDF using SPARQL ASK query
 
-@prefix : <#> .
+@prefix : <metadata-#{variant}#> .
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
 @prefix csvt: <http://w3c.github.io/csvw/tests/vocab#> .
 
-<>  a mf:Manifest ;
+<metadata-#{variant}>  a mf:Manifest ;
 )
     output << %(  rdfs:label "#{TITLE[variant]}";)
     output << %(  rdfs:comment "#{DESCRIPTION[variant]}";)
@@ -270,7 +274,7 @@ else
       end
     end
   end
-  File.open("manifest.html", "w") do |output|
+  File.open("index.html", "w") do |output|
     output.puts(vocab.to_html)
   end
 end

--- a/tests/mk_vocab.rb
+++ b/tests/mk_vocab.rb
@@ -6,10 +6,11 @@
 #    jsonld --compact --context vocab_context.jsonld --input-format ttl vocab.ttl  -o vocab.jsonld
 require 'linkeddata'
 require 'haml'
+require 'active_support'
 
 File.open("vocab.jsonld", "w") do |f|
   r = RDF::Repository.load("vocab.ttl")
-  JSON::LD::API.fromRDF(r, :useNativeTypes => true) do |expanded|
+  JSON::LD::API.fromRDF(r, useNativeTypes: true) do |expanded|
     # Remove leading/trailing and multiple whitespace from rdf:comments
     expanded.each do |o|
       c = o[RDF::RDFS.comment.to_s].first['@value']
@@ -23,9 +24,9 @@ File.open("vocab.jsonld", "w") do |f|
       template = File.read("vocab_template.haml")
       
       html = Haml::Engine.new(template, :format => :html5).render(self,
-        :ontology => compacted['@graph'].detect {|o| o['@id'] == "http://w3c.github.io/csvw/tests/vocab#"},
-        :classes => compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
-        :properties => compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']}
+        ontology:   compacted['@graph'].detect {|o| o['@id'] == "http://w3c.github.io/csvw/tests/vocab#"},
+        classes:    compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
+        properties: compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']}
       )
       File.open("vocab.html", "w") {|fh| fh.write html}
     end

--- a/tests/mk_vocab.rb
+++ b/tests/mk_vocab.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+# Generate vocab.jsonld and vocab.html from vocab.ttl and vocab_template.
+#
+# Generating vocab.jsonld is equivalent to running the following:
+#
+#    jsonld --compact --context vocab_context.jsonld --input-format ttl vocab.ttl  -o vocab.jsonld
+require 'linkeddata'
+require 'haml'
+
+File.open("vocab.jsonld", "w") do |f|
+  r = RDF::Repository.load("vocab.ttl")
+  JSON::LD::API.fromRDF(r, :useNativeTypes => true) do |expanded|
+    # Remove leading/trailing and multiple whitespace from rdf:comments
+    expanded.each do |o|
+      c = o[RDF::RDFS.comment.to_s].first['@value']
+      o[RDF::RDFS.comment.to_s].first['@value'] = c.strip.gsub(/\s+/m, ' ')
+    end
+    JSON::LD::API.compact(expanded, File.open("vocab_context.jsonld")) do |compacted|
+      # Create vocab.jsonld
+      f.write(compacted.to_json(JSON::LD::JSON_STATE))
+
+      # Create vocab.html using vocab_template.haml and compacted vocabulary
+      template = File.read("vocab_template.haml")
+      
+      html = Haml::Engine.new(template, :format => :html5).render(self,
+        :ontology => compacted['@graph'].detect {|o| o['@id'] == "http://w3c.github.io/csvw/tests/vocab#"},
+        :classes => compacted['@graph'].select {|o| o['@type'] == "rdfs:Class"}.sort_by {|o| o['rdfs:label']},
+        :properties => compacted['@graph'].select {|o| o['@type'] == "rdf:Property"}.sort_by {|o| o['rdfs:label']}
+      )
+      File.open("vocab.html", "w") {|fh| fh.write html}
+    end
+  end
+end

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -56,9 +56,9 @@
         %dl.test-description
           - man['entries'].each do |test|
             %dt
-              = "#{id}#{test['id']}:"
+              = "#{test['id']}:"
               %span{about: test['id'], property: "mf:name"}<~test['name']
-            %dd{property: "mf:entry", inlist: true, resource: id + test['id'], typeof: test['type']}
+            %dd{property: "mf:entry", inlist: true, resource: test['id'], typeof: test['type']}
               %p{property: "rdfs:comment"}<~test['comment']
               %dl.test-detail
                 %dt="approval"
@@ -94,15 +94,15 @@
                 - if test['option']
                   %dt="options"
                   %dd{property: "csvt:option", typeof: ""}
-                    - if test['option']['csvt:noProv']
+                    - if test['option']['noProv']
                       noProv:
-                      %span{property: "csvt:noProv", datatype: "xsd:boolean"}="true"
-                    - if test['option']['csvt:minimal']
+                      %span{property: "noProv", datatype: "xsd:boolean"}="true"
+                    - if test['option']['minimal']
                       minimal:
                       %span{property: "csvt:minimal", datatype: "xsd:boolean"}="true"
-                    - if test['option']['user_metadata']
+                    - if test['option']['metadata']
                       user metadata:
-                      %span{property: "csvt:metadata", resource: test['option']['user_metadata']}<~test['option']['user_metadata']
+                      %a{property: "csvt:metadata", href: test['option']['metadata']}<~test['option']['metadata']
     %footer
       %span{property: "dc:publisher"}
         W3C CSV on the Web Working Group

--- a/tests/template.haml
+++ b/tests/template.haml
@@ -1,0 +1,108 @@
+!!! 5
+%html{lang: :en, prefix: "csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
+  %head
+    %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
+    %link{rel: "stylesheet", type: "text/css", href: "http://www.w3.org/StyleSheets/TR/W3C-ED"}
+    :css
+      body: {bacground-image: none;}
+      dl.test-detail, dl.test-options {
+        padding: 0.5em;
+      }
+      dl.test-detail>dt, dl.test-options>dt {
+        float: left;
+        clear: left;
+        text-align: right;
+        font-weight: bold;
+        color: green;
+      }
+      dl.test-detail>dt:after, dl.test-options>dt:after {content: ": "}
+      dl.test-detail>dd, dl.test-options>dd {
+        margin: 0 0 0 110px;
+        padding: 0 0 0.5em 0;
+      }
+      dl.test-description>dt {margin-top: 2em;}
+      dd {margin-left: 0;}
+      dd code {display: inline;}
+      footer {text-align: center;}
+    %title
+      = man['label']
+  %body{resource: man['id'], typeof: man['type']}
+    %p
+      %a{href: "http://www.w3.org/"}
+        %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
+    %h1{property: "rdfs:label"}<= man['label']
+    %p{property: "rdfs:comment"}<= man['comment']
+    :markdown
+      See the [CSVT Vocabulary](vocab.html) for the meaning of properties and options.
+
+    %section.contents
+      %h2="Contents"
+      %ol
+        - manifests.each do |id, man|
+          %li
+            %a{href: "##{id}"}<=man['label']
+    - manifests.each do |id, man|
+      %section{id: id, property: "mf:entry", inlist: true, resource: id, typeof: man['type']}
+        %h2<=man['label']
+        %p{property: "rdfs:comment"}<= man['comment']
+        %p
+          - if id =~/json/
+            Instructions specific to running JSON tests.
+          - elsif id =~ /rdf/
+            Instructions specific to running RDF tests.
+          - elsif id =~ /validation/
+            Instructions specific to running Validataion tests.
+        %dl.test-description
+          - man['entries'].each do |test|
+            %dt
+              = "#{id}#{test['id']}:"
+              %span{about: test['id'], property: "mf:name"}<~test['name']
+            %dd{property: "mf:entry", inlist: true, resource: id + test['id'], typeof: test['type']}
+              %p{property: "rdfs:comment"}<~test['comment']
+              %dl.test-detail
+                %dt="approval"
+                %dd{property: "mf:approval", resource: test['approval']}<~test['approval']
+                - if test['action']
+                  %dt="action"
+                  %dd
+                    %a{property: "mf:action", href: test['action']}<~test['action']
+                - if test['result']
+                  %dt="result"
+                  %dd
+                    %a{property: "mf:result", href: test['result']}<~test['result']
+                - if test['httpLink']
+                  %dt="Link Header"
+                  %dd{property: "csvt:httpLink", content: test['httpLink']}
+                    %code
+                      &= test['httpLink']
+                - if test['httpStatus']
+                  %dt="Status Code"
+                  %dd{property: "csvt:httpStatus", content: test['httpStatus'], datatype: "xsd:integer"}
+                    %code
+                      &= test['httpStatus']
+                - if test['contentType']
+                  %dt="Content Type"
+                  %dd{property: "csvt:contentType", content: test['contentType']}
+                    %code
+                      &= test['contentType']
+                - if test['implicit']
+                  %dt="Implicit"
+                  %dd{rel: "csvt:implicit"}
+                    - test['implicit'].each do |u|
+                      %a{href: u}<~u
+                - if test['option']
+                  %dt="options"
+                  %dd{property: "csvt:option", typeof: ""}
+                    - if test['option']['csvt:noProv']
+                      noProv:
+                      %span{property: "csvt:noProv", datatype: "xsd:boolean"}="true"
+                    - if test['option']['csvt:minimal']
+                      minimal:
+                      %span{property: "csvt:minimal", datatype: "xsd:boolean"}="true"
+                    - if test['option']['user_metadata']
+                      user metadata:
+                      %span{property: "csvt:metadata", resource: test['option']['user_metadata']}<~test['option']['user_metadata']
+    %footer
+      %span{property: "dc:publisher"}
+        W3C CSV on the Web Working Group

--- a/tests/test001.json
+++ b/tests/test001.json
@@ -1,45 +1,89 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test001.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "Surname": "Homer",
-      "FamilyName": "Simpson"
-    },
-    {
-      "rownum": 2,
-      "Surname": "Marge",
-      "FamilyName": "Simpson"
-    },
-    {
-      "rownum": 3,
-      "Surname": "Bart",
-      "FamilyName": "Simpson"
-    },
-    {
-      "rownum": 4,
-      "Surname": "Lisa",
-      "FamilyName": "Simpson"
-    },
-    {
-      "rownum": 5,
-      "Surname": "Maggie",
-      "FamilyName": "Simpson"
-    },
-    {
-      "rownum": 6,
-      "Surname": "Ned",
-      "FamilyName": "Flanders"
-    },
-    {
-      "rownum": 7,
-      "Surname": "Krusty",
-      "FamilyName": "the Clown"
-    },
-    {
-      "rownum": 8,
-      "Surname": "Waylon",
-      "FamilyName": "Smithers"
+      "url": "http://w3c.github.io/csvw/tests/test001.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "Surname": "Homer",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "Surname": "Marge",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "Surname": "Bart",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "Surname": "Lisa",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "Surname": "Maggie",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "Surname": "Ned",
+              "FamilyName": "Flanders"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=8",
+          "rownum": 7,
+          "describes": [
+            {
+              "Surname": "Krusty",
+              "FamilyName": "the Clown"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test001.csv#row=9",
+          "rownum": 8,
+          "describes": [
+            {
+              "Surname": "Waylon",
+              "FamilyName": "Smithers"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test001.ttl
+++ b/tests/test001.ttl
@@ -1,43 +1,69 @@
 @prefix : <test001.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Bart";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Lisa";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Maggie";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Flanders";
-      :Surname "Ned";
-      csvw:rownum 6
-    ],  [
-      :FamilyName "the Clown";
-      :Surname "Krusty";
-      csvw:rownum 7
-    ],  [
-      :FamilyName "Smithers";
-      :Surname "Waylon";
-      csvw:rownum 8
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer"
+        ];
+        csvw:rownum 1;
+        csvw:url <test001.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge"
+        ];
+        csvw:rownum 2;
+        csvw:url <test001.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Bart"
+        ];
+        csvw:rownum 3;
+        csvw:url <test001.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Lisa"
+        ];
+        csvw:rownum 4;
+        csvw:url <test001.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Maggie"
+        ];
+        csvw:rownum 5;
+        csvw:url <test001.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName "Flanders";
+          :Surname "Ned"
+        ];
+        csvw:rownum 6;
+        csvw:url <test001.csv#row=7>
+      ],  [
+        csvw:describes [
+          :FamilyName "the Clown";
+          :Surname "Krusty"
+        ];
+        csvw:rownum 7;
+        csvw:url <test001.csv#row=8>
+      ],  [
+        csvw:describes [
+          :FamilyName "Smithers";
+          :Surname "Waylon"
+        ];
+        csvw:rownum 8;
+        csvw:url <test001.csv#row=9>
+      ];
+      csvw:url <test001.csv>
     ]
  ] .

--- a/tests/test002.json
+++ b/tests/test002.json
@@ -1,13 +1,89 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test002.csv",
-  "row": [
-    {"rownum": 1, "Surname": "Homer", "FamilyName": "Simpson"},
-    {"rownum": 2, "Surname": "Marge", "FamilyName": "Simpson"},
-    {"rownum": 3, "Surname": "Bart", "FamilyName": "Simpson"},
-    {"rownum": 4, "Surname": "Lisa", "FamilyName": "Simpson"},
-    {"rownum": 5, "Surname": "Maggie", "FamilyName": "Simpson"},
-    {"rownum": 6, "Surname": "Ned", "FamilyName": "Flanders"},
-    {"rownum": 7, "Surname": "Krusty", "FamilyName": "the Clown"},
-    {"rownum": 8, "Surname": "Waylon", "FamilyName": "Smithers"}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test002.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "Surname": "Homer",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "Surname": "Marge",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "Surname": "Bart",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "Surname": "Lisa",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "Surname": "Maggie",
+              "FamilyName": "Simpson"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "Surname": "Ned",
+              "FamilyName": "Flanders"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=8",
+          "rownum": 7,
+          "describes": [
+            {
+              "Surname": "Krusty",
+              "FamilyName": "the Clown"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test002.csv#row=9",
+          "rownum": 8,
+          "describes": [
+            {
+              "Surname": "Waylon",
+              "FamilyName": "Smithers"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test002.ttl
+++ b/tests/test002.ttl
@@ -1,43 +1,69 @@
 @prefix : <test002.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Bart";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Lisa";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Maggie";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Flanders";
-      :Surname "Ned";
-      csvw:rownum 6
-    ],  [
-      :FamilyName "the Clown";
-      :Surname "Krusty";
-      csvw:rownum 7
-    ],  [
-      :FamilyName "Smithers";
-      :Surname "Waylon";
-      csvw:rownum 8
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer"
+        ];
+        csvw:rownum 1;
+        csvw:url <test002.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge"
+        ];
+        csvw:rownum 2;
+        csvw:url <test002.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Bart"
+        ];
+        csvw:rownum 3;
+        csvw:url <test002.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Lisa"
+        ];
+        csvw:rownum 4;
+        csvw:url <test002.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Maggie"
+        ];
+        csvw:rownum 5;
+        csvw:url <test002.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName "Flanders";
+          :Surname "Ned"
+        ];
+        csvw:rownum 6;
+        csvw:url <test002.csv#row=7>
+      ],  [
+        csvw:describes [
+          :FamilyName "the Clown";
+          :Surname "Krusty"
+        ];
+        csvw:rownum 7;
+        csvw:url <test002.csv#row=8>
+      ],  [
+        csvw:describes [
+          :FamilyName "Smithers";
+          :Surname "Waylon"
+        ];
+        csvw:rownum 8;
+        csvw:url <test002.csv#row=9>
+      ];
+      csvw:url <test002.csv>
     ]
  ] .

--- a/tests/test003.json
+++ b/tests/test003.json
@@ -1,13 +1,89 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test003.csv",
-  "row": [
-    {"rownum": 1, "Surname": "Homer", "FamilyName": "Simpson"},
-    {"rownum": 2, "Surname": "Marge", "FamilyName": "Simpson"},
-    {"rownum": 3, "Surname": "Bart", "FamilyName": "Simpson"},
-    {"rownum": 4, "Surname": "Lisa", "FamilyName": "Simpson"},
-    {"rownum": 5, "Surname": "Maggie", "FamilyName": "Simpson"},
-    {"rownum": 6, "Surname": "Ned", "FamilyName": "Flanders"},
-    {"rownum": 7, "Surname": "Krusty", "FamilyName": "the Clown"},
-    {"rownum": 8, "Surname": "Waylon", "FamilyName": "Smithers"}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test003.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "Surname": " Homer ",
+              "FamilyName": " Simpson "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "Surname": " Marge ",
+              "FamilyName": " Simpson "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "Surname": " Bart ",
+              "FamilyName": " Simpson "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "Surname": " Lisa ",
+              "FamilyName": " Simpson "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "Surname": " Maggie ",
+              "FamilyName": " Simpson "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "Surname": " Ned ",
+              "FamilyName": " Flanders "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=8",
+          "rownum": 7,
+          "describes": [
+            {
+              "Surname": " Krusty ",
+              "FamilyName": " the Clown "
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test003.csv#row=9",
+          "rownum": 8,
+          "describes": [
+            {
+              "Surname": " Waylon ",
+              "FamilyName": " Smithers "
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test003.ttl
+++ b/tests/test003.ttl
@@ -1,43 +1,69 @@
 @prefix : <test003.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Bart";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Lisa";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Maggie";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Flanders";
-      :Surname "Ned";
-      csvw:rownum 6
-    ],  [
-      :FamilyName "the Clown";
-      :Surname "Krusty";
-      csvw:rownum 7
-    ],  [
-      :FamilyName "Smithers";
-      :Surname "Waylon";
-      csvw:rownum 8
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName " Simpson ";
+          :Surname " Homer "
+        ];
+        csvw:rownum 1;
+        csvw:url <test003.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName " Simpson ";
+          :Surname " Marge "
+        ];
+        csvw:rownum 2;
+        csvw:url <test003.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName " Simpson ";
+          :Surname " Bart "
+        ];
+        csvw:rownum 3;
+        csvw:url <test003.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName " Simpson ";
+          :Surname " Lisa "
+        ];
+        csvw:rownum 4;
+        csvw:url <test003.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName " Simpson ";
+          :Surname " Maggie "
+        ];
+        csvw:rownum 5;
+        csvw:url <test003.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName " Flanders ";
+          :Surname " Ned "
+        ];
+        csvw:rownum 6;
+        csvw:url <test003.csv#row=7>
+      ],  [
+        csvw:describes [
+          :FamilyName " the Clown ";
+          :Surname " Krusty "
+        ];
+        csvw:rownum 7;
+        csvw:url <test003.csv#row=8>
+      ],  [
+        csvw:describes [
+          :FamilyName " Smithers ";
+          :Surname " Waylon "
+        ];
+        csvw:rownum 8;
+        csvw:url <test003.csv#row=9>
+      ];
+      csvw:url <test003.csv>
     ]
  ] .

--- a/tests/test005.json
+++ b/tests/test005.json
@@ -1,17 +1,153 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test005.csv",
-  "row": [
-    {"rownum": 1, "id": "1", "Surname": "Homer", "FamilyName": "Simpson", "child_id": "3"},
-    {"rownum": 2, "id": "1", "Surname": "Homer", "FamilyName": "Simpson", "child_id": "4"},
-    {"rownum": 3, "id": "1", "Surname": "Homer", "FamilyName": "Simpson", "child_id": "5"},
-    {"rownum": 4, "id": "2", "Surname": "Marge", "FamilyName": "Simpson", "child_id": "3"},
-    {"rownum": 5, "id": "2", "Surname": "Marge", "FamilyName": "Simpson", "child_id": "4"},
-    {"rownum": 6, "id": "2", "Surname": "Marge", "FamilyName": "Simpson", "child_id": "5"},
-    {"rownum": 7, "id": "3", "Surname": "Bart", "FamilyName": "Simpson", "child_id": null},
-    {"rownum": 8, "id": "4", "Surname": "Lisa", "FamilyName": "Simpson", "child_id": null},
-    {"rownum": 9, "id": "5", "Surname": "Maggie", "FamilyName": "Simpson", "child_id": null},
-    {"rownum": 10, "id": "6", "Surname": "Ned", "FamilyName": "Flanders", "child_id": null},
-    {"rownum": 11, "id": "7", "Surname": "Krusty", "FamilyName": "the Clown", "child_id": null},
-    {"rownum": 12, "id": "8", "Surname": "Waylon", "FamilyName": "Smithers", "child_id": null}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test005.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "id": "1",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "child_id": "3"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "id": "1",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "child_id": "4"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "id": "1",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "child_id": "5"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "id": "2",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "child_id": "3"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "id": "2",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "child_id": "4"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "id": "2",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "child_id": "5"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=8",
+          "rownum": 7,
+          "describes": [
+            {
+              "id": "3",
+              "Surname": "Bart",
+              "FamilyName": "Simpson",
+              "child_id": ""
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=9",
+          "rownum": 8,
+          "describes": [
+            {
+              "id": "4",
+              "Surname": "Lisa",
+              "FamilyName": "Simpson",
+              "child_id": ""
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=10",
+          "rownum": 9,
+          "describes": [
+            {
+              "id": "5",
+              "Surname": "Maggie",
+              "FamilyName": "Simpson",
+              "child_id": ""
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=11",
+          "rownum": 10,
+          "describes": [
+            {
+              "id": "6",
+              "Surname": "Ned",
+              "FamilyName": "Flanders",
+              "child_id": ""
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=12",
+          "rownum": 11,
+          "describes": [
+            {
+              "id": "7",
+              "Surname": "Krusty",
+              "FamilyName": "the Clown",
+              "child_id": ""
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test005.csv#row=13",
+          "rownum": 12,
+          "describes": [
+            {
+              "id": "8",
+              "Surname": "Waylon",
+              "FamilyName": "Smithers",
+              "child_id": ""
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test005.ttl
+++ b/tests/test005.ttl
@@ -1,77 +1,121 @@
 @prefix : <test005.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :child_id "3";
-      :id "1";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :child_id "4";
-      :id "1";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :child_id "5";
-      :id "1";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :child_id "3";
-      :id "2";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :child_id "4";
-      :id "2";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :child_id "5";
-      :id "2";
-      csvw:rownum 6
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Bart";
-      :id "3";
-      csvw:rownum 7
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Lisa";
-      :id "4";
-      csvw:rownum 8
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Maggie";
-      :id "5";
-      csvw:rownum 9
-    ],  [
-      :FamilyName "Flanders";
-      :Surname "Ned";
-      :id "6";
-      csvw:rownum 10
-    ],  [
-      :FamilyName "the Clown";
-      :Surname "Krusty";
-      :id "7";
-      csvw:rownum 11
-    ],  [
-      :FamilyName "Smithers";
-      :Surname "Waylon";
-      :id "8";
-      csvw:rownum 12
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :child_id "3";
+          :id "1"
+        ];
+        csvw:rownum 1;
+        csvw:url <test005.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :child_id "4";
+          :id "1"
+        ];
+        csvw:rownum 2;
+        csvw:url <test005.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :child_id "5";
+          :id "1"
+        ];
+        csvw:rownum 3;
+        csvw:url <test005.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :child_id "3";
+          :id "2"
+        ];
+        csvw:rownum 4;
+        csvw:url <test005.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :child_id "4";
+          :id "2"
+        ];
+        csvw:rownum 5;
+        csvw:url <test005.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :child_id "5";
+          :id "2"
+        ];
+        csvw:rownum 6;
+        csvw:url <test005.csv#row=7>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Bart";
+          :child_id "";
+          :id "3"
+        ];
+        csvw:rownum 7;
+        csvw:url <test005.csv#row=8>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Lisa";
+          :child_id "";
+          :id "4"
+        ];
+        csvw:rownum 8;
+        csvw:url <test005.csv#row=9>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Maggie";
+          :child_id "";
+          :id "5"
+        ];
+        csvw:rownum 9;
+        csvw:url <test005.csv#row=10>
+      ],  [
+        csvw:describes [
+          :FamilyName "Flanders";
+          :Surname "Ned";
+          :child_id "";
+          :id "6"
+        ];
+        csvw:rownum 10;
+        csvw:url <test005.csv#row=11>
+      ],  [
+        csvw:describes [
+          :FamilyName "the Clown";
+          :Surname "Krusty";
+          :child_id "";
+          :id "7"
+        ];
+        csvw:rownum 11;
+        csvw:url <test005.csv#row=12>
+      ],  [
+        csvw:describes [
+          :FamilyName "Smithers";
+          :Surname "Waylon";
+          :child_id "";
+          :id "8"
+        ];
+        csvw:rownum 12;
+        csvw:url <test005.csv#row=13>
+      ];
+      csvw:url <>
     ]
  ] .

--- a/tests/test006.json
+++ b/tests/test006.json
@@ -1,11 +1,75 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test006.csv",
-  "row": [
-    {"rownum": 1, "Surname": "Homer", "FamilyName": "Simpson", "childName": "Bart"},
-    {"rownum": 2, "Surname": "Homer", "FamilyName": "Simpson", "childName": "Lisa"},
-    {"rownum": 3, "Surname": "Homer", "FamilyName": "Simpson", "childName": "Maggie"},
-    {"rownum": 4, "Surname": "Marge", "FamilyName": "Simpson", "childName": "Bart"},
-    {"rownum": 5, "Surname": "Marge", "FamilyName": "Simpson", "childName": "Lisa"},
-    {"rownum": 6, "Surname": "Marge", "FamilyName": "Simpson", "childName": "Maggie"}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test006.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childName": "Bart"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childName": "Lisa"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childName": "Maggie"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childName": "Bart"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childName": "Lisa"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test006.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childName": "Maggie"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test006.ttl
+++ b/tests/test006.ttl
@@ -1,41 +1,61 @@
 @prefix : <test006.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childName "Bart";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childName "Lisa";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childName "Maggie";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childName "Bart";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childName "Lisa";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childName "Maggie";
-      csvw:rownum 6
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childName "Bart"
+        ];
+        csvw:rownum 1;
+        csvw:url <test006.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childName "Lisa"
+        ];
+        csvw:rownum 2;
+        csvw:url <test006.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childName "Maggie"
+        ];
+        csvw:rownum 3;
+        csvw:url <test006.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childName "Bart"
+        ];
+        csvw:rownum 4;
+        csvw:url <test006.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childName "Lisa"
+        ];
+        csvw:rownum 5;
+        csvw:url <test006.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childName "Maggie"
+        ];
+        csvw:rownum 6;
+        csvw:url <test006.csv#row=7>
+      ];
+      csvw:url <test006.csv>
     ]
  ] .

--- a/tests/test007.json
+++ b/tests/test007.json
@@ -1,11 +1,87 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test007.csv",
-  "row": [
-    {"rownum": 1, "foaf_id": "http://example/homer", "Surname": "Homer", "FamilyName": "Simpson", "childFoaf": "http://example/bart", "childName": "Bart"},
-    {"rownum": 2, "foaf_id": "http://example/homer", "Surname": "Homer", "FamilyName": "Simpson", "childFoaf": "http://example/lisa", "childName": "Lisa"},
-    {"rownum": 3, "foaf_id": "http://example/homer", "Surname": "Homer", "FamilyName": "Simpson", "childFoaf": "http://example/maggie", "childName": "Maggie"},
-    {"rownum": 4, "foaf_id": "http://example/marge", "Surname": "Marge", "FamilyName": "Simpson", "childFoaf": "http://example/bart", "childName": "Bart"},
-    {"rownum": 5, "foaf_id": "http://example/marge", "Surname": "Marge", "FamilyName": "Simpson", "childFoaf": "http://example/lisa", "childName": "Lisa"},
-    {"rownum": 6, "foaf_id": "http://example/marge", "Surname": "Marge", "FamilyName": "Simpson", "childFoaf": "http://example/maggie", "childName": "Maggie"}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test007.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "foaf_id": "http://example/homer",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/bart",
+              "childName": "Bart"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "foaf_id": "http://example/homer",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/lisa",
+              "childName": "Lisa"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "foaf_id": "http://example/homer",
+              "Surname": "Homer",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/maggie",
+              "childName": "Maggie"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "foaf_id": "http://example/marge",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/bart",
+              "childName": "Bart"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=6",
+          "rownum": 5,
+          "describes": [
+            {
+              "foaf_id": "http://example/marge",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/lisa",
+              "childName": "Lisa"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test007.csv#row=7",
+          "rownum": 6,
+          "describes": [
+            {
+              "foaf_id": "http://example/marge",
+              "Surname": "Marge",
+              "FamilyName": "Simpson",
+              "childFoaf": "http://example/maggie",
+              "childName": "Maggie"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test007.ttl
+++ b/tests/test007.ttl
@@ -1,53 +1,73 @@
 @prefix : <test007.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childFoaf "http://example/bart";
-      :childName "Bart";
-      :foaf_id "http://example/homer";
-      csvw:rownum 1
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childFoaf "http://example/lisa";
-      :childName "Lisa";
-      :foaf_id "http://example/homer";
-      csvw:rownum 2
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Homer";
-      :childFoaf "http://example/maggie";
-      :childName "Maggie";
-      :foaf_id "http://example/homer";
-      csvw:rownum 3
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childFoaf "http://example/bart";
-      :childName "Bart";
-      :foaf_id "http://example/marge";
-      csvw:rownum 4
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childFoaf "http://example/lisa";
-      :childName "Lisa";
-      :foaf_id "http://example/marge";
-      csvw:rownum 5
-    ],  [
-      :FamilyName "Simpson";
-      :Surname "Marge";
-      :childFoaf "http://example/maggie";
-      :childName "Maggie";
-      :foaf_id "http://example/marge";
-      csvw:rownum 6
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childFoaf "http://example/bart";
+          :childName "Bart";
+          :foaf_id "http://example/homer"
+        ];
+        csvw:rownum 1;
+        csvw:url <test007.csv#row=2>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childFoaf "http://example/lisa";
+          :childName "Lisa";
+          :foaf_id "http://example/homer"
+        ];
+        csvw:rownum 2;
+        csvw:url <test007.csv#row=3>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Homer";
+          :childFoaf "http://example/maggie";
+          :childName "Maggie";
+          :foaf_id "http://example/homer"
+        ];
+        csvw:rownum 3;
+        csvw:url <test007.csv#row=4>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childFoaf "http://example/bart";
+          :childName "Bart";
+          :foaf_id "http://example/marge"
+        ];
+        csvw:rownum 4;
+        csvw:url <test007.csv#row=5>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childFoaf "http://example/lisa";
+          :childName "Lisa";
+          :foaf_id "http://example/marge"
+        ];
+        csvw:rownum 5;
+        csvw:url <test007.csv#row=6>
+      ],  [
+        csvw:describes [
+          :FamilyName "Simpson";
+          :Surname "Marge";
+          :childFoaf "http://example/maggie";
+          :childName "Maggie";
+          :foaf_id "http://example/marge"
+        ];
+        csvw:rownum 6;
+        csvw:url <test007.csv#row=7>
+      ];
+      csvw:url <test007.csv>
     ]
  ] .

--- a/tests/test008.json
+++ b/tests/test008.json
@@ -1,23 +1,42 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test008.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "Book1": "1",
-      "Book2": "7680",
-      "Path": "http://dbpedia.org/ontology/language,http://dbpedia.org/resource/English_language,http://dbpedia.org/ontology/language"
-    },
-    {
-      "rownum": 2,
-      "Book1": "1",
-      "Book2": "2",
-      "Path": "http://dbpedia.org/ontology/author,http://dbpedia.org/resource/Diana_Gabaldon,http://dbpedia.org/ontology/author"
-    },
-    {
-      "rownum": 3,
-      "Book1": "1",
-      "Book2": "2",
-      "Path": "http://dbpedia.org/ontology/country,http://dbpedia.org/resource/United_States,http://dbpedia.org/ontology/country"
+      "url": "http://w3c.github.io/csvw/tests/test008.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test008.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "Book1": "1",
+              "Book2": "7680",
+              "Path": "http://dbpedia.org/ontology/language,http://dbpedia.org/resource/English_language,http://dbpedia.org/ontology/language"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test008.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "Book1": "1",
+              "Book2": "2",
+              "Path": "http://dbpedia.org/ontology/author,http://dbpedia.org/resource/Diana_Gabaldon,http://dbpedia.org/ontology/author"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test008.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "Book1": "1",
+              "Book2": "2",
+              "Path": "http://dbpedia.org/ontology/country,http://dbpedia.org/resource/United_States,http://dbpedia.org/ontology/country"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test008.ttl
+++ b/tests/test008.ttl
@@ -1,26 +1,37 @@
-@prefix : <http://w3c.github.io/csvw/tests/test008.csv#> .
+@prefix : <test008.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :Book1 "1";
-      :Book2 "7680";
-      :Path "http://dbpedia.org/ontology/language,http://dbpedia.org/resource/English_language,http://dbpedia.org/ontology/language";
-      csvw:rownum 1
-    ],  [
-      :Book1 "1";
-      :Book2 "2";
-      :Path "http://dbpedia.org/ontology/author,http://dbpedia.org/resource/Diana_Gabaldon,http://dbpedia.org/ontology/author";
-      csvw:rownum 2
-    ],  [
-      :Book1 "1";
-      :Book2 "2";
-      :Path "http://dbpedia.org/ontology/country,http://dbpedia.org/resource/United_States,http://dbpedia.org/ontology/country";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :Book1 "1";
+          :Book2 "7680";
+          :Path "http://dbpedia.org/ontology/language,http://dbpedia.org/resource/English_language,http://dbpedia.org/ontology/language"
+        ];
+        csvw:rownum 1;
+        csvw:url <test008.csv#row=2>
+      ],  [
+        csvw:describes [
+          :Book1 "1";
+          :Book2 "2";
+          :Path "http://dbpedia.org/ontology/author,http://dbpedia.org/resource/Diana_Gabaldon,http://dbpedia.org/ontology/author"
+        ];
+        csvw:rownum 2;
+        csvw:url <test008.csv#row=3>
+      ],  [
+        csvw:describes [
+          :Book1 "1";
+          :Book2 "2";
+          :Path "http://dbpedia.org/ontology/country,http://dbpedia.org/resource/United_States,http://dbpedia.org/ontology/country"
+        ];
+        csvw:rownum 3;
+        csvw:url <test008.csv#row=4>
+      ];
+      csvw:url <test008.csv>
     ]
  ] .

--- a/tests/test009.json
+++ b/tests/test009.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test009.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "On%20Street": "ADDISON AV",
-      "Species": "Celtis australis",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "On%20Street": "EMERSON ST",
-      "Species": "Liquidambar styraciflua",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "On%20Street": "EMERSON ST",
-      "Species": "Liquidambar styraciflua",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test009.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test009.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test009.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test009.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test009.ttl
+++ b/tests/test009.ttl
@@ -1,32 +1,43 @@
 @prefix : <test009.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :Inventory%20Date "10/18/2010";
-      :On%20Street "ADDISON AV";
-      :Species "Celtis australis";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :Inventory%20Date "6/2/2010";
-      :On%20Street "EMERSON ST";
-      :Species "Liquidambar styraciflua";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :Inventory%20Date "6/2/2010";
-      :On%20Street "EMERSON ST";
-      :Species "Liquidambar styraciflua";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test009.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test009.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test009.csv#row=4>
+      ];
+      csvw:url <test009.csv>
     ]
  ] .

--- a/tests/test010.json
+++ b/tests/test010.json
@@ -1,9 +1,49 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test010.csv",
-  "row": [
-    {"rownum": 1, "country": "AD", "name": "Andorra"},
-    {"rownum": 2, "country": "AF", "name": "Afghanistan"},
-    {"rownum": 3, "country": "AI", "name": "Anguilla"},
-    {"rownum": 4, "country": "AL", "name": "Albania"}
+  "table": [
+    {
+      "url": "http://w3c.github.io/csvw/tests/test010.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test010.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "country": "AD",
+              "name": "Andorra"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test010.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "country": "AF",
+              "name": "Afghanistan"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test010.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "country": "AI",
+              "name": "Anguilla"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test010.csv#row=5",
+          "rownum": 4,
+          "describes": [
+            {
+              "country": "AL",
+              "name": "Albania"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/tests/test010.ttl
+++ b/tests/test010.ttl
@@ -1,26 +1,41 @@
-@prefix : <http://w3c.github.io/csvw/tests/test010.csv#> .
+@prefix : <test010.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :country "AD";
-      :name "Andorra";
-      csvw:rownum 1
-    ],  [
-      :country "AF";
-      :name "Afghanistan";
-      csvw:rownum 2
-    ],  [
-      :country "AI";
-      :name "Anguilla";
-      csvw:rownum 3
-    ],  [
-      :country "AL";
-      :name "Albania";
-      csvw:rownum 4
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :country "AD";
+          :name "Andorra"
+        ];
+        csvw:rownum 1;
+        csvw:url <test010.csv#row=2>
+      ],  [
+        csvw:describes [
+          :country "AF";
+          :name "Afghanistan"
+        ];
+        csvw:rownum 2;
+        csvw:url <test010.csv#row=3>
+      ],  [
+        csvw:describes [
+          :country "AI";
+          :name "Anguilla"
+        ];
+        csvw:rownum 3;
+        csvw:url <test010.csv#row=4>
+      ],  [
+        csvw:describes [
+          :country "AL";
+          :name "Albania"
+        ];
+        csvw:rownum 4;
+        csvw:url <test010.csv#row=5>
+      ];
+      csvw:url <test010.csv>
     ]
  ] .

--- a/tests/test011.json
+++ b/tests/test011.json
@@ -1,37 +1,60 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test011.csv",
-  "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
-  "dc:publisher": "Example Municipality",
-  "dc:license": "http://opendefinition.org/licenses/cc-by/",
-  "dc:modified": "2010-12-31",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "url": "http://w3c.github.io/csvw/tests/test011.csv#gid-1",
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "url": "http://w3c.github.io/csvw/tests/test011.csv#gid-2",
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "url": "http://w3c.github.io/csvw/tests/test011.csv#gid-3",
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test011.csv",
+      "dc:title": "Tree Operations",
+      "dc:keywords": [
+        "tree",
+        "street",
+        "maintenance"
+      ],
+      "dc:publisher": "Example Municipality",
+      "dc:license": "http://opendefinition.org/licenses/cc-by/",
+      "dc:modified": "2010-12-31",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test011.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "@id": "http://w3c.github.io/csvw/tests/test011.csv#gid-1",
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-10-18"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test011.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "@id": "http://w3c.github.io/csvw/tests/test011.csv#gid-2",
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test011.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "@id": "http://w3c.github.io/csvw/tests/test011.csv#gid-3",
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test011.ttl
+++ b/tests/test011.ttl
@@ -1,7 +1,6 @@
-@prefix : <http://w3c.github.io/csvw/tests/test011.csv#> .
+@prefix : <test011.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
 @prefix dc: <http://purl.org/dc/terms/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
@@ -9,31 +8,44 @@
    :inventory_date "2010-10-18"^^xsd:date;
    :on_street "ADDISON AV";
    :species "Celtis australis";
-   :trim_cycle "Large Tree Routine Prune";
-   csvw:rownum 1 .
+   :trim_cycle "Large Tree Routine Prune" .
 
 :gid-2 :GID "2";
    :inventory_date "2010-06-02"^^xsd:date;
    :on_street "EMERSON ST";
    :species "Liquidambar styraciflua";
-   :trim_cycle "Large Tree Routine Prune";
-   csvw:rownum 2 .
+   :trim_cycle "Large Tree Routine Prune" .
 
 :gid-3 :GID "3";
    :inventory_date "2010-06-02"^^xsd:date;
    :on_street "EMERSON ST";
    :species "Liquidambar styraciflua";
-   :trim_cycle "Large Tree Routine Prune";
-   csvw:rownum 3 .
+   :trim_cycle "Large Tree Routine Prune" .
 
  [
-    a csvw:Table;
-    dc:title "Tree Operations"@en;
-    dc:keywords "tree"@en, "street"@en, "maintenance"@en;
-    dc:license <http://opendefinition.org/licenses/cc-by/>;
-    dc:modified "2010-12-31"^^xsd:date;
-    dc:publisher "Example Municipality"@en;
-    csvw:row :gid-1,
-      :gid-2,
-      :gid-3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      dc:title "Tree Operations"@en;
+      dc:keywords "tree"@en,
+        "street"@en,
+        "maintenance"@en;
+      dc:license <http://opendefinition.org/licenses/cc-by/>;
+      dc:modified "2010-12-31"^^xsd:date;
+      dc:publisher "Example Municipality"@en;
+      csvw:row [
+        csvw:describes :gid-1;
+        csvw:rownum 1;
+        csvw:url <test011.csv#row=2>
+      ],  [
+        csvw:describes :gid-2;
+        csvw:rownum 2;
+        csvw:url <test011.csv#row=3>
+      ],  [
+        csvw:describes :gid-3;
+        csvw:rownum 3;
+        csvw:url <test011.csv#row=4>
+      ];
+      csvw:url <test011.csv>
+    ]
  ] .

--- a/tests/test012/result.json
+++ b/tests/test012/result.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test012/action.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test012/action.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test012/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-10-18"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test012/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test012/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test012/result.ttl
+++ b/tests/test012/result.ttl
@@ -1,31 +1,43 @@
 @prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :inventory_date "2010-10-18"^^xsd:date;
+          :on_street "ADDISON AV";
+          :species "Celtis australis";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/test013.json
+++ b/tests/test013.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test013.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test013.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test013.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-10-18"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test013.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test013.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test013.ttl
+++ b/tests/test013.ttl
@@ -1,31 +1,43 @@
 @prefix : <test013.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :inventory_date "2010-10-18"^^xsd:date;
+          :on_street "ADDISON AV";
+          :species "Celtis australis";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test013.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test013.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test013.csv#row=4>
+      ];
+      csvw:url <test013.csv>
     ]
  ] .

--- a/tests/test014.json
+++ b/tests/test014.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test014.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test014.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test014.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-10-18"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test014.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test014.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test014.ttl
+++ b/tests/test014.ttl
@@ -1,31 +1,43 @@
-@prefix : <http://w3c.github.io/csvw/tests/test014.csv#> .
+@prefix : <test014.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :inventory_date "2010-10-18"^^xsd:date;
+          :on_street "ADDISON AV";
+          :species "Celtis australis";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test014.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test014.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :inventory_date "2010-06-02"^^xsd:date;
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test014.csv#row=4>
+      ];
+      csvw:url <test014.csv>
     ]
  ] .

--- a/tests/test015/result.json
+++ b/tests/test015/result.json
@@ -1,30 +1,49 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test015/action.csv",
-  "dc:label": ["user", "metadata"],
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test015/action.csv",
+      "dc:label": "user",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test015/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test015/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test015/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test015/result.ttl
+++ b/tests/test015/result.ttl
@@ -1,33 +1,45 @@
 @prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
 @prefix dc: <http://purl.org/dc/terms/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    dc:label "user", "metadata";
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      dc:label "user";
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/test016/result.json
+++ b/tests/test016/result.json
@@ -1,30 +1,49 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test016/action.csv",
-  "dc:label": ["linked", "metadata"],
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test016/action.csv",
+      "dc:label": "linked",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test016/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test016/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test016/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test016/result.ttl
+++ b/tests/test016/result.ttl
@@ -1,33 +1,45 @@
 @prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
 @prefix dc: <http://purl.org/dc/terms/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    dc:label "linked", "metadata";
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      dc:label "linked";
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/test017/result.json
+++ b/tests/test017/result.json
@@ -1,30 +1,49 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test017/action.csv",
-  "dc:label": ["file", "metadata"],
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test017/action.csv",
+      "dc:label": "file",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test017/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test017/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test017/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test017/result.ttl
+++ b/tests/test017/result.ttl
@@ -1,33 +1,45 @@
 @prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
 @prefix dc: <http://purl.org/dc/terms/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    dc:label "file", "metadata";
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      dc:label "file";
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/test018/result.json
+++ b/tests/test018/result.json
@@ -1,30 +1,49 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test018/action.csv",
-  "dc:label": ["user", "linked", "file", "directory"],
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test018/action.csv",
+      "dc:label": "user",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test018/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test018/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test018/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test018/result.ttl
+++ b/tests/test018/result.ttl
@@ -1,33 +1,45 @@
 @prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
 @prefix dc: <http://purl.org/dc/terms/> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    dc:label "user", "linked", "file", "directory";
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      dc:label "user";
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/test019.json
+++ b/tests/test019.json
@@ -1,37 +1,61 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test019.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "_col.1": "GID",
-      "_col.2": "On Street",
-      "_col.3": "Species",
-      "_col.4": "Trim Cycle",
-      "_col.5": "Inventory Date"
-    },
-    {
-      "rownum": 2,
-      "_col.1": "1",
-      "_col.2": "ADDISON AV",
-      "_col.3": "Celtis australis",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "10/18/2010"
-    },
-    {
-      "rownum": 3,
-      "_col.1": "2",
-      "_col.2": "EMERSON ST",
-      "_col.3": "Liquidambar styraciflua",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "6/2/2010"
-    },
-    {
-      "rownum": 4,
-      "_col.1": "3",
-      "_col.2": "EMERSON ST",
-      "_col.3": "Liquidambar styraciflua",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test019.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test019.csv#row=1",
+          "rownum": 1,
+          "describes": [
+            {
+              "_col.1": "GID",
+              "_col.2": "On Street",
+              "_col.3": "Species",
+              "_col.4": "Trim Cycle",
+              "_col.5": "Inventory Date"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test019.csv#row=2",
+          "rownum": 2,
+          "describes": [
+            {
+              "_col.1": "1",
+              "_col.2": "ADDISON AV",
+              "_col.3": "Celtis australis",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test019.csv#row=3",
+          "rownum": 3,
+          "describes": [
+            {
+              "_col.1": "2",
+              "_col.2": "EMERSON ST",
+              "_col.3": "Liquidambar styraciflua",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test019.csv#row=4",
+          "rownum": 4,
+          "describes": [
+            {
+              "_col.1": "3",
+              "_col.2": "EMERSON ST",
+              "_col.3": "Liquidambar styraciflua",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test019.ttl
+++ b/tests/test019.ttl
@@ -1,38 +1,53 @@
-@prefix : <http://w3c.github.io/csvw/tests/test019.csv#> .
+@prefix : <test019.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :_col.1 "GID";
-      :_col.2 "On Street";
-      :_col.3 "Species";
-      :_col.4 "Trim Cycle";
-      :_col.5 "Inventory Date";
-      csvw:rownum 1
-    ],  [
-      :_col.1 "1";
-      :_col.2 "ADDISON AV";
-      :_col.3 "Celtis australis";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "10/18/2010";
-      csvw:rownum 2
-    ],  [
-      :_col.1 "2";
-      :_col.2 "EMERSON ST";
-      :_col.3 "Liquidambar styraciflua";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "6/2/2010";
-      csvw:rownum 3
-    ],  [
-      :_col.1 "3";
-      :_col.2 "EMERSON ST";
-      :_col.3 "Liquidambar styraciflua";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "6/2/2010";
-      csvw:rownum 4
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :_col.1 "GID";
+          :_col.2 "On Street";
+          :_col.3 "Species";
+          :_col.4 "Trim Cycle";
+          :_col.5 "Inventory Date"
+        ];
+        csvw:rownum 1;
+        csvw:url <test019.csv#row=1>
+      ],  [
+        csvw:describes [
+          :_col.1 "1";
+          :_col.2 "ADDISON AV";
+          :_col.3 "Celtis australis";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "10/18/2010"
+        ];
+        csvw:rownum 2;
+        csvw:url <test019.csv#row=2>
+      ],  [
+        csvw:describes [
+          :_col.1 "2";
+          :_col.2 "EMERSON ST";
+          :_col.3 "Liquidambar styraciflua";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "6/2/2010"
+        ];
+        csvw:rownum 3;
+        csvw:url <test019.csv#row=3>
+      ],  [
+        csvw:describes [
+          :_col.1 "3";
+          :_col.2 "EMERSON ST";
+          :_col.3 "Liquidambar styraciflua";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "6/2/2010"
+        ];
+        csvw:rownum 4;
+        csvw:url <test019.csv#row=4>
+      ];
+      csvw:url <test019.csv>
     ]
  ] .

--- a/tests/test020.json
+++ b/tests/test020.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test020.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV ",
-      "species": "Celtis australis ",
-      "trim_cycle": "Large Tree Routine Prune ",
-      "inventory_date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST ",
-      "species": "Liquidambar styraciflua ",
-      "trim_cycle": "Large Tree Routine Prune ",
-      "inventory_date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST ",
-      "species": "Liquidambar styraciflua ",
-      "trim_cycle": "Large Tree Routine Prune ",
-      "inventory_date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test020.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test020.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1 ",
+              "on_street": "ADDISON AV ",
+              "species": "Celtis australis ",
+              "trim_cycle": "Large Tree Routine Prune ",
+              "inventory_date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test020.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2 ",
+              "on_street": "EMERSON ST ",
+              "species": "Liquidambar styraciflua ",
+              "trim_cycle": "Large Tree Routine Prune ",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test020.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3 ",
+              "on_street": "EMERSON ST ",
+              "species": "Liquidambar styraciflua ",
+              "trim_cycle": "Large Tree Routine Prune ",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test020.ttl
+++ b/tests/test020.ttl
@@ -1,31 +1,43 @@
 @prefix : <test020.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "10/18/2010";
-      :on_street "ADDISON AV ";
-      :species "Celtis australis ";
-      :trim_cycle "Large Tree Routine Prune ";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST ";
-      :species "Liquidambar styraciflua ";
-      :trim_cycle "Large Tree Routine Prune ";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST ";
-      :species "Liquidambar styraciflua ";
-      :trim_cycle "Large Tree Routine Prune ";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1 ";
+          :inventory_date "10/18/2010";
+          :on_street "ADDISON AV ";
+          :species "Celtis australis ";
+          :trim_cycle "Large Tree Routine Prune "
+        ];
+        csvw:rownum 1;
+        csvw:url <test020.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2 ";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST ";
+          :species "Liquidambar styraciflua ";
+          :trim_cycle "Large Tree Routine Prune "
+        ];
+        csvw:rownum 2;
+        csvw:url <test020.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3 ";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST ";
+          :species "Liquidambar styraciflua ";
+          :trim_cycle "Large Tree Routine Prune "
+        ];
+        csvw:rownum 3;
+        csvw:url <test020.csv#row=4>
+      ];
+      csvw:url <test020.csv>
     ]
  ] .

--- a/tests/test021.json
+++ b/tests/test021.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test021.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": " ADDISON AV",
-      "species": " Celtis australis",
-      "trim_cycle": " Large Tree Routine Prune",
-      "inventory_date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": " EMERSON ST",
-      "species": " Liquidambar styraciflua",
-      "trim_cycle": " Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": " EMERSON ST",
-      "species": " Liquidambar styraciflua",
-      "trim_cycle": " Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test021.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test021.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": " 1",
+              "on_street": " ADDISON AV",
+              "species": " Celtis australis",
+              "trim_cycle": " Large Tree Routine Prune",
+              "inventory_date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test021.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": " 2",
+              "on_street": " EMERSON ST",
+              "species": " Liquidambar styraciflua",
+              "trim_cycle": " Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test021.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": " 3",
+              "on_street": " EMERSON ST",
+              "species": " Liquidambar styraciflua",
+              "trim_cycle": " Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test021.ttl
+++ b/tests/test021.ttl
@@ -1,31 +1,43 @@
 @prefix : <test021.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "10/18/2010";
-      :on_street " ADDISON AV";
-      :species " Celtis australis";
-      :trim_cycle " Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "6/2/2010";
-      :on_street " EMERSON ST";
-      :species " Liquidambar styraciflua";
-      :trim_cycle " Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "6/2/2010";
-      :on_street " EMERSON ST";
-      :species " Liquidambar styraciflua";
-      :trim_cycle " Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID " 1";
+          :inventory_date "10/18/2010";
+          :on_street " ADDISON AV";
+          :species " Celtis australis";
+          :trim_cycle " Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test021.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID " 2";
+          :inventory_date "6/2/2010";
+          :on_street " EMERSON ST";
+          :species " Liquidambar styraciflua";
+          :trim_cycle " Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test021.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID " 3";
+          :inventory_date "6/2/2010";
+          :on_street " EMERSON ST";
+          :species " Liquidambar styraciflua";
+          :trim_cycle " Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test021.csv#row=4>
+      ];
+      csvw:url <test021.csv>
     ]
  ] .

--- a/tests/test022.json
+++ b/tests/test022.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test022.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test022.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test022.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test022.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test022.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test022.ttl
+++ b/tests/test022.ttl
@@ -1,31 +1,43 @@
 @prefix : <test022.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "10/18/2010";
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :inventory_date "10/18/2010";
+          :on_street "ADDISON AV";
+          :species "Celtis australis";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test022.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test022.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test022.csv#row=4>
+      ];
+      csvw:url <test022.csv>
     ]
  ] .

--- a/tests/test023.json
+++ b/tests/test023.json
@@ -1,37 +1,61 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test023.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "_col.1": "GID",
-      "_col.2": "On Street",
-      "_col.3": "Species",
-      "_col.4": "Trim Cycle",
-      "_col.5": "Inventory Date"
-    },
-    {
-      "rownum": 2,
-      "_col.1": "1",
-      "_col.2": "ADDISON AV",
-      "_col.3": "Celtis australis",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "10/18/2010"
-    },
-    {
-      "rownum": 3,
-      "_col.1": "2",
-      "_col.2": "EMERSON ST",
-      "_col.3": "Liquidambar styraciflua",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "6/2/2010"
-    },
-    {
-      "rownum": 4,
-      "_col.1": "3",
-      "_col.2": "EMERSON ST",
-      "_col.3": "Liquidambar styraciflua",
-      "_col.4": "Large Tree Routine Prune",
-      "_col.5": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test023.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test023.csv#row=1",
+          "rownum": 1,
+          "describes": [
+            {
+              "_col.1": "GID",
+              "_col.2": "On Street",
+              "_col.3": "Species",
+              "_col.4": "Trim Cycle",
+              "_col.5": "Inventory Date"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test023.csv#row=2",
+          "rownum": 2,
+          "describes": [
+            {
+              "_col.1": "1",
+              "_col.2": "ADDISON AV",
+              "_col.3": "Celtis australis",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test023.csv#row=3",
+          "rownum": 3,
+          "describes": [
+            {
+              "_col.1": "2",
+              "_col.2": "EMERSON ST",
+              "_col.3": "Liquidambar styraciflua",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test023.csv#row=4",
+          "rownum": 4,
+          "describes": [
+            {
+              "_col.1": "3",
+              "_col.2": "EMERSON ST",
+              "_col.3": "Liquidambar styraciflua",
+              "_col.4": "Large Tree Routine Prune",
+              "_col.5": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test023.ttl
+++ b/tests/test023.ttl
@@ -1,38 +1,53 @@
 @prefix : <test023.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :_col.1 "GID";
-      :_col.2 "On Street";
-      :_col.3 "Species";
-      :_col.4 "Trim Cycle";
-      :_col.5 "Inventory Date";
-      csvw:rownum 1
-    ],  [
-      :_col.1 "1";
-      :_col.2 "ADDISON AV";
-      :_col.3 "Celtis australis";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "10/18/2010";
-      csvw:rownum 2
-    ],  [
-      :_col.1 "2";
-      :_col.2 "EMERSON ST";
-      :_col.3 "Liquidambar styraciflua";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "6/2/2010";
-      csvw:rownum 3
-    ],  [
-      :_col.1 "3";
-      :_col.2 "EMERSON ST";
-      :_col.3 "Liquidambar styraciflua";
-      :_col.4 "Large Tree Routine Prune";
-      :_col.5 "6/2/2010";
-      csvw:rownum 4
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :_col.1 "GID";
+          :_col.2 "On Street";
+          :_col.3 "Species";
+          :_col.4 "Trim Cycle";
+          :_col.5 "Inventory Date"
+        ];
+        csvw:rownum 1;
+        csvw:url <test023.csv#row=1>
+      ],  [
+        csvw:describes [
+          :_col.1 "1";
+          :_col.2 "ADDISON AV";
+          :_col.3 "Celtis australis";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "10/18/2010"
+        ];
+        csvw:rownum 2;
+        csvw:url <test023.csv#row=2>
+      ],  [
+        csvw:describes [
+          :_col.1 "2";
+          :_col.2 "EMERSON ST";
+          :_col.3 "Liquidambar styraciflua";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "6/2/2010"
+        ];
+        csvw:rownum 3;
+        csvw:url <test023.csv#row=3>
+      ],  [
+        csvw:describes [
+          :_col.1 "3";
+          :_col.2 "EMERSON ST";
+          :_col.3 "Liquidambar styraciflua";
+          :_col.4 "Large Tree Routine Prune";
+          :_col.5 "6/2/2010"
+        ];
+        csvw:rownum 4;
+        csvw:url <test023.csv#row=4>
+      ];
+      csvw:url <test023.csv>
     ]
  ] .

--- a/tests/test024.json
+++ b/tests/test024.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test024.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "On%20Street": "ADDISON AV",
-      "Species": "Celtis australis",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "On%20Street": "EMERSON ST",
-      "Species": "Liquidambar styraciflua",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "On%20Street": "EMERSON ST",
-      "Species": "Liquidambar styraciflua",
-      "Trim%20Cycle": "Large Tree Routine Prune",
-      "Inventory%20Date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test024.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test024.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "On%20Street": "ADDISON AV",
+              "Species": "Celtis australis",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test024.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test024.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "On%20Street": "EMERSON ST",
+              "Species": "Liquidambar styraciflua",
+              "Trim%20Cycle": "Large Tree Routine Prune",
+              "Inventory%20Date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test024.ttl
+++ b/tests/test024.ttl
@@ -1,31 +1,43 @@
-@prefix : <http://w3c.github.io/csvw/tests/test024.csv#> .
+@prefix : <test024.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :Inventory%20Date "10/18/2010";
-      :On%20Street "ADDISON AV";
-      :Species "Celtis australis";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :Inventory%20Date "6/2/2010";
-      :On%20Street "EMERSON ST";
-      :Species "Liquidambar styraciflua";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :Inventory%20Date "6/2/2010";
-      :On%20Street "EMERSON ST";
-      :Species "Liquidambar styraciflua";
-      :Trim%20Cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :Inventory%20Date "10/18/2010";
+          :On%20Street "ADDISON AV";
+          :Species "Celtis australis";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test024.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test024.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :Inventory%20Date "6/2/2010";
+          :On%20Street "EMERSON ST";
+          :Species "Liquidambar styraciflua";
+          :Trim%20Cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test024.csv#row=4>
+      ];
+      csvw:url <test024.csv>
     ]
  ] .

--- a/tests/test025.json
+++ b/tests/test025.json
@@ -1,29 +1,51 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test025.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "10/18/2010"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "6/2/2010"
+      "url": "http://w3c.github.io/csvw/tests/test025.csv",
+      "notes": [
+        "GID,On Street,Species,Trim Cycle,Inventory Date"
+      ],
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test025.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "10/18/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test025.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test025.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "6/2/2010"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test025.ttl
+++ b/tests/test025.ttl
@@ -1,31 +1,44 @@
 @prefix : <test025.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "10/18/2010";
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "6/2/2010";
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:notes "GID,On Street,Species,Trim Cycle,Inventory Date";
+      csvw:row [
+        csvw:describes [
+          :GID "1";
+          :inventory_date "10/18/2010";
+          :on_street "ADDISON AV";
+          :species "Celtis australis";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <test025.csv#row=2>
+      ],  [
+        csvw:describes [
+          :GID "2";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <test025.csv#row=3>
+      ],  [
+        csvw:describes [
+          :GID "3";
+          :inventory_date "6/2/2010";
+          :on_street "EMERSON ST";
+          :species "Liquidambar styraciflua";
+          :trim_cycle "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <test025.csv#row=4>
+      ];
+      csvw:url <test025.csv>
     ]
  ] .

--- a/tests/test026/result.json
+++ b/tests/test026/result.json
@@ -1,29 +1,48 @@
 {
-  "url": "http://w3c.github.io/csvw/tests/test026/action.csv",
-  "row": [
+  "table": [
     {
-      "rownum": 1,
-      "GID": "1",
-      "on_street": "ADDISON AV",
-      "species": "Celtis australis",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-10-18"
-    },
-    {
-      "rownum": 2,
-      "GID": "2",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
-    },
-    {
-      "rownum": 3,
-      "GID": "3",
-      "on_street": "EMERSON ST",
-      "species": "Liquidambar styraciflua",
-      "trim_cycle": "Large Tree Routine Prune",
-      "inventory_date": "2010-06-02"
+      "url": "http://w3c.github.io/csvw/tests/test026/action.csv",
+      "row": [
+        {
+          "url": "http://w3c.github.io/csvw/tests/test026/action.csv#row=2",
+          "rownum": 1,
+          "describes": [
+            {
+              "GID": "1",
+              "on_street": "ADDISON AV",
+              "species": "Celtis australis",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-10-18"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test026/action.csv#row=3",
+          "rownum": 2,
+          "describes": [
+            {
+              "GID": "2",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        },
+        {
+          "url": "http://w3c.github.io/csvw/tests/test026/action.csv#row=4",
+          "rownum": 3,
+          "describes": [
+            {
+              "GID": "3",
+              "on_street": "EMERSON ST",
+              "species": "Liquidambar styraciflua",
+              "trim_cycle": "Large Tree Routine Prune",
+              "inventory_date": "2010-06-02"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/tests/test026/result.ttl
+++ b/tests/test026/result.ttl
@@ -1,31 +1,42 @@
-@prefix : <action.csv#> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
  [
-    a csvw:Table;
-    csvw:row [
-      :GID "1";
-      :inventory_date "2010-10-18"^^xsd:date;
-      :on_street "ADDISON AV";
-      :species "Celtis australis";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 1
-    ],  [
-      :GID "2";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 2
-    ],  [
-      :GID "3";
-      :inventory_date "2010-06-02"^^xsd:date;
-      :on_street "EMERSON ST";
-      :species "Liquidambar styraciflua";
-      :trim_cycle "Large Tree Routine Prune";
-      csvw:rownum 3
+    a csvw:TableGroup;
+    csvw:table [
+      a csvw:Table;
+      csvw:row [
+        csvw:describes [
+          <action.csv#GID> "1";
+          <action.csv#inventory_date> "2010-10-18"^^xsd:date;
+          <action.csv#on_street> "ADDISON AV";
+          <action.csv#species> "Celtis australis";
+          <action.csv#trim_cycle> "Large Tree Routine Prune"
+        ];
+        csvw:rownum 1;
+        csvw:url <action.csv#row=2>
+      ],  [
+        csvw:describes [
+          <action.csv#GID> "2";
+          <action.csv#inventory_date> "2010-06-02"^^xsd:date;
+          <action.csv#on_street> "EMERSON ST";
+          <action.csv#species> "Liquidambar styraciflua";
+          <action.csv#trim_cycle> "Large Tree Routine Prune"
+        ];
+        csvw:rownum 2;
+        csvw:url <action.csv#row=3>
+      ],  [
+        csvw:describes [
+          <action.csv#GID> "3";
+          <action.csv#inventory_date> "2010-06-02"^^xsd:date;
+          <action.csv#on_street> "EMERSON ST";
+          <action.csv#species> "Liquidambar styraciflua";
+          <action.csv#trim_cycle> "Large Tree Routine Prune"
+        ];
+        csvw:rownum 3;
+        csvw:url <action.csv#row=4>
+      ];
+      csvw:url <action.csv>
     ]
  ] .

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
-<html prefix='csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#'>
+<html lang='en' prefix='csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#'>
   <head>
     <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
     <meta content='width=device-width, initial-scale=1.0' name='viewport'>
-    <link href='http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css' rel='stylesheet' type='text/css'>
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js' type='text/javascript'></script>
-    <script src='http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js' type='text/javascript'></script>
-    <script src='http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js' type='text/javascript'></script>
+    <link href='http://www.w3.org/StyleSheets/TR/W3C-ED' rel='stylesheet' type='text/css'>
     <style>
+      body: {bacground-image: none;}
+      dt {margin-top: 2em;}
       dd code {display: inline;}
       footer {text-align: center;}
     </style>
@@ -15,467 +14,427 @@
       CSVW Test Vocabulary
     </title>
   </head>
-  <body resource='http://w3c.github.io/csvw/tests/vocab#' role='document'>
+  <body resource='http://w3c.github.io/csvw/tests/vocab#' typeof='owl:Ontology'>
     <meta property='dc:creator' value='Gregg Kellogg'>
     <link href='http://w3c.github.io/csvw/tests/vocab#' property='dc:identifier'>
-    <nav class='navbar' role='navigation'>
-      <div class='container-fluid'>
-        <div class='navbar-header'>
-          <button class='navbar-toggle' type='button'>
-            <span class='sr-only'>Toggle Navigation</span>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-          </button>
-          <a class='navbar-brand' href='index.html'>
-            CSVW Test Suite
-          </a>
-        </div>
-        <ul class='nav navbar-nav'>
-          <li>
-            <a href='index.html'>
-              <span class='icon-beer'></span>
-              Test Suite
-            </a>
-          </li>
-          <li>
-            <a href='vocab.html'>
-              <span class='icon-beer'></span>
-              Test Vocabulary
-            </a>
-          </li>
-          <li class='dropdown'>
-            <a class='dropdown-toggle' data-toggle='dropdown' href='#'>
-              <span class='icon-folder-open'></span>
-              Specifications
-              <b class='caret'></b>
-            </a>
-            <ul class='dropdown-menu'>
-              <li class='nav-header'>
-                <strong>
-                  Latest
-                </strong>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/model/'>
-                  Model for Tabular Data and Metadata on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/metadata/'>
-                  Metadata Vocabulary for Tabular Data
-                </a>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/csv2json/'>
-                  Generating JSON from Tabular Data on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/csv2rdf/'>
-                  Generating RDF from Tabular Data on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/ns/'>
-                  Tabular Data Namespace
-                </a>
-              </li>
-              <li>
-                <a href='http://w3c.github.io/csvw/use-cases-and-requirements/'>
-                  Use Cases and Requirements
-                </a>
-              </li>
-              <li class='divider'></li>
-              <li class='nav-header'>
-                <strong>
-                  Published Documents
-                </strong>
-              </li>
-              <li>
-                <a href='http://www.w3.org/TR/tabular-data-model/'>
-                  Model for Tabular Data and Metadata on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://www.w3.org/TR/tabular-metadata/'>
-                  Metadata Vocabulary for Tabular Data
-                </a>
-              </li>
-              <li>
-                <a href='http://www.w3.org/TR/csv2json/'>
-                  Generating JSON from Tabular Data on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://www.w3.org/TR/csv2rdf/'>
-                  Generating RDF from Tabular Data on the Web
-                </a>
-              </li>
-              <li>
-                <a href='http://www.w3.org/ns/csvw/'>
-                  Tabular Data Namespace
-                </a>
-              </li>
-              <li>
-                <a href='http://www.w3.org/TR/csvw-ucr/'>
-                  Use Cases and Requirements
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </nav>
-    <div class='hero-unit'>
-      <h1 property='dc:title'>CSVW Test Vocabulary</h1>
-      <p property='dc:description rdfs:comment'>Test case manifest vocabulary extensions</p>
-    </div>
-    <div class='container'>
-      <div class='row'>
-        <h2 class='span12' id='classes' style='text-align: center;'>
-          Test Case Classes
-        </h2>
-        <p>This vocabulary extends the standard <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">RDF Test Vocabulary</a> with CSVW-specific tests.</p>
-      </div>
-      <div class='row'>
-        <section class='offset2 span8'>
-          <dl>
-            <dt about='csvwt:CsvSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvSparqlTest</dt>
-            <dd about='csvwt:CsvSparqlTest'>
-              <em property='rdfs:label'>CSV SPARQL Test</em>
-              <p property='rdfs:comment'><p>A <code>CsvSparqlTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:CsvValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvValidationTest</dt>
-            <dd about='csvwt:CsvValidationTest'>
-              <em property='rdfs:label'>CSV Validation Test</em>
-              <p property='rdfs:comment'><p>A <code>CsvValidationTest</code> takes an input file(<code>mf:accept</code>) in text/csv format to produce a JSON representation of the <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model">annotated tabular data model</a> as defined in [[csvw-test-suite]]. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:CsvToJsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToJsonTest</dt>
-            <dd about='csvwt:CsvToJsonTest'>
-              <em property='rdfs:label'>CSV to JSON Test</em>
-              <p property='rdfs:comment'><p>A <code>CsvToJsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response. The expected results are compared using JSON object comparison with the processor output.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:CsvToRdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToRdfTest</dt>
-            <dd about='csvwt:CsvToRdfTest'>
-              <em property='rdfs:label'>CSV to RDF Test</em>
-              <p property='rdfs:comment'><p>A <code>CsvToRdfTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:ManifestValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:ManifestValidationTest</dt>
-            <dd about='csvwt:ManifestValidationTest'>
-              <em property='rdfs:label'>Manifest Validation Test</em>
-              <p property='rdfs:comment'><p>A <code>ManifestValidationTest</code> takes an input file(<code>mf:accept</code>) in application/csvm+json format to produce a JSON representation of the <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model">annotated tabular data model</a> as defined in [[csvw-test-suite]]. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:MetadataSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:MetadataSparqlTest</dt>
-            <dd about='csvwt:MetadataSparqlTest'>
-              <em property='rdfs:label'>Metadata SPARQL Test</em>
-              <p property='rdfs:comment'><p>A <code>MetadataSparqlTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:Metadata2JsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2JsonTest</dt>
-            <dd about='csvwt:Metadata2JsonTest'>
-              <em property='rdfs:label'>Metadata to JSON Test</em>
-              <p property='rdfs:comment'><p>A <code>Metadata2JsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:Metadata2RdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2RdfTest</dt>
-            <dd about='csvwt:Metadata2RdfTest'>
-              <em property='rdfs:label'>Metadata to RDF Test</em>
-              <p property='rdfs:comment'><p>A <code>Metadata2RdfTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:NegativeSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeSyntaxTest</dt>
-            <dd about='csvwt:NegativeSyntaxTest'>
-              <em property='rdfs:label'>Negative Syntax Test</em>
-              <p property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeEvaluationTest</dt>
-            <dd about='csvwt:NegativeEvaluationTest'>
-              <em property='rdfs:label'>Positive Evaluation Test</em>
-              <p property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> results in the error identified by the literal value of <code>mf:result</code>. The specifics of invoking test, including the interpretation of options (and other input files are specified through sub-class.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveEvaluationTest</dt>
-            <dd about='csvwt:PositiveEvaluationTest'>
-              <em property='rdfs:label'>Positive Evaluation Test</em>
-              <p property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> exactly matches the output file specified as <code>mf:result</code> using the comparison defined in another class. The specifics of invoking test, including the interpretation of options and other input files are specified through a sub-class.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:PositiveSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveSyntaxTest</dt>
-            <dd about='csvwt:PositiveSyntaxTest'>
-              <em property='rdfs:label'>Positive Syntax Test</em>
-              <p property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:Option' property='rdfs:label' typeof='rdfs:Class'>csvwt:Option</dt>
-            <dd about='csvwt:Option'>
-              <em property='rdfs:label'>Processor Options</em>
-              <p property='rdfs:comment'><p>Options passed to the test runner to affect invocation of the appropriate API method.</p></p>
-            </dd>
-            <dt about='csvwt:Test' property='rdfs:label' typeof='rdfs:Class'>csvwt:Test</dt>
-            <dd about='csvwt:Test'>
-              <em property='rdfs:label'>Superclass of all CSVW tests</em>
-              <p property='rdfs:comment'><p>All CSVW tests have an input file referenced using <code>mf:action</code>. Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> . Other tests may take different inputs and options as defined for each test class.</p>
-              <div>
-                <strong>
-                  subClassOf:
-                </strong>
-                <code property='rdfs:subClassOf' resource='mf:ManifestEntry'>mf:ManifestEntry</code>
-              </div></p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-      <div class='row'>
-        <h2 class='span12' id='classes' style='text-align: center;'>
-          Test Case Properties
-        </h2>
-      </div>
-      <div class='row'>
-        <section class='offset2 span8'>
-          <dl>
-            <dt about='csvwt:httpLink' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:httpLink'>
-              <em property='rdfs:label'>HTTP link</em>
-              <p property='rdfs:comment'><p>An HTTP Link header to be added to the result of requesting the input file.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:httpStatus' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:httpStatus'>
-              <em property='rdfs:label'>HTTP status</em>
-              <p property='rdfs:comment'><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:metadata' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:metadata'>
-              <em property='rdfs:label'>Metadata</em>
-              <p property='rdfs:comment'><p>URL of User supplied metadata.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:anyUri'>xsd:anyUri</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:minimal' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:minimal'>
-              <em property='rdfs:label'>Minimal</em>
-              <p property='rdfs:comment'><p>Generate minimal vs. standard output.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:noProv' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:noProv'>
-              <em property='rdfs:label'>No Provenance</em>
-              <p property='rdfs:comment'><p>Processor should run without generating provenance triples.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:base' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:base'>
-              <em property='rdfs:label'>base</em>
-              <p property='rdfs:comment'><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:contentType' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:contentType'>
-              <em property='rdfs:label'>content type</em>
-              <p property='rdfs:comment'><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:implicit' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:implicit'>
-              <em property='rdfs:label'>implicit</em>
-              <p property='rdfs:comment'><p>Implicit input files</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:option' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:option'>
-              <em property='rdfs:label'>option</em>
-              <p property='rdfs:comment'><p>Options affecting processing</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='csvwt:Option'>csvwt:Option</code>
-              </div></p>
-            </dd>
-            <dt about='csvwt:redirectTo' property='rdfs:label' typeof='rdf:Property'></dt>
-            <dd about='csvwt:redirectTo'>
-              <em property='rdfs:label'>redirect to</em>
-              <p property='rdfs:comment'><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div></p>
-            </dd>
-          </dl>
-        </section>
-      </div>
-    </div>
+    <p>
+      <a href='http://www.w3.org/'>
+        <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
+      </a>
+    </p>
+    <h1 property='dc:title rdfs:label'>CSVW Test Vocabulary</h1>
+    <span property='dc:description rdfs:comment'>
+      <p>This is a vocabulary document used to define classes and properties used in
+      <a href="http://w3c.github.io/csvw/tests/">CSVW Test Cases</a> and associated test manifests.</p>
+      
+      <p>This vocabulary extends the <a href="http://www.w3.org/ns/rdftest#">RDF Test Vocabulary</a>
+      and <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">Test Manifest Vocabulary</a> with CSVW-specific tests.
+      The URI of the vocabulary is <code>http://w3c.github.io/csvw/tests/vocab#</code>
+      (abbreviated by <code>csvwt</code> in this document).
+      <a href="vocab.ttl">Turtle</a> and <a href="vocab.jsonld">JSON-LD</a> versions of the vocabular are also available.
+      The vocabulary is published by the <a href="http://www.w3.org/2013/csvw/wiki/Main_Page">W3C CSV on the Web Working Group</a>.</p>
+    </span>
+    <section>
+      <h2>Vocabulary Terms</h2>
+      <p>The vocabulary terms below constitute the complete CSVW Test vocabulary</p>
+      <section>
+        <h3 id='classes'>Classes</h3>
+        <dl>
+          <dt about='csvwt:CsvNegativeValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvNegativeValidationTest</dt>
+          <dd about='csvwt:CsvNegativeValidationTest'>
+            <em property='rdfs:label'>CSV Negative Validation Test</em>
+            <span property='rdfs:comment'><p>A <code>CsvNegativeValidationTest</code> takes an input file(<code>mf:accept</code>) in text/csv format and validates it as described in the <a href="http://w3c.github.io/csvw/metadata/">tabular-metadata</a> and finds no errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:NegativeValidationTest'>csvwt:NegativeValidationTest</code>
+            </div>
+          </dd>
+          <dt about='csvwt:CsvPositiveValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvPositiveValidationTest</dt>
+          <dd about='csvwt:CsvPositiveValidationTest'>
+            <em property='rdfs:label'>CSV Positive Validation Test</em>
+            <span property='rdfs:comment'><p>A <code>CsvPositiveValidationTest</code> takes an input file(<code>mf:accept</code>) in text/csv format and validates it as described in the <a href="http://w3c.github.io/csvw/metadata/">tabular-metadata</a> and finds no errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:PositiveValidationTest'>csvwt:PositiveValidationTest</code>
+            </div>
+          </dd>
+          <dt about='csvwt:CsvSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvSparqlTest</dt>
+          <dd about='csvwt:CsvSparqlTest'>
+            <em property='rdfs:label'>CSV SPARQL Test</em>
+            <span property='rdfs:comment'><p>A <code>CsvSparqlTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <ul>
+                <li>
+                  <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+                </li>
+                <li>
+                  <code property='rdfs:subClassOf' resource='mf:QueryEvaluationTest'>mf:QueryEvaluationTest</code>
+                </li>
+              </ul>
+            </div>
+          </dd>
+          <dt about='csvwt:CsvToJsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToJsonTest</dt>
+          <dd about='csvwt:CsvToJsonTest'>
+            <em property='rdfs:label'>CSV to JSON Test</em>
+            <span property='rdfs:comment'><p>A <code>CsvToJsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response. The expected results are compared using JSON object comparison with the processor output.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+            </div>
+          </dd>
+          <dt about='csvwt:CsvToRdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToRdfTest</dt>
+          <dd about='csvwt:CsvToRdfTest'>
+            <em property='rdfs:label'>CSV to RDF Test</em>
+            <span property='rdfs:comment'><p>A <code>CsvToRdfTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <ul>
+                <li>
+                  <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+                </li>
+                <li>
+                  <code property='rdfs:subClassOf' resource='rdft:TestEval'>rdft:TestEval</code>
+                </li>
+              </ul>
+            </div>
+          </dd>
+          <dt about='csvwt:ManifestNegativeValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:ManifestNegativeValidationTest</dt>
+          <dd about='csvwt:ManifestNegativeValidationTest'>
+            <em property='rdfs:label'>Manifest Negative Validation Test</em>
+            <span property='rdfs:comment'><p>A <code>ManifestNegativeValidationTest</code> takes an input file(<code>mf:accept</code>) in application/csvm+json format and validates it as described in the <a href="http://w3c.github.io/csvw/metadata/">tabular-metadata</a> and finds no errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:ManifestPositiveValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:ManifestPositiveValidationTest</dt>
+          <dd about='csvwt:ManifestPositiveValidationTest'>
+            <em property='rdfs:label'>Manifest Positive Validation Test</em>
+            <span property='rdfs:comment'><p>A <code>ManifestPositiveValidationTest</code> takes an input file(<code>mf:accept</code>) in application/csvm+json format and validates it as described in the <a href="http://w3c.github.io/csvw/metadata/">tabular-metadata</a> and finds no errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:MetadataSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:MetadataSparqlTest</dt>
+          <dd about='csvwt:MetadataSparqlTest'>
+            <em property='rdfs:label'>Metadata SPARQL Test</em>
+            <span property='rdfs:comment'><p>A <code>MetadataSparqlTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <ul>
+                <li>
+                  <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+                </li>
+                <li>
+                  <code property='rdfs:subClassOf' resource='mf:QueryEvaluationTest'>mf:QueryEvaluationTest</code>
+                </li>
+              </ul>
+            </div>
+          </dd>
+          <dt about='csvwt:Metadata2JsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2JsonTest</dt>
+          <dd about='csvwt:Metadata2JsonTest'>
+            <em property='rdfs:label'>Metadata to JSON Test</em>
+            <span property='rdfs:comment'><p>A <code>Metadata2JsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+            </div>
+          </dd>
+          <dt about='csvwt:Metadata2RdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2RdfTest</dt>
+          <dd about='csvwt:Metadata2RdfTest'>
+            <em property='rdfs:label'>Metadata to RDF Test</em>
+            <span property='rdfs:comment'><p>A <code>Metadata2RdfTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <ul>
+                <li>
+                  <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+                </li>
+                <li>
+                  <code property='rdfs:subClassOf' resource='rdft:TestEval'>rdft:TestEval</code>
+                </li>
+              </ul>
+            </div>
+          </dd>
+          <dt about='csvwt:NegativeValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeValidationTest</dt>
+          <dd about='csvwt:NegativeValidationTest'>
+            <em property='rdfs:label'>Negative Syntax Test</em>
+            <span property='rdfs:comment'><p>A type of test specifically for validation testing. Validation tests are not required to have an associated result, only an action. A Negative Validation Test is passed when a processor validates the input and finds one or more errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeEvaluationTest</dt>
+          <dd about='csvwt:NegativeEvaluationTest'>
+            <em property='rdfs:label'>Positive Evaluation Test</em>
+            <span property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> results in the error identified by the literal value of <code>mf:result</code>. The specifics of invoking test, including the interpretation of options (and other input files are specified through sub-class.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveEvaluationTest</dt>
+          <dd about='csvwt:PositiveEvaluationTest'>
+            <em property='rdfs:label'>Positive Evaluation Test</em>
+            <span property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> exactly matches the output file specified as <code>mf:result</code> using the comparison defined in another class. The specifics of invoking test, including the interpretation of options and other input files are specified through a sub-class.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:PositiveValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveValidationTest</dt>
+          <dd about='csvwt:PositiveValidationTest'>
+            <em property='rdfs:label'>Positive Validation Test</em>
+            <span property='rdfs:comment'><p>A type of test specifically for validation testing. Validation tests are not required to have an associated result, only an action. A Positive Validation Test is passed when a processor validates the input and finds no validation errors.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+          </dd>
+          <dt about='csvwt:Option' property='rdfs:label' typeof='rdfs:Class'>csvwt:Option</dt>
+          <dd about='csvwt:Option'>
+            <em property='rdfs:label'>Processor Options</em>
+            <span property='rdfs:comment'><p>Options passed to the test runner to affect invocation of the appropriate API method.</p></span>
+          </dd>
+          <dt about='csvwt:Test' property='rdfs:label' typeof='rdfs:Class'>csvwt:Test</dt>
+          <dd about='csvwt:Test'>
+            <em property='rdfs:label'>Superclass of all CSVW tests</em>
+            <span property='rdfs:comment'><p>All CSVW tests have an input file referenced using <code>mf:action</code>. Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> . Other tests may take different inputs and options as defined for each test class.</p></span>
+            <div>
+              <strong>
+                subClassOf:
+              </strong>
+              <ul>
+                <li>
+                  <code property='rdfs:subClassOf' resource='mf:ManifestEntry'>mf:ManifestEntry</code>
+                </li>
+                <li>
+                  <code property='rdfs:subClassOf' resource='rdft:Test'>rdft:Test</code>
+                </li>
+              </ul>
+            </div>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h3 id='properties'>Properties</h3>
+        <dl>
+          <dt about='csvwt:httpLink' property='rdfs:label' typeof='rdf:Property'>csvwt:httpLink</dt>
+          <dd about='csvwt:httpLink'>
+            <em property='rdfs:label'>HTTP link</em>
+            <span property='rdfs:comment'><p>An HTTP Link header to be added to the result of requesting the input file.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+          <dt about='csvwt:httpStatus' property='rdfs:label' typeof='rdf:Property'>csvwt:httpStatus</dt>
+          <dd about='csvwt:httpStatus'>
+            <em property='rdfs:label'>HTTP status</em>
+            <span property='rdfs:comment'><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+          <dt about='csvwt:metadata' property='rdfs:label' typeof='rdf:Property'>csvwt:metadata</dt>
+          <dd about='csvwt:metadata'>
+            <em property='rdfs:label'>Metadata</em>
+            <span property='rdfs:comment'><p>URL of User supplied metadata.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:anyUri'>xsd:anyUri</code>
+            </div>
+          </dd>
+          <dt about='csvwt:minimal' property='rdfs:label' typeof='rdf:Property'>csvwt:minimal</dt>
+          <dd about='csvwt:minimal'>
+            <em property='rdfs:label'>Minimal</em>
+            <span property='rdfs:comment'><p>Generate minimal vs. standard output.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+          <dt about='csvwt:noProv' property='rdfs:label' typeof='rdf:Property'>csvwt:noProv</dt>
+          <dd about='csvwt:noProv'>
+            <em property='rdfs:label'>No Provenance</em>
+            <span property='rdfs:comment'><p>Processor should run without generating provenance triples.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+          <dt about='csvwt:base' property='rdfs:label' typeof='rdf:Property'>csvwt:base</dt>
+          <dd about='csvwt:base'>
+            <em property='rdfs:label'>base</em>
+            <span property='rdfs:comment'><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+            </div>
+          </dd>
+          <dt about='csvwt:contentType' property='rdfs:label' typeof='rdf:Property'>csvwt:contentType</dt>
+          <dd about='csvwt:contentType'>
+            <em property='rdfs:label'>content type</em>
+            <span property='rdfs:comment'><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+          <dt about='csvwt:implicit' property='rdfs:label' typeof='rdf:Property'>csvwt:implicit</dt>
+          <dd about='csvwt:implicit'>
+            <em property='rdfs:label'>implicit</em>
+            <span property='rdfs:comment'><p>Implicit input files</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+            </div>
+          </dd>
+          <dt about='csvwt:option' property='rdfs:label' typeof='rdf:Property'>csvwt:option</dt>
+          <dd about='csvwt:option'>
+            <em property='rdfs:label'>option</em>
+            <span property='rdfs:comment'><p>Options affecting processing</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='csvwt:Option'>csvwt:Option</code>
+            </div>
+          </dd>
+          <dt about='csvwt:redirectTo' property='rdfs:label' typeof='rdf:Property'>csvwt:redirectTo</dt>
+          <dd about='csvwt:redirectTo'>
+            <em property='rdfs:label'>redirect to</em>
+            <span property='rdfs:comment'><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p></span>
+            <div>
+              <strong>
+                domain:
+              </strong>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+            </div>
+            <div>
+              <strong>
+                range:
+              </strong>
+              <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+            </div>
+          </dd>
+        </dl>
+      </section>
+    </section>
     <footer>
-      <span property='dc:publisher'>W3C Data on the Web Working Group</span>
+      <span property='dc:publisher'>W3C CSV on the Web Working Group</span>
     </footer>
   </body>
 </html>

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html prefix='csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#'>
+  <head>
+    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
+    <link href='http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css' rel='stylesheet' type='text/css'>
+    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js' type='text/javascript'></script>
+    <script src='http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js' type='text/javascript'></script>
+    <script src='http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js' type='text/javascript'></script>
+    <style>
+      dd code {display: inline;}
+      footer {text-align: center;}
+    </style>
+    <title>
+      CSVW Test Vocabulary
+    </title>
+  </head>
+  <body resource='http://w3c.github.io/csvw/tests/vocab#' role='document'>
+    <meta property='dc:creator' value='Gregg Kellogg'>
+    <link href='http://w3c.github.io/csvw/tests/vocab#' property='dc:identifier'>
+    <nav class='navbar' role='navigation'>
+      <div class='container-fluid'>
+        <div class='navbar-header'>
+          <button class='navbar-toggle' type='button'>
+            <span class='sr-only'>Toggle Navigation</span>
+            <span class='icon-bar'></span>
+            <span class='icon-bar'></span>
+            <span class='icon-bar'></span>
+          </button>
+          <a class='navbar-brand' href='index.html'>
+            CSVW Test Suite
+          </a>
+        </div>
+        <ul class='nav navbar-nav'>
+          <li>
+            <a href='index.html'>
+              <span class='icon-beer'></span>
+              Test Suite
+            </a>
+          </li>
+          <li>
+            <a href='vocab.html'>
+              <span class='icon-beer'></span>
+              Test Vocabulary
+            </a>
+          </li>
+          <li class='dropdown'>
+            <a class='dropdown-toggle' data-toggle='dropdown' href='#'>
+              <span class='icon-folder-open'></span>
+              Specifications
+              <b class='caret'></b>
+            </a>
+            <ul class='dropdown-menu'>
+              <li class='nav-header'>
+                <strong>
+                  Latest
+                </strong>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/model/'>
+                  Model for Tabular Data and Metadata on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/metadata/'>
+                  Metadata Vocabulary for Tabular Data
+                </a>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/csv2json/'>
+                  Generating JSON from Tabular Data on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/csv2rdf/'>
+                  Generating RDF from Tabular Data on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/ns/'>
+                  Tabular Data Namespace
+                </a>
+              </li>
+              <li>
+                <a href='http://w3c.github.io/csvw/use-cases-and-requirements/'>
+                  Use Cases and Requirements
+                </a>
+              </li>
+              <li class='divider'></li>
+              <li class='nav-header'>
+                <strong>
+                  Published Documents
+                </strong>
+              </li>
+              <li>
+                <a href='http://www.w3.org/TR/tabular-data-model/'>
+                  Model for Tabular Data and Metadata on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://www.w3.org/TR/tabular-metadata/'>
+                  Metadata Vocabulary for Tabular Data
+                </a>
+              </li>
+              <li>
+                <a href='http://www.w3.org/TR/csv2json/'>
+                  Generating JSON from Tabular Data on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://www.w3.org/TR/csv2rdf/'>
+                  Generating RDF from Tabular Data on the Web
+                </a>
+              </li>
+              <li>
+                <a href='http://www.w3.org/ns/csvw/'>
+                  Tabular Data Namespace
+                </a>
+              </li>
+              <li>
+                <a href='http://www.w3.org/TR/csvw-ucr/'>
+                  Use Cases and Requirements
+                </a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <div class='hero-unit'>
+      <h1 property='dc:title'>CSVW Test Vocabulary</h1>
+      <p property='dc:description rdfs:comment'>Test case manifest vocabulary extensions</p>
+    </div>
+    <div class='container'>
+      <div class='row'>
+        <h2 class='span12' id='classes' style='text-align: center;'>
+          Test Case Classes
+        </h2>
+        <p>This vocabulary extends the standard <a href="http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#">RDF Test Vocabulary</a> with CSVW-specific tests.</p>
+      </div>
+      <div class='row'>
+        <section class='offset2 span8'>
+          <dl>
+            <dt about='csvwt:CsvSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvSparqlTest</dt>
+            <dd about='csvwt:CsvSparqlTest'>
+              <em property='rdfs:label'>CSV SPARQL Test</em>
+              <p property='rdfs:comment'><p>A <code>CsvSparqlTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:CsvValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvValidationTest</dt>
+            <dd about='csvwt:CsvValidationTest'>
+              <em property='rdfs:label'>CSV Validation Test</em>
+              <p property='rdfs:comment'><p>A <code>CsvValidationTest</code> takes an input file(<code>mf:accept</code>) in text/csv format to produce a JSON representation of the <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model">annotated tabular data model</a> as defined in [[csvw-test-suite]]. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:CsvToJsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToJsonTest</dt>
+            <dd about='csvwt:CsvToJsonTest'>
+              <em property='rdfs:label'>CSV to JSON Test</em>
+              <p property='rdfs:comment'><p>A <code>CsvToJsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response. The expected results are compared using JSON object comparison with the processor output.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:CsvToRdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:CsvToRdfTest</dt>
+            <dd about='csvwt:CsvToRdfTest'>
+              <em property='rdfs:label'>CSV to RDF Test</em>
+              <p property='rdfs:comment'><p>A <code>CsvToRdfTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:ManifestValidationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:ManifestValidationTest</dt>
+            <dd about='csvwt:ManifestValidationTest'>
+              <em property='rdfs:label'>Manifest Validation Test</em>
+              <p property='rdfs:comment'><p>A <code>ManifestValidationTest</code> takes an input file(<code>mf:accept</code>) in application/csvm+json format to produce a JSON representation of the <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model">annotated tabular data model</a> as defined in [[csvw-test-suite]]. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:MetadataSparqlTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:MetadataSparqlTest</dt>
+            <dd about='csvwt:MetadataSparqlTest'>
+              <em property='rdfs:label'>Metadata SPARQL Test</em>
+              <p property='rdfs:comment'><p>A <code>MetadataSparqlTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which used as the default graph of a SPARQL <code>ASK</code> query contained in <code>mf:result</code>. The test entry MAY use <code>:implicit</code> files, have user-specified <code>:metadata</code>, and have a <code>:httpLink</code> header defining a <code>describedBy</code> relationship. Test Processors SHOULD act as if the file referenced via <code>mf:action</code> is returned using such a link header if it is not included in the HTTP response.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:Metadata2JsonTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2JsonTest</dt>
+            <dd about='csvwt:Metadata2JsonTest'>
+              <em property='rdfs:label'>Metadata to JSON Test</em>
+              <p property='rdfs:comment'><p>A <code>Metadata2JsonTest</code> takes an input file (<code>mf:accept</code>) in text/csv format to produce a an JSON file. The test entry MAY use <code>:implicit</code> files. The expected results are compared using JSON object comparison with the processor output.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:Metadata2RdfTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:Metadata2RdfTest</dt>
+            <dd about='csvwt:Metadata2RdfTest'>
+              <em property='rdfs:label'>Metadata to RDF Test</em>
+              <p property='rdfs:comment'><p>A <code>Metadata2RdfTest</code> takes an input file (<code>mf:accept</code>) in application/csvm+json format to produce a an RDF graph which is <a href="http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism">isomorphic</a> to the graph generated from the result file (<code>mf:result</code>) (see [[RDF-CONCEPTS]]). The test entry MAY use <code>:implicit</code> files.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:PositiveEvaluationTest'>csvwt:PositiveEvaluationTest</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:NegativeSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeSyntaxTest</dt>
+            <dd about='csvwt:NegativeSyntaxTest'>
+              <em property='rdfs:label'>Negative Syntax Test</em>
+              <p property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:NegativeEvaluationTest</dt>
+            <dd about='csvwt:NegativeEvaluationTest'>
+              <em property='rdfs:label'>Positive Evaluation Test</em>
+              <p property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> results in the error identified by the literal value of <code>mf:result</code>. The specifics of invoking test, including the interpretation of options (and other input files are specified through sub-class.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveEvaluationTest</dt>
+            <dd about='csvwt:PositiveEvaluationTest'>
+              <em property='rdfs:label'>Positive Evaluation Test</em>
+              <p property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> exactly matches the output file specified as <code>mf:result</code> using the comparison defined in another class. The specifics of invoking test, including the interpretation of options and other input files are specified through a sub-class.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:PositiveSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>csvwt:PositiveSyntaxTest</dt>
+            <dd about='csvwt:PositiveSyntaxTest'>
+              <em property='rdfs:label'>Positive Syntax Test</em>
+              <p property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='csvwt:Test'>csvwt:Test</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:Option' property='rdfs:label' typeof='rdfs:Class'>csvwt:Option</dt>
+            <dd about='csvwt:Option'>
+              <em property='rdfs:label'>Processor Options</em>
+              <p property='rdfs:comment'><p>Options passed to the test runner to affect invocation of the appropriate API method.</p></p>
+            </dd>
+            <dt about='csvwt:Test' property='rdfs:label' typeof='rdfs:Class'>csvwt:Test</dt>
+            <dd about='csvwt:Test'>
+              <em property='rdfs:label'>Superclass of all CSVW tests</em>
+              <p property='rdfs:comment'><p>All CSVW tests have an input file referenced using <code>mf:action</code>. Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> . Other tests may take different inputs and options as defined for each test class.</p>
+              <div>
+                <strong>
+                  subClassOf:
+                </strong>
+                <code property='rdfs:subClassOf' resource='mf:ManifestEntry'>mf:ManifestEntry</code>
+              </div></p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+      <div class='row'>
+        <h2 class='span12' id='classes' style='text-align: center;'>
+          Test Case Properties
+        </h2>
+      </div>
+      <div class='row'>
+        <section class='offset2 span8'>
+          <dl>
+            <dt about='csvwt:httpLink' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:httpLink'>
+              <em property='rdfs:label'>HTTP link</em>
+              <p property='rdfs:comment'><p>An HTTP Link header to be added to the result of requesting the input file.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:httpStatus' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:httpStatus'>
+              <em property='rdfs:label'>HTTP status</em>
+              <p property='rdfs:comment'><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:metadata' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:metadata'>
+              <em property='rdfs:label'>Metadata</em>
+              <p property='rdfs:comment'><p>URL of User supplied metadata.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:anyUri'>xsd:anyUri</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:minimal' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:minimal'>
+              <em property='rdfs:label'>Minimal</em>
+              <p property='rdfs:comment'><p>Generate minimal vs. standard output.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:noProv' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:noProv'>
+              <em property='rdfs:label'>No Provenance</em>
+              <p property='rdfs:comment'><p>Processor should run without generating provenance triples.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:base' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:base'>
+              <em property='rdfs:label'>base</em>
+              <p property='rdfs:comment'><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:contentType' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:contentType'>
+              <em property='rdfs:label'>content type</em>
+              <p property='rdfs:comment'><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:implicit' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:implicit'>
+              <em property='rdfs:label'>implicit</em>
+              <p property='rdfs:comment'><p>Implicit input files</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:option' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:option'>
+              <em property='rdfs:label'>option</em>
+              <p property='rdfs:comment'><p>Options affecting processing</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='csvwt:Option'>csvwt:Option</code>
+              </div></p>
+            </dd>
+            <dt about='csvwt:redirectTo' property='rdfs:label' typeof='rdf:Property'></dt>
+            <dd about='csvwt:redirectTo'>
+              <em property='rdfs:label'>redirect to</em>
+              <p property='rdfs:comment'><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p>
+              <div>
+                <strong>
+                  domain:
+                </strong>
+                <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
+              </div>
+              <div>
+                <strong>
+                  range:
+                </strong>
+                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+              </div></p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </div>
+    <footer>
+      <span property='dc:publisher'>W3C Data on the Web Working Group</span>
+    </footer>
+  </body>
+</html>

--- a/tests/vocab.html
+++ b/tests/vocab.html
@@ -259,7 +259,6 @@
                 domain:
               </strong>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
               <strong>
@@ -276,7 +275,6 @@
               <strong>
                 domain:
               </strong>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
@@ -295,7 +293,6 @@
                 domain:
               </strong>
               <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
-              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
             </div>
             <div>
               <strong>
@@ -312,7 +309,6 @@
               <strong>
                 domain:
               </strong>
-              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
               <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
             </div>
             <div>
@@ -331,7 +327,6 @@
                 domain:
               </strong>
               <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
-              <code property='rdfs:domain' resource='csvwt:Option'>csvwt:Option</code>
             </div>
             <div>
               <strong>
@@ -348,7 +343,6 @@
               <strong>
                 domain:
               </strong>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
@@ -367,7 +361,6 @@
                 domain:
               </strong>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
               <strong>
@@ -384,7 +377,6 @@
               <strong>
                 domain:
               </strong>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
@@ -403,7 +395,6 @@
                 domain:
               </strong>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>
               <strong>
@@ -420,7 +411,6 @@
               <strong>
                 domain:
               </strong>
-              <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
               <code property='rdfs:domain' resource='csvwt:Test'>csvwt:Test</code>
             </div>
             <div>

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -1,0 +1,212 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "csvw": "http://www.w3.org/ns/csvw#",
+    "csvwt": "http://w3c.github.io/csvw/tests/vocab#",
+    "dc:identifier": {
+      "@type": "@id"
+    },
+    "rdfs:subClassOf": {
+      "@type": "@id"
+    },
+    "rdfs:domain": {
+      "@type": "@id"
+    },
+    "rdfs:range": {
+      "@type": "@id"
+    }
+  },
+  "@graph": [
+    {
+      "@id": "http://w3c.github.io/csvw/tests/vocab#",
+      "dc:creator": "Gregg Kellogg",
+      "dc:date": "2015-01-05",
+      "dc:description": "Test case manifest vocabulary extensions",
+      "dc:identifier": "http://w3c.github.io/csvw/tests/vocab#",
+      "dc:publisher": "W3C Data on the Web Working Group",
+      "dc:title": "CSVW Test Vocabulary",
+      "rdfs:comment": "Test case manifest vocabulary extensions"
+    },
+    {
+      "@id": "csvwt:CsvSparqlTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvSparqlTest` takes an input file (`mf:accept`) in text/csv format to produce a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
+      "rdfs:label": "CSV SPARQL Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:CsvToJsonTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvToJsonTest` takes an input file (`mf:accept`) in text/csv format to produce a an JSON file. The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response. The expected results are compared using JSON object comparison with the processor output.",
+      "rdfs:label": "CSV to JSON Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:CsvToRdfTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvToRdfTest` takes an input file (`mf:accept`) in text/csv format to produce a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`) (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
+      "rdfs:label": "CSV to RDF Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:CsvValidationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvValidationTest` takes an input file(`mf:accept`) in text/csv format to produce a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model) as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files. The expected results are compared using JSON object comparison with the processor output.",
+      "rdfs:label": "CSV Validation Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:ManifestValidationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `ManifestValidationTest` takes an input file(`mf:accept`) in application/csvm+json format to produce a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model) as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files. The expected results are compared using JSON object comparison with the processor output.",
+      "rdfs:label": "Manifest Validation Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:Metadata2JsonTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `Metadata2JsonTest` takes an input file (`mf:accept`) in text/csv format to produce a an JSON file. The test entry MAY use `:implicit` files. The expected results are compared using JSON object comparison with the processor output.",
+      "rdfs:label": "Metadata to JSON Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:Metadata2RdfTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `Metadata2RdfTest` takes an input file (`mf:accept`) in application/csvm+json format to produce a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`) (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files.",
+      "rdfs:label": "Metadata to RDF Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:MetadataSparqlTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `MetadataSparqlTest` takes an input file (`mf:accept`) in application/csvm+json format to produce a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
+      "rdfs:label": "Metadata SPARQL Test",
+      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+    },
+    {
+      "@id": "csvwt:NegativeEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A Negative Evaluation test is successful when the result of processing the input file specified as `mf:action` results in the error identified by the literal value of `mf:result`. The specifics of invoking test, including the interpretation of options (and other input files are specified through sub-class.",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "csvwt:Test"
+    },
+    {
+      "@id": "csvwt:NegativeSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.",
+      "rdfs:label": "Negative Syntax Test",
+      "rdfs:subClassOf": "csvwt:Test"
+    },
+    {
+      "@id": "csvwt:Option",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "Options passed to the test runner to affect invocation of the appropriate API method.",
+      "rdfs:label": "Processor Options"
+    },
+    {
+      "@id": "csvwt:PositiveEvaluationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A Positive Evaluation test is successful when the result of processing the input file specified as `mf:action` exactly matches the output file specified as `mf:result` using the comparison defined in another class. The specifics of invoking test, including the interpretation of options and other input files are specified through a sub-class.",
+      "rdfs:label": "Positive Evaluation Test",
+      "rdfs:subClassOf": "csvwt:Test"
+    },
+    {
+      "@id": "csvwt:PositiveSyntaxTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.",
+      "rdfs:label": "Positive Syntax Test",
+      "rdfs:subClassOf": "csvwt:Test"
+    },
+    {
+      "@id": "csvwt:Test",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "All CSVW tests have an input file referenced using `mf:action`. Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` . Other tests may take different inputs and options as defined for each test class.",
+      "rdfs:label": "Superclass of all CSVW tests",
+      "rdfs:subClassOf": "mf:ManifestEntry"
+    },
+    {
+      "@id": "csvwt:base",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "base",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "csvwt:contentType",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "content type",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "csvwt:httpLink",
+      "@type": "rdf:Property",
+      "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "HTTP link",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "csvwt:httpStatus",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "HTTP status",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "csvwt:implicit",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Implicit input files",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "implicit",
+      "rdfs:range": "rdfs:Resource"
+    },
+    {
+      "@id": "csvwt:metadata",
+      "@type": "rdf:Property",
+      "rdfs:comment": "URL of User supplied metadata.",
+      "rdfs:domain": "csvwt:Option",
+      "rdfs:label": "Metadata",
+      "rdfs:range": "xsd:anyUri"
+    },
+    {
+      "@id": "csvwt:minimal",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Generate minimal vs. standard output.",
+      "rdfs:domain": "csvwt:Option",
+      "rdfs:label": "Minimal",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "csvwt:noProv",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Processor should run without generating provenance triples.",
+      "rdfs:domain": "csvwt:Option",
+      "rdfs:label": "No Provenance",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "csvwt:option",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Options affecting processing",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "option",
+      "rdfs:range": "csvwt:Option"
+    },
+    {
+      "@id": "csvwt:redirectTo",
+      "@type": "rdf:Property",
+      "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
+      "rdfs:domain": "csvwt:Test",
+      "rdfs:label": "redirect to",
+      "rdfs:range": "xsd:boolean"
+    }
+  ]
+}

--- a/tests/vocab.jsonld
+++ b/tests/vocab.jsonld
@@ -1,12 +1,13 @@
 {
   "@context": {
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "dc": "http://purl.org/dc/elements/1.1/",
-    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
     "csvw": "http://www.w3.org/ns/csvw#",
     "csvwt": "http://w3c.github.io/csvw/tests/vocab#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
     "dc:identifier": {
       "@type": "@id"
     },
@@ -24,19 +25,36 @@
     {
       "@id": "http://w3c.github.io/csvw/tests/vocab#",
       "dc:creator": "Gregg Kellogg",
-      "dc:date": "2015-01-05",
-      "dc:description": "Test case manifest vocabulary extensions",
+      "dc:date": "2015-03-19",
+      "dc:description": "\n    This is a vocabulary document used to define classes and properties used in\n    [CSVW Test Cases](http://w3c.github.io/csvw/tests/) and associated test manifests.\n  ",
       "dc:identifier": "http://w3c.github.io/csvw/tests/vocab#",
-      "dc:publisher": "W3C Data on the Web Working Group",
+      "dc:publisher": "W3C CSV on the Web Working Group",
       "dc:title": "CSVW Test Vocabulary",
-      "rdfs:comment": "Test case manifest vocabulary extensions"
+      "rdfs:comment": "This is a vocabulary document used to define classes and properties used in [CSVW Test Cases](http://w3c.github.io/csvw/tests/) and associated test manifests."
+    },
+    {
+      "@id": "csvwt:CsvNegativeValidationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvNegativeValidationTest` takes an input file(`mf:accept`) in text/csv format and validates it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.",
+      "rdfs:label": "CSV Negative Validation Test",
+      "rdfs:subClassOf": "csvwt:NegativeValidationTest"
+    },
+    {
+      "@id": "csvwt:CsvPositiveValidationTest",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A `CsvPositiveValidationTest` takes an input file(`mf:accept`) in text/csv format and validates it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.",
+      "rdfs:label": "CSV Positive Validation Test",
+      "rdfs:subClassOf": "csvwt:PositiveValidationTest"
     },
     {
       "@id": "csvwt:CsvSparqlTest",
       "@type": "rdfs:Class",
       "rdfs:comment": "A `CsvSparqlTest` takes an input file (`mf:accept`) in text/csv format to produce a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
       "rdfs:label": "CSV SPARQL Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:subClassOf": [
+        "csvwt:PositiveEvaluationTest",
+        "mf:QueryEvaluationTest"
+      ]
     },
     {
       "@id": "csvwt:CsvToJsonTest",
@@ -50,21 +68,24 @@
       "@type": "rdfs:Class",
       "rdfs:comment": "A `CsvToRdfTest` takes an input file (`mf:accept`) in text/csv format to produce a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`) (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
       "rdfs:label": "CSV to RDF Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:subClassOf": [
+        "csvwt:PositiveEvaluationTest",
+        "rdft:TestEval"
+      ]
     },
     {
-      "@id": "csvwt:CsvValidationTest",
+      "@id": "csvwt:ManifestNegativeValidationTest",
       "@type": "rdfs:Class",
-      "rdfs:comment": "A `CsvValidationTest` takes an input file(`mf:accept`) in text/csv format to produce a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model) as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files. The expected results are compared using JSON object comparison with the processor output.",
-      "rdfs:label": "CSV Validation Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:comment": "A `ManifestNegativeValidationTest` takes an input file(`mf:accept`) in application/csvm+json format and validates it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.",
+      "rdfs:label": "Manifest Negative Validation Test",
+      "rdfs:subClassOf": "csvwt:Test"
     },
     {
-      "@id": "csvwt:ManifestValidationTest",
+      "@id": "csvwt:ManifestPositiveValidationTest",
       "@type": "rdfs:Class",
-      "rdfs:comment": "A `ManifestValidationTest` takes an input file(`mf:accept`) in application/csvm+json format to produce a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model) as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files. The expected results are compared using JSON object comparison with the processor output.",
-      "rdfs:label": "Manifest Validation Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:comment": "A `ManifestPositiveValidationTest` takes an input file(`mf:accept`) in application/csvm+json format and validates it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.",
+      "rdfs:label": "Manifest Positive Validation Test",
+      "rdfs:subClassOf": "csvwt:Test"
     },
     {
       "@id": "csvwt:Metadata2JsonTest",
@@ -78,14 +99,20 @@
       "@type": "rdfs:Class",
       "rdfs:comment": "A `Metadata2RdfTest` takes an input file (`mf:accept`) in application/csvm+json format to produce a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`) (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files.",
       "rdfs:label": "Metadata to RDF Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:subClassOf": [
+        "csvwt:PositiveEvaluationTest",
+        "rdft:TestEval"
+      ]
     },
     {
       "@id": "csvwt:MetadataSparqlTest",
       "@type": "rdfs:Class",
       "rdfs:comment": "A `MetadataSparqlTest` takes an input file (`mf:accept`) in application/csvm+json format to produce a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`, and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD act as if the file referenced via `mf:action` is returned using such a link header if it is not included in the HTTP response.",
       "rdfs:label": "Metadata SPARQL Test",
-      "rdfs:subClassOf": "csvwt:PositiveEvaluationTest"
+      "rdfs:subClassOf": [
+        "csvwt:PositiveEvaluationTest",
+        "mf:QueryEvaluationTest"
+      ]
     },
     {
       "@id": "csvwt:NegativeEvaluationTest",
@@ -95,9 +122,9 @@
       "rdfs:subClassOf": "csvwt:Test"
     },
     {
-      "@id": "csvwt:NegativeSyntaxTest",
+      "@id": "csvwt:NegativeValidationTest",
       "@type": "rdfs:Class",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.",
+      "rdfs:comment": "A type of test specifically for validation testing. Validation tests are not required to have an associated result, only an action. A Negative Validation Test is passed when a processor validates the input and finds one or more errors.",
       "rdfs:label": "Negative Syntax Test",
       "rdfs:subClassOf": "csvwt:Test"
     },
@@ -115,10 +142,10 @@
       "rdfs:subClassOf": "csvwt:Test"
     },
     {
-      "@id": "csvwt:PositiveSyntaxTest",
+      "@id": "csvwt:PositiveValidationTest",
       "@type": "rdfs:Class",
-      "rdfs:comment": "A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.",
-      "rdfs:label": "Positive Syntax Test",
+      "rdfs:comment": "A type of test specifically for validation testing. Validation tests are not required to have an associated result, only an action. A Positive Validation Test is passed when a processor validates the input and finds no validation errors.",
+      "rdfs:label": "Positive Validation Test",
       "rdfs:subClassOf": "csvwt:Test"
     },
     {
@@ -126,7 +153,10 @@
       "@type": "rdfs:Class",
       "rdfs:comment": "All CSVW tests have an input file referenced using `mf:action`. Positive and Negative Evaluation Tests also have a result file referenced using `mf:result` . Other tests may take different inputs and options as defined for each test class.",
       "rdfs:label": "Superclass of all CSVW tests",
-      "rdfs:subClassOf": "mf:ManifestEntry"
+      "rdfs:subClassOf": [
+        "mf:ManifestEntry",
+        "rdft:Test"
+      ]
     },
     {
       "@id": "csvwt:base",

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -181,7 +181,7 @@
 
 :noProv a rdf:Property;
   rdfs:label "No Provenance";
-  rdfs:comment "Processor should run without generating provenance triples.";
+  rdfs:comment "Processor should run without generating optional provenance information.";
   rdfs:domain :Option;
   rdfs:range xsd:boolean .
 

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -2,26 +2,35 @@
 # This vocabulary defines classes an properties which extend
 # the test-manifest vocabulary at <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest>.
 
-@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix dc:     <http://purl.org/dc/elements/1.1/> .
-@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
-@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 @prefix :       <http://w3c.github.io/csvw/tests/vocab#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix csvwt:  <http://w3c.github.io/csvw/tests/vocab#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdft:   <http://www.w3.org/ns/rdftest#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 
-: dc:title         "CSVW Test Vocabulary" ;
-  dc:creator       "Gregg Kellogg" ;
-  dc:publisher     "W3C Data on the Web Working Group" ;
-  dc:description   "Test case manifest vocabulary extensions" ;
-  rdfs:comment     "Test case manifest vocabulary extensions" ;
-  dc:date          "2015-01-05" ;
-  dc:identifier    : .
+: dc:title         "CSVW Test Vocabulary";
+  dc:creator       "Gregg Kellogg";
+  dc:publisher     "W3C CSV on the Web Working Group";
+  dc:description   """
+    This is a vocabulary document used to define classes and properties used in
+    [CSVW Test Cases](http://w3c.github.io/csvw/tests/) and associated test manifests.
+  """;
+  rdfs:comment     """
+  This is a vocabulary document used to define classes and properties used in
+  [CSVW Test Cases](http://w3c.github.io/csvw/tests/) and associated test manifests.
+  """;
+  dc:date          "2015-03-19";
+  dc:identifier    csvwt: .
 
 ## ---- Test Case Classes ---
 
-:Test a rdfs:Class ;
+:Test a rdfs:Class;
   rdfs:subClassOf mf:ManifestEntry;
-  rdfs:label "Superclass of all CSVW tests" ;
+  rdfs:label "Superclass of all CSVW tests";
+  rdfs:subClassOf rdft:Test;
   rdfs:comment """
     All CSVW tests have an input file referenced using `mf:action`. Positive
     and Negative Evaluation Tests also have a result file referenced using
@@ -29,9 +38,9 @@
     for each test class.
   """ .
 
-:PositiveEvaluationTest a rdfs:Class ;
-  rdfs:label "Positive Evaluation Test" ;
-  rdfs:subClassOf :Test ;
+:PositiveEvaluationTest a rdfs:Class;
+  rdfs:label "Positive Evaluation Test";
+  rdfs:subClassOf :Test;
   rdfs:comment """
     A Positive Evaluation test is successful when the result of processing the
     input file specified as `mf:action` exactly matches the output file
@@ -40,9 +49,9 @@
     other input files are specified through a sub-class.
   """ .
 
-:NegativeEvaluationTest a rdfs:Class ;
-  rdfs:label "Positive Evaluation Test" ;
-  rdfs:subClassOf :Test ;
+:NegativeEvaluationTest a rdfs:Class;
+  rdfs:label "Positive Evaluation Test";
+  rdfs:subClassOf :Test;
   rdfs:comment """
     A Negative Evaluation test is successful when the result of processing the
     input file specified as `mf:action` results in the error identified by the
@@ -51,26 +60,27 @@
     sub-class.
   """ .
 
-:PositiveSyntaxTest a rdfs:Class ;
-  rdfs:subClassOf :Test ;
-  rdfs:label "Positive Syntax Test" ;
+:PositiveValidationTest a rdfs:Class;
+  rdfs:subClassOf :Test;
+  rdfs:label "Positive Validation Test";
   rdfs:comment """
-    A type of test specifically for syntax testing.
-    Syntax tests are not required to have an associated result, only an action.
+    A type of test specifically for validation testing.
+    Validation tests are not required to have an associated result, only an action.
+    A Positive Validation Test is passed when a processor validates the input and finds no validation errors.
   """ .
 
-:NegativeSyntaxTest a rdfs:Class ;
-  rdfs:subClassOf :Test ;
-  rdfs:label "Negative Syntax Test" ;
+:NegativeValidationTest a rdfs:Class;
+  rdfs:subClassOf :Test;
+  rdfs:label "Negative Syntax Test";
   rdfs:comment """
-    A type of test specifically for syntax testing.
-    Syntax tests are not required to have an associated result, only an action.
-    Negative syntax tests are tests of which the result should be a parser error.
+    A type of test specifically for validation testing.
+    Validation tests are not required to have an associated result, only an action.
+    A Negative Validation Test is passed when a processor validates the input and finds one or more errors.
   """ .
 
-:CsvToRdfTest a rdfs:Class ;
-  rdfs:label "CSV to RDF Test" ;
-  rdfs:subClassOf :PositiveEvaluationTest;
+:CsvToRdfTest a rdfs:Class;
+  rdfs:label "CSV to RDF Test";
+  rdfs:subClassOf :PositiveEvaluationTest, rdft:TestEval;
   rdfs:comment """
     A `CsvToRdfTest` takes an input file (`mf:accept`) in text/csv format to produce
     a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`)
@@ -80,9 +90,9 @@
     is not included in the HTTP response.
   """ .
 
-:CsvSparqlTest a rdfs:Class ;
-  rdfs:label "CSV SPARQL Test" ;
-  rdfs:subClassOf :PositiveEvaluationTest;
+:CsvSparqlTest a rdfs:Class;
+  rdfs:label "CSV SPARQL Test";
+  rdfs:subClassOf :PositiveEvaluationTest, mf:QueryEvaluationTest;
   rdfs:comment """
     A `CsvSparqlTest` takes an input file (`mf:accept`) in text/csv format to produce
     a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`,
@@ -91,8 +101,8 @@
     is not included in the HTTP response.
   """ .
 
-:CsvToJsonTest a rdfs:Class ;
-  rdfs:label "CSV to JSON Test" ;
+:CsvToJsonTest a rdfs:Class;
+  rdfs:label "CSV to JSON Test";
   rdfs:subClassOf :PositiveEvaluationTest;
   rdfs:comment """
     A `CsvToJsonTest` takes an input file (`mf:accept`) in text/csv format to
@@ -104,18 +114,18 @@
     JSON object comparison with the processor output.
   """ .
 
-:Metadata2RdfTest a rdfs:Class ;
-  rdfs:label "Metadata to RDF Test" ;
-  rdfs:subClassOf :PositiveEvaluationTest;
+:Metadata2RdfTest a rdfs:Class;
+  rdfs:label "Metadata to RDF Test";
+  rdfs:subClassOf :PositiveEvaluationTest, rdft:TestEval;
   rdfs:comment """
     A `Metadata2RdfTest` takes an input file (`mf:accept`) in application/csvm+json format to produce
     a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`)
     (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files.
   """ .
 
-:MetadataSparqlTest a rdfs:Class ;
-  rdfs:label "Metadata SPARQL Test" ;
-  rdfs:subClassOf :PositiveEvaluationTest;
+:MetadataSparqlTest a rdfs:Class;
+  rdfs:label "Metadata SPARQL Test";
+  rdfs:subClassOf :PositiveEvaluationTest, mf:QueryEvaluationTest;
   rdfs:comment """
     A `MetadataSparqlTest` takes an input file (`mf:accept`) in application/csvm+json format to produce
     a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`,
@@ -124,8 +134,8 @@
     is not included in the HTTP response.
   """ .
 
-:Metadata2JsonTest a rdfs:Class ;
-  rdfs:label "Metadata to JSON Test" ;
+:Metadata2JsonTest a rdfs:Class;
+  rdfs:label "Metadata to JSON Test";
   rdfs:subClassOf :PositiveEvaluationTest;
   rdfs:comment """
     A `Metadata2JsonTest` takes an input file (`mf:accept`) in text/csv format to produce
@@ -133,107 +143,109 @@
     The expected results are compared using JSON object comparison with the processor output.
   """ .
 
-:CsvValidationTest a rdfs:Class ;
-  rdfs:subClassOf :PositiveEvaluationTest ;
-  rdfs:label "CSV Validation Test" ;
+:CsvPositiveValidationTest a rdfs:Class;
+  rdfs:subClassOf :PositiveValidationTest;
+  rdfs:label "CSV Positive Validation Test";
   rdfs:comment """
-    A `CsvValidationTest` takes an input file(`mf:accept`) in text/csv format to produce
-    a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model)
-    as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files.
-    The expected results are compared using JSON object comparison with the processor output.
+    A `CsvPositiveValidationTest` takes an input file(`mf:accept`) in text/csv format and validates
+    it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.
   """ .
 
-:ManifestValidationTest a rdfs:Class ;
-  rdfs:subClassOf :PositiveEvaluationTest ;
-  rdfs:label "Manifest Validation Test" ;
+:ManifestPositiveValidationTest a rdfs:Class;
+  rdfs:subClassOf :Test;
+  rdfs:label "Manifest Positive Validation Test";
   rdfs:comment """
-    A `ManifestValidationTest` takes an input file(`mf:accept`) in application/csvm+json format to produce
-    a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model)
-    as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files.
-    The expected results are compared using JSON object comparison with the processor output.
+    A `ManifestPositiveValidationTest` takes an input file(`mf:accept`) in application/csvm+json format and validates
+    it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.
   """ .
 
-:Option a rdfs:Class ;
-  rdfs:label "Processor Options" ;
+:CsvNegativeValidationTest a rdfs:Class;
+  rdfs:subClassOf :NegativeValidationTest;
+  rdfs:label "CSV Negative Validation Test";
+  rdfs:comment """
+    A `CsvNegativeValidationTest` takes an input file(`mf:accept`) in text/csv format and validates
+    it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.
+  """ .
+
+:ManifestNegativeValidationTest a rdfs:Class;
+  rdfs:subClassOf :Test;
+  rdfs:label "Manifest Negative Validation Test";
+  rdfs:comment """
+    A `ManifestNegativeValidationTest` takes an input file(`mf:accept`) in application/csvm+json format and validates
+    it as described in the [tabular-metadata](http://w3c.github.io/csvw/metadata/) and finds no errors.
+  """ .
+
+:Option a rdfs:Class;
+  rdfs:label "Processor Options";
   rdfs:comment "Options passed to the test runner to affect invocation of the appropriate API method." .
 
-:noProv a rdf:Property ;
+:noProv a rdf:Property;
   rdfs:label "No Provenance";
-  rdfs:comment """
-    Processor should run without generating provenance triples.
-  """;
+  rdfs:comment "Processor should run without generating provenance triples.";
   rdfs:domain :Option;
   rdfs:range xsd:boolean .
 
-:minimal a rdf:Property ;
+:minimal a rdf:Property;
   rdfs:label "Minimal";
-  rdfs:comment """
-    Generate minimal vs. standard output.
-  """;
+  rdfs:comment "Generate minimal vs. standard output.";
   rdfs:domain :Option;
   rdfs:range xsd:boolean .
 
-:metadata a rdf:Property ;
+:metadata a rdf:Property;
   rdfs:label "Metadata";
-  rdfs:comment """
-    URL of User supplied metadata.
-  """;
+  rdfs:comment "URL of User supplied metadata.";
   rdfs:domain :Option;
   rdfs:range xsd:anyUri .
 
 ## ---- Property declarations for each test ----
 
-:implicit a rdf:Property ;
+:implicit a rdf:Property;
   rdfs:label "implicit";
-  rdfs:comment "Implicit input files" ;
-  rdfs:domain	 :Test ;
+  rdfs:comment "Implicit input files";
+  rdfs:domain	 :Test;
   rdfs:range   rdfs:Resource .
 
-:option a rdf:Property ;
+:option a rdf:Property;
   rdfs:label "option";
-  rdfs:comment "Options affecting processing" ;
-  rdfs:domain	 :Test ;
+  rdfs:comment "Options affecting processing";
+  rdfs:domain	 :Test;
   rdfs:range   :Option .
 
-:base a rdf:Property ;
+:base a rdf:Property;
   rdfs:label "base";
   rdfs:comment """
     The base IRI to use when expanding or compacting the document.
     If set, this overrides the input document's IRI.
-  """ ;
-  rdfs:domain	 :Test ;
+  """;
+  rdfs:domain	 :Test;
   rdfs:range   rdfs:Resource .
 
-:contentType a rdf:Property ;
+:contentType a rdf:Property;
   rdfs:label "content type";
-  rdfs:comment """
-    The HTTP Content-Type used for the input file, in case it is a non-registered type.
-    """ ;
-  rdfs:domain	 :Test ;
+  rdfs:comment "The HTTP Content-Type used for the input file, in case it is a non-registered type.";
+  rdfs:domain	 :Test;
   rdfs:range   xsd:boolean .
 
-:redirectTo a rdf:Property ;
+:redirectTo a rdf:Property;
   rdfs:label "redirect to";
   rdfs:comment """
     The location of a URL for redirection. A request made of the input file must be redirected
     to the designated URL.
-    """ ;
-  rdfs:domain	 :Test ;
+    """;
+  rdfs:domain	 :Test;
   rdfs:range   xsd:boolean .
 
-:httpStatus a rdf:Property ;
+:httpStatus a rdf:Property;
   rdfs:label "HTTP status";
   rdfs:comment """
     The HTTP status code that must be returned when the input file is requested. This
     is typically used along with the `redirectTo` property.
-    """ ;
-  rdfs:domain	 :Test ;
+    """;
+  rdfs:domain	 :Test;
   rdfs:range   xsd:boolean .
 
-:httpLink a rdf:Property ;
+:httpLink a rdf:Property;
   rdfs:label "HTTP link";
-  rdfs:comment """
-    An HTTP Link header to be added to the result of requesting the input file.
-    """ ;
-  rdfs:domain	 :Test ;
+  rdfs:comment "An HTTP Link header to be added to the result of requesting the input file.";
+  rdfs:domain	 :Test;
   rdfs:range   xsd:boolean .

--- a/tests/vocab.ttl
+++ b/tests/vocab.ttl
@@ -9,11 +9,11 @@
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
 @prefix :       <http://w3c.github.io/csvw/tests/vocab#> .
 
-: rdfs:comment     "Manifest vocabulary for CSVW test cases" ;
+: dc:title         "CSVW Test Vocabulary" ;
   dc:creator       "Gregg Kellogg" ;
   dc:publisher     "W3C Data on the Web Working Group" ;
-  dc:title         "Test case manifest vocabulary extensions" ;
   dc:description   "Test case manifest vocabulary extensions" ;
+  rdfs:comment     "Test case manifest vocabulary extensions" ;
   dc:date          "2015-01-05" ;
   dc:identifier    : .
 
@@ -108,7 +108,7 @@
   rdfs:label "Metadata to RDF Test" ;
   rdfs:subClassOf :PositiveEvaluationTest;
   rdfs:comment """
-    A `Metadata2RdfTest` takes an input file (`mf:accept`) in application/ld+json format to produce
+    A `Metadata2RdfTest` takes an input file (`mf:accept`) in application/csvm+json format to produce
     a an RDF graph which is [isomorphic](http://www.w3.org/TR/rdf11-concepts/#graph-isomorphism) to the graph generated from the result file (`mf:result`)
     (see [[RDF-CONCEPTS]]). The test entry MAY use `:implicit` files.
   """ .
@@ -117,7 +117,7 @@
   rdfs:label "Metadata SPARQL Test" ;
   rdfs:subClassOf :PositiveEvaluationTest;
   rdfs:comment """
-    A `MetadataSparqlTest` takes an input file (`mf:accept`) in application/ld+json format to produce
+    A `MetadataSparqlTest` takes an input file (`mf:accept`) in application/csvm+json format to produce
     a an RDF graph which used as the default graph of a SPARQL `ASK` query contained in `mf:result`. The test entry MAY use `:implicit` files, have user-specified `:metadata`,
     and have a `:httpLink` header defining a `describedBy` relationship. Test Processors SHOULD
     act as if the file referenced via `mf:action` is returned using such a link header if it
@@ -133,24 +133,52 @@
     The expected results are compared using JSON object comparison with the processor output.
   """ .
 
+:CsvValidationTest a rdfs:Class ;
+  rdfs:subClassOf :PositiveEvaluationTest ;
+  rdfs:label "CSV Validation Test" ;
+  rdfs:comment """
+    A `CsvValidationTest` takes an input file(`mf:accept`) in text/csv format to produce
+    a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model)
+    as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files.
+    The expected results are compared using JSON object comparison with the processor output.
+  """ .
+
+:ManifestValidationTest a rdfs:Class ;
+  rdfs:subClassOf :PositiveEvaluationTest ;
+  rdfs:label "Manifest Validation Test" ;
+  rdfs:comment """
+    A `ManifestValidationTest` takes an input file(`mf:accept`) in application/csvm+json format to produce
+    a JSON representation of the [annotated tabular data model](http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model)
+    as defined in [[csvw-test-suite]]. The test entry MAY use `:implicit` files.
+    The expected results are compared using JSON object comparison with the processor output.
+  """ .
+
 :Option a rdfs:Class ;
   rdfs:label "Processor Options" ;
   rdfs:comment "Options passed to the test runner to affect invocation of the appropriate API method." .
 
-:noProv a rdf:Property
+:noProv a rdf:Property ;
   rdfs:label "No Provenance";
   rdfs:comment """
-    Processor should run without generating provenance triples
+    Processor should run without generating provenance triples.
   """;
-  rdfs:domain :Option
+  rdfs:domain :Option;
   rdfs:range xsd:boolean .
 
-:metadata a rdf:Property
+:minimal a rdf:Property ;
+  rdfs:label "Minimal";
+  rdfs:comment """
+    Generate minimal vs. standard output.
+  """;
+  rdfs:domain :Option;
+  rdfs:range xsd:boolean .
+
+:metadata a rdf:Property ;
   rdfs:label "Metadata";
   rdfs:comment """
     URL of User supplied metadata.
   """;
-  rdfs:domain :Option
+  rdfs:domain :Option;
   rdfs:range xsd:anyUri .
 
 ## ---- Property declarations for each test ----

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "csvw": "http://www.w3.org/ns/csvw#",
+    "csvwt": "http://w3c.github.io/csvw/tests/vocab#",
+    "dc:identifier": {"@type": "@id"},
+    "rdfs:subClassOf": {"@type": "@id"},
+    "rdfs:domain": {"@type": "@id"},
+    "rdfs:range": {"@type": "@id"}
+  }
+}

--- a/tests/vocab_context.jsonld
+++ b/tests/vocab_context.jsonld
@@ -1,12 +1,14 @@
 {
   "@context": {
-    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "dc": "http://purl.org/dc/elements/1.1/",
-    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
     "csvw": "http://www.w3.org/ns/csvw#",
     "csvwt": "http://w3c.github.io/csvw/tests/vocab#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdft": "http://www.w3.org/ns/rdftest#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
     "dc:identifier": {"@type": "@id"},
     "rdfs:subClassOf": {"@type": "@id"},
     "rdfs:domain": {"@type": "@id"},

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,0 +1,138 @@
+!!! 5
+%html{:prefix => "csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#"}
+  %head
+    %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
+    %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0"}
+    %link{:rel => "stylesheet", :type => "text/css", :href => "http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"}
+    %script{:type => "text/javascript", :src => "http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"}
+    %script{:type => "text/javascript", :src => "http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"}
+    %script{:type => "text/javascript", :src => "http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"}
+    :css
+      dd code {display: inline;}
+      footer {text-align: center;}
+    %title
+      = ontology['dc:title']
+  %body{resource: ontology['@id'], role: :document}
+    %meta{property: "dc:creator", value: ontology["dc:creator"]}
+    %link{property: "dc:identifier", href: ontology["@id"]}
+    %nav.navbar{role: :navigation}
+      %div.container-fluid
+        %div.navbar-header
+          %button.navbar-toggle{type: "button"}
+            %span.sr-only="Toggle Navigation"
+            %span.icon-bar
+            %span.icon-bar
+            %span.icon-bar
+          %a.navbar-brand{:href => "index.html"}
+            CSVW Test Suite
+        %ul.nav.navbar-nav
+          %li
+            %a{:href => "index.html"}
+              %span.icon-beer
+              Test Suite
+          %li
+            %a{:href => "vocab.html"}
+              %span.icon-beer
+              Test Vocabulary
+          %li.dropdown
+            %a.dropdown-toggle{:href => "#", "data-toggle" => "dropdown"}
+              %span.icon-folder-open
+              Specifications
+              %b.caret
+            %ul.dropdown-menu
+              %li.nav-header
+                %strong
+                  Latest
+              %li
+                %a{:href => "http://w3c.github.io/csvw/model/"}
+                  Model for Tabular Data and Metadata on the Web
+              %li
+                %a{:href => "http://w3c.github.io/csvw/metadata/"}
+                  Metadata Vocabulary for Tabular Data
+              %li
+                %a{:href => "http://w3c.github.io/csvw/csv2json/"}
+                  Generating JSON from Tabular Data on the Web
+              %li
+                %a{:href => "http://w3c.github.io/csvw/csv2rdf/"}
+                  Generating RDF from Tabular Data on the Web
+              %li
+                %a{:href => "http://w3c.github.io/csvw/ns/"}
+                  Tabular Data Namespace
+              %li
+                %a{:href => "http://w3c.github.io/csvw/use-cases-and-requirements/"}
+                  Use Cases and Requirements
+              %li.divider
+              %li.nav-header
+                %strong
+                  Published Documents
+              %li
+                %a{:href => "http://www.w3.org/TR/tabular-data-model/"}
+                  Model for Tabular Data and Metadata on the Web
+              %li
+                %a{:href => "http://www.w3.org/TR/tabular-metadata/"}
+                  Metadata Vocabulary for Tabular Data
+              %li
+                %a{:href => "http://www.w3.org/TR/csv2json/"}
+                  Generating JSON from Tabular Data on the Web
+              %li
+                %a{:href => "http://www.w3.org/TR/csv2rdf/"}
+                  Generating RDF from Tabular Data on the Web
+              %li
+                %a{:href => "http://www.w3.org/ns/csvw/"}
+                  Tabular Data Namespace
+              %li
+                %a{:href => "http://www.w3.org/TR/csvw-ucr/"}
+                  Use Cases and Requirements
+    %div.hero-unit
+      %h1{:property => "dc:title"}<= ontology["dc:title"]
+      %p{:property => "dc:description rdfs:comment"}<=ontology["dc:description"]
+
+    %div.container
+      %div.row
+        %h2.span12#classes{:style => "text-align: center;"}
+          Test Case Classes
+        :markdown
+          This vocabulary extends the standard [RDF Test Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with CSVW-specific tests.
+      %div.row
+        %section.offset2.span8
+          %dl
+            - classes.each do |cls|
+              %dt{:about => cls['@id'], :typeof => cls['@type'], :property => "rdfs:label"}<~cls["@id"]
+              %dd{:about => cls['@id']}
+                %em{property: "rdfs:label"}<~cls["rdfs:label"]
+                %p{:property => "rdfs:comment"}<
+                  :markdown
+                    #{cls["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+                  - if cls["rdfs:subClassOf"]
+                    %div
+                      %strong
+                        subClassOf:
+                      %code{:property => "rdfs:subClassOf", :resource => cls["rdfs:subClassOf"]}
+                        = cls["rdfs:subClassOf"]
+      %div.row
+        %h2.span12#classes{:style => "text-align: center;"}
+          Test Case Properties
+      %div.row
+        %section.offset2.span8
+          %dl
+            - properties.each do |prop|
+              %dt{:about => prop['@id'], :typeof => prop['@type'], :property => "rdfs:label"}<~prop["@id"][ontology['@id'].length..-1]
+              %dd{:about => prop['@id']}
+                %em{property: "rdfs:label"}<~prop["rdfs:label"]
+                %p{:property => "rdfs:comment"}<
+                  :markdown
+                    #{prop["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+                  - if prop["rdfs:domain"]
+                    %div
+                      %strong
+                        domain:
+                      %code{:property => "rdfs:domain", :resource => prop["rdfs:domain"]}
+                        = prop["rdfs:domain"]
+                  - if prop["rdfs:range"]
+                    %div
+                      %strong
+                        range:
+                      %code{:property => "rdfs:range", :resource => prop["rdfs:range"]}
+                        = prop["rdfs:range"]
+    %footer
+      %span{:property => "dc:publisher"}<= ontology["dc:publisher"]

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -73,8 +73,6 @@
                           %code{property: "rdfs:domain", resource: e}=e
                   - else
                     %code{property: "rdfs:domain", resource: prop["rdfs:domain"]}=prop["rdfs:domain"]
-                  %code{property: "rdfs:domain", resource: prop["rdfs:domain"]}
-                    = Array(prop["rdfs:domain"]).to_sentence
               - if prop["rdfs:range"]
                 %div
                   %strong

--- a/tests/vocab_template.haml
+++ b/tests/vocab_template.haml
@@ -1,138 +1,90 @@
 !!! 5
-%html{:prefix => "csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#"}
+%html{lang: :en, prefix: "csvwt: http://w3c.github.io/csvw/tests/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest# rdft: http://www.w3.org/ns/rdftest#"}
   %head
-    %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
-    %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0"}
-    %link{:rel => "stylesheet", :type => "text/css", :href => "http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css"}
-    %script{:type => "text/javascript", :src => "http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"}
-    %script{:type => "text/javascript", :src => "http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"}
-    %script{:type => "text/javascript", :src => "http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"}
+    %meta{"http-equiv" => "Content-Type", content: "text/html;charset=utf-8"}
+    %meta{name: "viewport", content: "width=device-width, initial-scale=1.0"}
+    %link{rel: "stylesheet", type: "text/css", href: "http://www.w3.org/StyleSheets/TR/W3C-ED"}
     :css
+      body: {bacground-image: none;}
+      dt {margin-top: 2em;}
       dd code {display: inline;}
       footer {text-align: center;}
     %title
       = ontology['dc:title']
-  %body{resource: ontology['@id'], role: :document}
+  %body{resource: ontology['@id'], typeof: "owl:Ontology"}
     %meta{property: "dc:creator", value: ontology["dc:creator"]}
     %link{property: "dc:identifier", href: ontology["@id"]}
-    %nav.navbar{role: :navigation}
-      %div.container-fluid
-        %div.navbar-header
-          %button.navbar-toggle{type: "button"}
-            %span.sr-only="Toggle Navigation"
-            %span.icon-bar
-            %span.icon-bar
-            %span.icon-bar
-          %a.navbar-brand{:href => "index.html"}
-            CSVW Test Suite
-        %ul.nav.navbar-nav
-          %li
-            %a{:href => "index.html"}
-              %span.icon-beer
-              Test Suite
-          %li
-            %a{:href => "vocab.html"}
-              %span.icon-beer
-              Test Vocabulary
-          %li.dropdown
-            %a.dropdown-toggle{:href => "#", "data-toggle" => "dropdown"}
-              %span.icon-folder-open
-              Specifications
-              %b.caret
-            %ul.dropdown-menu
-              %li.nav-header
-                %strong
-                  Latest
-              %li
-                %a{:href => "http://w3c.github.io/csvw/model/"}
-                  Model for Tabular Data and Metadata on the Web
-              %li
-                %a{:href => "http://w3c.github.io/csvw/metadata/"}
-                  Metadata Vocabulary for Tabular Data
-              %li
-                %a{:href => "http://w3c.github.io/csvw/csv2json/"}
-                  Generating JSON from Tabular Data on the Web
-              %li
-                %a{:href => "http://w3c.github.io/csvw/csv2rdf/"}
-                  Generating RDF from Tabular Data on the Web
-              %li
-                %a{:href => "http://w3c.github.io/csvw/ns/"}
-                  Tabular Data Namespace
-              %li
-                %a{:href => "http://w3c.github.io/csvw/use-cases-and-requirements/"}
-                  Use Cases and Requirements
-              %li.divider
-              %li.nav-header
-                %strong
-                  Published Documents
-              %li
-                %a{:href => "http://www.w3.org/TR/tabular-data-model/"}
-                  Model for Tabular Data and Metadata on the Web
-              %li
-                %a{:href => "http://www.w3.org/TR/tabular-metadata/"}
-                  Metadata Vocabulary for Tabular Data
-              %li
-                %a{:href => "http://www.w3.org/TR/csv2json/"}
-                  Generating JSON from Tabular Data on the Web
-              %li
-                %a{:href => "http://www.w3.org/TR/csv2rdf/"}
-                  Generating RDF from Tabular Data on the Web
-              %li
-                %a{:href => "http://www.w3.org/ns/csvw/"}
-                  Tabular Data Namespace
-              %li
-                %a{:href => "http://www.w3.org/TR/csvw-ucr/"}
-                  Use Cases and Requirements
-    %div.hero-unit
-      %h1{:property => "dc:title"}<= ontology["dc:title"]
-      %p{:property => "dc:description rdfs:comment"}<=ontology["dc:description"]
+    %p
+      %a{href: "http://www.w3.org/"}
+        %img{src: "http://www.w3.org/Icons/w3c_home", alt: "W3C", height: 48, width: 72}
+    %h1{property: "dc:title rdfs:label"}<= ontology["dc:title"]
+    %span{property: "dc:description rdfs:comment"}
+      :markdown
+        #{ontology["dc:description"].gsub(/^\s+/, '')}
 
-    %div.container
-      %div.row
-        %h2.span12#classes{:style => "text-align: center;"}
-          Test Case Classes
-        :markdown
-          This vocabulary extends the standard [RDF Test Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with CSVW-specific tests.
-      %div.row
-        %section.offset2.span8
-          %dl
-            - classes.each do |cls|
-              %dt{:about => cls['@id'], :typeof => cls['@type'], :property => "rdfs:label"}<~cls["@id"]
-              %dd{:about => cls['@id']}
-                %em{property: "rdfs:label"}<~cls["rdfs:label"]
-                %p{:property => "rdfs:comment"}<
-                  :markdown
-                    #{cls["rdfs:comment"].to_s.gsub(/^\s+/, '')}
-                  - if cls["rdfs:subClassOf"]
-                    %div
-                      %strong
-                        subClassOf:
-                      %code{:property => "rdfs:subClassOf", :resource => cls["rdfs:subClassOf"]}
-                        = cls["rdfs:subClassOf"]
-      %div.row
-        %h2.span12#classes{:style => "text-align: center;"}
-          Test Case Properties
-      %div.row
-        %section.offset2.span8
-          %dl
-            - properties.each do |prop|
-              %dt{:about => prop['@id'], :typeof => prop['@type'], :property => "rdfs:label"}<~prop["@id"][ontology['@id'].length..-1]
-              %dd{:about => prop['@id']}
-                %em{property: "rdfs:label"}<~prop["rdfs:label"]
-                %p{:property => "rdfs:comment"}<
-                  :markdown
-                    #{prop["rdfs:comment"].to_s.gsub(/^\s+/, '')}
-                  - if prop["rdfs:domain"]
-                    %div
-                      %strong
-                        domain:
-                      %code{:property => "rdfs:domain", :resource => prop["rdfs:domain"]}
-                        = prop["rdfs:domain"]
-                  - if prop["rdfs:range"]
-                    %div
-                      %strong
-                        range:
-                      %code{:property => "rdfs:range", :resource => prop["rdfs:range"]}
-                        = prop["rdfs:range"]
+        This vocabulary extends the [RDF Test Vocabulary](http://www.w3.org/ns/rdftest#)
+        and [Test Manifest Vocabulary](http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#) with CSVW-specific tests.
+        The URI of the vocabulary is `http://w3c.github.io/csvw/tests/vocab#`
+        (abbreviated by `csvwt` in this document).
+        [Turtle](vocab.ttl) and [JSON-LD](vocab.jsonld) versions of the vocabular are also available.
+        The vocabulary is published by the [W3C CSV on the Web Working Group](http://www.w3.org/2013/csvw/wiki/Main_Page).
+    %section
+      %h2="Vocabulary Terms"
+      %p="The vocabulary terms below constitute the complete CSVW Test vocabulary"
+      %section
+        %h3#classes="Classes"
+        %dl
+          - classes.each do |cls|
+            %dt{about: cls['@id'], typeof: cls['@type'], property: "rdfs:label"}<~cls["@id"]
+            %dd{about: cls['@id']}
+              %em{property: "rdfs:label"}<~cls["rdfs:label"]
+              %span{property: "rdfs:comment"}<
+                :markdown
+                  #{cls["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+              - if cls["rdfs:subClassOf"]
+                %div
+                  %strong
+                    subClassOf:
+                  - if cls["rdfs:subClassOf"].is_a?(Array)
+                    %ul
+                      - cls["rdfs:subClassOf"].each do |e|
+                        %li
+                          %code{property: "rdfs:subClassOf", resource: e}=e
+                  - else
+                    %code{property: "rdfs:subClassOf", resource: cls["rdfs:subClassOf"]}=cls["rdfs:subClassOf"]
+      %section
+        %h3#properties="Properties"
+        %dl
+          - properties.each do |prop|
+            %dt{about: prop['@id'], typeof: prop['@type'], property: "rdfs:label"}<~prop["@id"]
+            %dd{about: prop['@id']}
+              %em{property: "rdfs:label"}<~prop["rdfs:label"]
+              %span{property: "rdfs:comment"}<
+                :markdown
+                  #{prop["rdfs:comment"].to_s.gsub(/^\s+/, '')}
+              - if prop["rdfs:domain"]
+                %div
+                  %strong
+                    domain:
+                  - if prop["rdfs:domain"].is_a?(Array)
+                    %ul
+                      - prop["rdfs:domain"].each do |e|
+                        %li
+                          %code{property: "rdfs:domain", resource: e}=e
+                  - else
+                    %code{property: "rdfs:domain", resource: prop["rdfs:domain"]}=prop["rdfs:domain"]
+                  %code{property: "rdfs:domain", resource: prop["rdfs:domain"]}
+                    = Array(prop["rdfs:domain"]).to_sentence
+              - if prop["rdfs:range"]
+                %div
+                  %strong
+                    range:
+                  - if prop["rdfs:range"].is_a?(Array)
+                    %ul
+                      - prop["rdfs:range"].each do |e|
+                        %li
+                          %code{property: "rdfs:range", resource: e}=e
+                  - else
+                    %code{property: "rdfs:range", resource: prop["rdfs:range"]}=prop["rdfs:range"]
     %footer
-      %span{:property => "dc:publisher"}<= ontology["dc:publisher"]
+      %span{property: "dc:publisher"}<= ontology["dc:publisher"]


### PR DESCRIPTION
This defines instructions for noProv handling in the vocabulary.

HTML Files added:

http://w3c.github.com/csvw/tests/index.html
http://w3c.github.com/csvw/tests/vocab.html

Fixes #289.
