### PR TITLE
Fixes to correct metdata in events-listing-metdata.json.

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -992,13 +992,13 @@ var respecConfig = {
             </thead>
             <tbody>
               <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var></td><td><code>name</code></td><td><code>Name</code></td><td></td></tr>
-              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var></td><td><code>start-date</code></td><td><code>Start Date</code></td><td></td></tr>
-              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var></td><td><code>location-name</code></td><td><code>Location Name</code></td><td></td></tr>
-              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var></td><td><code>location-address</code></td><td><code>Location Address</code></td><td></td></tr>
-              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var></td><td><code>ticket-url</code></td><td><code>Ticket Url</code></td><td></td></tr>
-              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var></td><td><code>type-event</code></td><td></td><td><code>true</code></td></tr>
-              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var></td><td><code>type-place</code></td><td></td><td><code>true</code></td></tr>
-              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var></td><td><code>type-offer</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var></td><td><code>start_date</code></td><td><code>Start Date</code></td><td></td></tr>
+              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var></td><td><code>location_name</code></td><td><code>Location Name</code></td><td></td></tr>
+              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var></td><td><code>location_address</code></td><td><code>Location Address</code></td><td></td></tr>
+              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var></td><td><code>ticket_url</code></td><td><code>Ticket Url</code></td><td></td></tr>
+              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var></td><td><code>type_event</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var></td><td><code>type_place</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var></td><td><code>type_offer</code></td><td></td><td><code>true</code></td></tr>
               <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var></td><td><code>location</code></td><td></td><td><code>true</code></td></tr>
               <tr><td><var>C10</var></td><td><var>T</var></td><td>10</td><td>10</td><td><var>C1.10</var>, <var>C2.10</var></td><td><code>offers</code></td><td></td><td><code>true</code></td></tr>
             </tbody>
@@ -1061,7 +1061,7 @@ var respecConfig = {
         <div class="note">
           <p>Three resources are defined for each row within the table; event, location and offer - therefore three <a title="object">objects</a> are created for each <a>row</a>.</p>
           <p>Each <a>column</a> explicitly defines both <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-propertyUrl"><code>propertyUrl</code></a> properties which are inherited by the column's <a title="cell">cells</a>.</p>
-          <p><a title="column">Columns</a> <var>C6</var>, <var>C7</var> and <var>C8</var> (<code>{ "name": "type-event"}</code>, <code>{ "name": "type-place"}</code> and <code>{ "name": "type-offer"}</code>) define the semantic types of the resources described by each <a>row</a>: <code>schema:MusicEvent</code>, <code>schema:Place</code> and <code>schema:Offer</code> respectively—noting that the use of <code>rdf:type</code> is converted to the <a>name</a> <code>@type</code> (as used in [[json-ld]]) by this conversion application.</p>
+          <p><a title="column">Columns</a> <var>C6</var>, <var>C7</var> and <var>C8</var> (<code>{ "name": "type_event"}</code>, <code>{ "name": "type_place"}</code> and <code>{ "name": "type_offer"}</code>) define the semantic types of the resources described by each <a>row</a>: <code>schema:MusicEvent</code>, <code>schema:Place</code> and <code>schema:Offer</code> respectively—noting that the use of <code>rdf:type</code> is converted to the <a>name</a> <code>@type</code> (as used in [[json-ld]]) by this conversion application.</p>
           <p><a title="column">Column</a> <var>C9</var> (<code>{ "name": "location"}</code>) uses the <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> to assert the relationship between the event and location resources.</p>
           <p><a title="column">Column</a> <var>C10</var> (<code>{ "name": "offer"}</code>) uses the <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> to assert the relationship between the event and offer resources.</p>
         </div>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -941,13 +941,13 @@ var respecConfig = {
             </thead>
             <tbody>
               <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var></td><td><code>name</code></td><td><code>Name</code></td><td></td></tr>
-              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var></td><td><code>start-date</code></td><td><code>Start Date</code></td><td></td></tr>
-              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var></td><td><code>location-name</code></td><td><code>Location Name</code></td><td></td></tr>
-              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var></td><td><code>location-address</code></td><td><code>Location Address</code></td><td></td></tr>
-              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var></td><td><code>ticket-url</code></td><td><code>Ticket Url</code></td><td></td></tr>
-              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var></td><td><code>type-event</code></td><td></td><td><code>true</code></td></tr>
-              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var></td><td><code>type-place</code></td><td></td><td><code>true</code></td></tr>
-              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var></td><td><code>type-offer</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var></td><td><code>start_date</code></td><td><code>Start Date</code></td><td></td></tr>
+              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var></td><td><code>location_name</code></td><td><code>Location Name</code></td><td></td></tr>
+              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var></td><td><code>location_address</code></td><td><code>Location Address</code></td><td></td></tr>
+              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var></td><td><code>ticket_url</code></td><td><code>Ticket Url</code></td><td></td></tr>
+              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var></td><td><code>type_event</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var></td><td><code>type_place</code></td><td></td><td><code>true</code></td></tr>
+              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var></td><td><code>type_offer</code></td><td></td><td><code>true</code></td></tr>
               <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var></td><td><code>location</code></td><td></td><td><code>true</code></td></tr>
               <tr><td><var>C10</var></td><td><var>T</var></td><td>10</td><td>10</td><td><var>C1.10</var>, <var>C2.10</var></td><td><code>offers</code></td><td></td><td><code>true</code></td></tr>
             </tbody>
@@ -1010,7 +1010,7 @@ var respecConfig = {
         <div class="note">
           <p>Three resources are defined for each row within the table; event, location and offer.</p>
           <p>Each <a>column</a> explicitly defines both <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-propertyUrl"><code>propertyUrl</code></a> properties which are inherited by the column's <a title="cell">cells</a>.</p>
-          <p><a title="column">Columns</a> <var>C6</var>, <var>C7</var> and <var>C8</var> (<code>{ "name": "type-event"}</code>, <code>{ "name": "type-place"}</code> and <code>{ "name": "type-offer"}</code>) define the semantic types of the resources described by each <a>row</a>: <code>schema:MusicEvent</code>, <code>schema:Place</code> and <code>schema:Offer</code> respectively.</p>
+          <p><a title="column">Columns</a> <var>C6</var>, <var>C7</var> and <var>C8</var> (<code>{ "name": "type_event"}</code>, <code>{ "name": "type_place"}</code> and <code>{ "name": "type_offer"}</code>) define the semantic types of the resources described by each <a>row</a>: <code>schema:MusicEvent</code>, <code>schema:Place</code> and <code>schema:Offer</code> respectively.</p>
           <p><a title="column">Column</a> <var>C9</var> (<code>{ "name": "location"}</code>) uses the <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> to assert the relationship between the event and location resources.</p>
           <p><a title="column">Column</a> <var>C10</var> (<code>{ "name": "offer"}</code>) uses the <a href="http://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> to assert the relationship between the event and offer resources.</p>
         </div>

--- a/examples/events-listing-minimal.ttl
+++ b/examples/events-listing-minimal.ttl
@@ -6,24 +6,24 @@
   schema:name "B.B. King" ;
   schema:startDate "2014-04-12T19:30:00"^^xsd:dateTime ;
   schema:location <#place-1> ;
-  schema:offer <#offer-1> .
+  schema:offers <#offer-1> .
 
 <#place-1> a schema:Place ;
   schema:name "Lupo’s Heartbreak Hotel" ;
   schema:address "79 Washington St., Providence, RI" .
 
 <#offer-1> a schema:Offer ;
-  schema:offer <https://www.etix.com/ticket/1771656> .
+  schema:url "https://www.etix.com/ticket/1771656"^^xsd:anyURI .
 
 <#event-2> a schema:MusicEvent ;
   schema:name "B.B. King" ;
   schema:startDate "2014-04-13T20:00:00"^^xsd:dateTime ;
   schema:location <#place-2> ;
-  schema:offer <#offer-2> .
+  schema:offers <#offer-2> .
 
 <#place-2> a schema:Place ;
   schema:name "Lynn Auditorium" ;
   schema:address "Lynn, MA, 01901" .
 
 <#offer-2> a schema:Offer ;
-  schema:offer <http://frontgatetickets.com/venue.php?id=11766> .
+  schema:url "http://frontgatetickets.com/venue.php?id=11766"^^xsd:anyURI .

--- a/examples/events-listing-standard.json
+++ b/examples/events-listing-standard.json
@@ -15,10 +15,10 @@
           "schema:name": "Lupo’s Heartbreak Hotel",
           "schema:address": "79 Washington St., Providence, RI"
         },
-        "schema:offer": {
+        "schema:offers": {
           "@id": "http://example.org/events-listing.csv#offer-1",
           "@type": "schema:Offer",
-          "schema:offer": "https://www.etix.com/ticket/1771656"
+          "schema:url": "https://www.etix.com/ticket/1771656"
         }
       }]
     }, {
@@ -35,10 +35,10 @@
           "schema:name": "Lynn Auditorium",
           "schema:address": "Lynn, MA, 01901"
         },
-        "schema:offer": {
+        "schema:offers": {
           "@id": "http://example.org/events-listing.csv#offer-2",
           "@type": "schema:Offer",
-          "schema:offer": "http://frontgatetickets.com/venue.php?id=11766"
+          "schema:url": "http://frontgatetickets.com/venue.php?id=11766"
         }
       }]
     }]

--- a/examples/events-listing-standard.ttl
+++ b/examples/events-listing-standard.ttl
@@ -7,11 +7,11 @@ _:95cc7970-ce99-44b0-900c-e2c2c028bbd3 a csvw:TableGroup ;
   csvw:table [ a csvw:Table ;
     csvw:url <http://example.org/events-listing.csv> ;
     csvw:row [
-      csvw:rownum "1"^^xsd:integer ;
+      csvw:rownum 1 ;
       csvw:url <#row=2> ;
       csvw:describes <#event-1>, <#place-1>, <#offer-1>
     ], [
-      csvw:rownum "2"^^xsd:integer ;
+      csvw:rownum 2 ;
       csvw:url <#row=3> ;
       csvw:describes <#event-2>, <#place-2>, <#offer-2>
     ]
@@ -21,24 +21,24 @@ _:95cc7970-ce99-44b0-900c-e2c2c028bbd3 a csvw:TableGroup ;
   schema:name "B.B. King" ;
   schema:startDate "2014-04-12T19:30:00"^^xsd:dateTime ;
   schema:location <#place-1> ;
-  schema:offer <#offer-1> .
+  schema:offers <#offer-1> .
 
 <#place-1> a schema:Place ;
   schema:name "Lupo’s Heartbreak Hotel" ;
   schema:address "79 Washington St., Providence, RI" .
 
 <#offer-1> a schema:Offer ;
-  schema:offer <https://www.etix.com/ticket/1771656> .
+  schema:url "https://www.etix.com/ticket/1771656"^^xsd:anyURI .
 
 <#event-2> a schema:MusicEvent ;
   schema:name "B.B. King" ;
   schema:startDate "2014-04-13T20:00:00"^^xsd:dateTime ;
   schema:location <#place-2> ;
-  schema:offer <#offer-2> .
+  schema:offers <#offer-2> .
 
 <#place-2> a schema:Place ;
   schema:name "Lynn Auditorium" ;
   schema:address "Lynn, MA, 01901" .
 
 <#offer-2> a schema:Offer ;
-  schema:offer <http://frontgatetickets.com/venue.php?id=11766> .
+  schema:url "http://frontgatetickets.com/venue.php?id=11766"^^xsd:anyURI .

--- a/examples/events-listing.csv-metadata.json
+++ b/examples/events-listing.csv-metadata.json
@@ -1,6 +1,7 @@
 {
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "events-listing.csv",
+  "dialect": {"trim": true},
   "tableSchema": {
     "columns": [{
       "name": "name",
@@ -8,7 +9,7 @@
       "aboutUrl": "#event-{_row}",
       "propertyUrl": "schema:name"
     }, {
-      "name": "start-date",
+      "name": "start_date",
       "title": "Start Date",
       "datatype": {
         "base": "datetime",
@@ -17,35 +18,35 @@
       "aboutUrl": "#event-{_row}",
       "propertyUrl": "schema:startDate"
     }, {
-      "name": "location-name",
+      "name": "location_name",
       "title": "Location Name",
       "aboutUrl": "#place-{_row}",
       "propertyUrl": "schema:name"
     }, {
-      "name": "location-address",
+      "name": "location_address",
       "title": "Location Address",
       "aboutUrl": "#place-{_row}",
       "propertyUrl": "schema:address"
     }, {
-      "name": "ticket-url",
+      "name": "ticket_url",
       "title": "Ticket Url",
       "datatype": "anyURI",
       "aboutUrl": "#offer-{_row}",
       "propertyUrl": "schema:url"
     }, {
-      "name": "type-event",
+      "name": "type_event",
       "virtual": true,
       "aboutUrl": "#event-{_row}",
       "propertyUrl": "rdf:type",
       "valueUrl": "schema:MusicEvent"
     }, {
-      "name": "type-place",
+      "name": "type_place",
       "virtual": true,
       "aboutUrl": "#place-{_row}",
       "propertyUrl": "rdf:type",
       "valueUrl": "schema:Place"
     }, {
-      "name": "type-offer",
+      "name": "type_offer",
       "virtual": true,
       "aboutUrl": "#offer-{_row}",
       "propertyUrl": "rdf:type",


### PR DESCRIPTION
- trim spaces to deal with format of CSV
- No "-" in column names.
- output uses schema:offers no schema:offer
- Offer has schema:url not schema:offer.
