### PR TITLE
amended column layout for cell annotations

### DIFF
--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -1171,7 +1171,7 @@ var respecConfig = {
           <p><a title="cell">Cell</a> annotations:</p>
           <table style="width: 100%; text-align: left">
             <thead>
-              <tr><th rowspan="2">id</th><th colspan="5">core annotations</th><th colspan="5">annotations</th></tr>
+              <tr><th rowspan="2">id</th><th colspan="6">core annotations</th><th colspan="4">annotations</th></tr>
               <tr><th>table</th><th>column</th><th>row</th><th>string value</th><th>value</th><th>errors</th><th><code>datatype</code></th><th><code>aboutUrl</code></th><th><code>propertyUrl</code></th><th><code>valueUrl</code></th></tr>
             </thead>
             <tbody>


### PR DESCRIPTION
modified arrangement of headers for cell annotations table in public
sector roles and professions example in csv2rdf … this seemed to get
changed in response to fixing an issue in the csv2json doc
