### PR TITLE
Proofreading the metadata document

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -302,7 +302,7 @@ var respecConfig = {
         <section>
           <h4>URI Template Properties</h4>
           <p>
-            A <dfn>URI template property</dfn> contains a [[!URI-TEMPLATE]] which can be used to generate a URI. These URI templates are expanded in the context of each row by combining the template with a set of variables with values. The variables that are set are:
+            <dfn title="URI template property">URI template properties</dfn> contain a [[!URI-TEMPLATE]] which can be used to generate a URI. These URI templates are expanded in the context of each row by combining the template with a set of variables with values. The variables that are set are:
           </p>
           <dl>
             <dt>column names</dt>
@@ -322,7 +322,7 @@ var respecConfig = {
             <dt><code>_sourceRow</code></dt>
             <dd><code>_sourceRow</code> is set to the <a href="http://w3c.github.io/csvw/syntax/#dfn-row-source-number" class="externalDFN">source number</a> of the row that is currently being processed; this usually varies from <code>_row</code> by <a href="http://w3c.github.io/csvw/syntax/#dfn-skip-rows" class="externalDFN">skip rows</a> and <a href="http://w3c.github.io/csvw/syntax/#dfn-header-rows" class="externalDFN">header rows</a></dd>
             <dt><code>_name</code></dt>
-            <dd><code>_name</code> is set to the URI decoded <a>property value</a> of the <code>name</code> property on the cell column that is currently being processed. <span class="note">URI decoding is necessary as <code>name</code> may have been encoded if taken from <code>title</code>; this prevents double percent encoding.</span>
+            <dd><code>_name</code> is set to the URI decoded <a>property value</a> of the <code>name</code> property on the cell column that is currently being processed. (URI decoding is necessary as <code>name</code> may have been encoded if taken from <code>title</code>; this prevents double percent encoding.)
             </dd>
           </dl>
           <p>
@@ -413,14 +413,14 @@ CSVW,foaf:Project,table;data;conversion
         <section>
           <h4>Column Reference Properties</h4>
           <p>
-            <dfn title="column reference property">Column reference properties</dfn> hold one or more references to other <a>column description</a> objects. The referenced description object must have an <code>name</code> property. Column reference properties can then reference column description objects through values that are:
+            <dfn title="column reference property">Column reference properties</dfn> hold one or more references to other <a>column description</a> objects. The referenced description object must have a <code>name</code> property. Column reference properties can then reference column description objects through values that are:
           </p>
           <ul>
             <li><strong>strings</strong> &mdash; which MUST match the <code>name</code> on a <a>column description</a> object within the metadata document</li>
             <li><strong>arrays</strong> &mdash; lists of strings as above</li>
           </ul>
           <p>
-            For example, the <code>primaryKey</code> property is an column reference property on the schema. It has to hold references to columns defined elsewhere in the schema, and the descriptions of those columns must have <code>name</code> properties. It can hold a single reference, like this:
+            For example, the <code>primaryKey</code> property is a column reference property on the schema. It has to hold references to columns defined elsewhere in the schema, and the descriptions of those columns must have <code>name</code> properties. It can hold a single reference, like this:
           </p>
           <pre class="example highlight">
 "tableSchema": {
@@ -516,7 +516,7 @@ CSVW,foaf:Project,table;data;conversion
            The <a>property value</a> of a <a>natural language property</a> is an object whose properties are language codes and where the values of those properties are an array of strings (see <cite><a href="http://www.w3.org/TR/json-ld/#language-maps">Language Maps</a></cite> in [[!JSON-LD]]).
           </p>
           <p class="note">
-            When extracting a <a>property value</a> metadata will have already been <a>merged</a>, a <a>natural language property</a> will already have this form.
+            When extracting a <a>property value</a> from a metadata that have already been <a>merged</a>, a <a>natural language property</a> will already have this form.
           </p>
         </section>
         <section>
@@ -529,7 +529,7 @@ CSVW,foaf:Project,table;data;conversion
             <li><strong>booleans</strong> &mdash; interpreted as booleans (<code>true</code> or <code>false</code>)</li>
             <li><strong>strings</strong> &mdash; interpreted as defined by the property</li>
             <li><strong>objects</strong> &mdash; interpreted as defined by the property</li>
-            <li><strong>arrays</strong> &mdash; lists of numbers, booleans, strings, or objects</li>
+            <li><strong>arrays</strong> &mdash; lists of numbers, booleans, strings or objects</li>
           </ul>
           <p>
             The <a>property value</a> of a boolean atomic property is <code>false</code> if unset; otherwise, the <a>property value</a> of an atomic property is that set in metadata or <code>null</code>, if unset. Processors MUST raise an error if a property is set to an invalid value type, such as a boolean atomic property being set to the number <code>1</code> or a numeric atomic property being set to the string <code>"3.1415"</code>.
@@ -542,7 +542,7 @@ CSVW,foaf:Project,table;data;conversion
           The top-level object (whether it is a <a>table group description</a> or a <a>table description</a>) MUST have a <code id="context">@context</code> property, an <a>array property</a>, as defined in <cite><a href="http://www.w3.org/TR/json-ld/#context-definitions">Section 8.7</a></cite> of [[!JSON-LD]]. The <code>@context</code> MUST contain one of the following:</p>
         <ul>
           <li>A string value of <code>http://www.w3.org/ns/csvw</code>, or</li>
-          <li>An array composed of a string and an object, where the string is <code>http://www.w3.org/ns/csvw</code> and the object representing a local context definition, which is restricted to contain either or both of the following members.</li>
+          <li>An array composed of a string and an object, where the string is <code>http://www.w3.org/ns/csvw</code> and the object represents a local context definition, which is restricted to contain either or both of the following members.</li>
         </ul>
         <dl>
           <dt id="context-language"><code>@language</code></dt>
@@ -599,7 +599,7 @@ CSVW,foaf:Project,table;data;conversion
                 If a <code>@value</code> property is used on an object, that object MUST NOT have any other properties aside from either <code>@type</code> or <code>@language</code>, and MUST NOT have both <code>@type</code> and <code>@language</code> as properties. The value of the <code>@value</code> property MUST be a string, number or boolean value.
               </p>
               <p>
-                If <code>@type</code> is used, its value MUST be one of:
+                If <code>@type</code> is also used, its value MUST be one of:
               </p>
               <ul>
                 <li>a built-in datatype, as defined in <a href="#built-in-datatypes" class="sectionRef"></a></li>
@@ -679,7 +679,7 @@ CSVW,foaf:Project,table;data;conversion
             </dd>
             <dt id="table-group-dialect"><code>dialect</code></dt>
             <dd>
-              <p>An <a>object property</a> that provides a single <a>dialect description</a>. If provided, <code>dialect</code> provides hints to processors about how to parse the referenced files for to create tabular data models for the tables in the group. This may be provided as an embedded object or as a URL reference. See <a href="#dialect-descriptions" class="sectionRef"></a> for more details.</p>
+              <p>An <a>object property</a> that provides a single <a>dialect description</a>. If provided, <code>dialect</code> provides hints to processors about how to parse the referenced files to create tabular data models for the tables in the group. This may be provided as an embedded object or as a URL reference. See <a href="#dialect-descriptions" class="sectionRef"></a> for more details.</p>
             </dd>
             <dt id="table-group-transformations"><code>transformations</code></dt>
             <dd>
@@ -778,12 +778,12 @@ CSVW,foaf:Project,table;data;conversion
       <section>
         <h3>Dialect Descriptions</h3>
         <p>
-          Much of the tabular data that is published on the web is messy, and CSV parsers frequently need to be configured in order to correctly read in CSV. A <dfn>dialect description</dfn> provides hints to parsers about how to parse the file linked to from the <code>url</code> property. It can have any of the following properties, which relate to the flags described in <a href="http://w3c.github.io/csvw/syntax/#parsing">Section 5 Parsing Tabular Data</a> within [[!tabular-data-model]]:
+          Much of the tabular data that is published on the web is messy, and CSV parsers frequently need to be configured in order to correctly read in CSV. A <dfn>dialect description</dfn> provides hints to parsers about how to parse the file linked to from the <code>url</code> property. It can have any of the following properties, which relate to the flags described in <a href="http://w3c.github.io/csvw/syntax/#parsing">Section 5 Parsing Tabular Data</a> within the [[!tabular-data-model]]:
         </p>
         <dl>
           <dt id="dialect-encoding"><code>encoding</code></dt>
           <dd>
-            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-encoding" class="externalDFN">encoding</a> flag to the single provided string value, which MUST be a defined [[!encoding]].</p>
+            <p>An <a>atomic property</a> that sets the <a href="http://w3c.github.io/csvw/syntax/#dfn-encoding" class="externalDFN">encoding</a> flag to the single provided string value, which MUST be a defined in [[!encoding]].</p>
           </dd>
           <dt id="dialect-lineTerminator"><code>lineTerminator</code></dt>
           <dd>
@@ -850,10 +850,10 @@ CSVW,foaf:Project,table;data;conversion
           Dialect descriptions do not provide a mechanism for handling CSV files in which there are multiple tables within a single file (eg separated by empty lines).
         </p>
         <p>The <a>property value</a> of a <a>dialect description</a> is that defined in the <a>table description</a>, if any, or that defined in the <a>table group description</a>, if any, or the default defined for that property.</p>
-        <div class="example">
           <p>
             The default dialect description for CSV files is:
           </p>
+        <div class="example">
           <pre>
 {
   "encoding": "utf-8",
@@ -870,8 +870,7 @@ CSVW,foaf:Project,table;data;conversion
   "skipBlankRows": false,
   "skipInitialSpace": false,
   "trim": false
-}
-          </pre>
+}</pre>
         </div>
       </section>
       <section>
@@ -1021,7 +1020,7 @@ CSVW,foaf:Project,table;data;conversion
                 <dl>
                   <dt id="foreign-key-reference-resource"><code>resource</code></dt>
                   <dd>
-                    <p>A <a>link property</a> holding a URL that is the identifier for a specific table that is being referenced. If this property is present then <code>tableSchema</code> MUST NOT be present. The <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> MUST contain a <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">table</a> whose <a href="http://w3c.github.io/csvw/syntax/#dfn-table-url" class="externalDFN">url</a> annotation is identical to the <a>property value</a> of this property. That table is the <a>referenced table</a>.</p>
+                    <p>A <a>link property</a> holding a URL that is the identifier for a specific table that is being referenced. If this property is present then <code>schemaReference</code> MUST NOT be present. The <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> MUST contain a <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">table</a> whose <a href="http://w3c.github.io/csvw/syntax/#dfn-table-url" class="externalDFN">url</a> annotation is identical to the <a>property value</a> of this property. That table is the <a>referenced table</a>.</p>
                   </dd>
                   <dt id="foreign-key-reference-schema"><code>schemaReference</code></dt>
                   <dd>
@@ -1097,7 +1096,7 @@ CSVW,foaf:Project,table;data;conversion
           <section>
             <h4>Foreign Key Reference Between Schemas</h4>
             <p>
-              When publishing information about public sector roles and salaries, as in <a href="http://w3c.github.io/csvw/csvw-ucr/#UC-OrganogramData">Use Case 4</a>, the UK government requires departments to publish two files which are interlinked. The first lists senior grades (simplified here) eg at <code>HEFCE_organogram_senior_data_31032011.csv</code>:
+              When publishing information about public sector roles and salaries, as in <a href="http://w3c.github.io/csvw/csvw-ucr/#UC-OrganogramData">Use Case 4</a>, the UK government requires departments to publish two files which are interlinked. The first lists senior grades (simplified here) e.g., at <code>HEFCE_organogram_senior_data_31032011.csv</code>:
             </p>
             <pre class="example">
 Post Unique Reference,              Name,Grade,             Job Title,Reports to Senior Post
@@ -1107,7 +1106,7 @@ Post Unique Reference,              Name,Grade,             Job Title,Reports to
                 90334,Sir Alan Langlands, SCS4,       Chief Executive,                    xx
             </pre>
             <p>
-              The second provides information about the number of junior positions that report to those individuals (simplified here) eg at <code>HEFCE_organogram_junior_data_31032011.csv</code>:
+              The second provides information about the number of junior positions that report to those individuals (simplified here) e.g., at <code>HEFCE_organogram_junior_data_31032011.csv</code>:
             </p>
             <pre class="example">
 Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic Job Title,Number of Posts in FTE,          Profession
@@ -1236,10 +1235,10 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <p>
               An <a>atomic property</a> that gives a single canonical name for the column. The value of this property is used to create the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-name" class="externalDFN">name</a> annotation for the described column. This MUST be a string. Conversion specifications MUST use this property as the basis for the names of properties/elements/attributes in the results of conversions.
             </p>
-            <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first value from the <a>property value</a> of <code>title</code> having the same language tag as <a>default language</a> or <code>und</code> of not specified percent-encoded as necessary to conform to the syntactic requirements described below, as a string without language, if any. Otherwise, it is the string <code>"_col.<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-number" class="externalDFN">column number</a>.
-            </p>
             <p>
               For ease of reference within <a title="URI template property">URI template properties</a>, column names are restricted as defined in <cite><a href="https://tools.ietf.org/html/rfc6570#page-14">Variables</a></cite> in [[!URI-TEMPLATE]] with the additional provision that names beginning with <code>"_"</code> are reserved by this specification and MUST NOT be used.
+            </p>
+            <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first value from the <a>property value</a> of <code>title</code>, having the same language tag as <a>default language</a> or <code>und</code> if not specified, percent-encoded as necessary to conform to the syntactic requirements as a string without language. Otherwise, it is the string <code>"_col.<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-number" class="externalDFN">column number</a>.
             </p>
           </dd>
           <dt id="column-title"><code>title</code></dt>
@@ -1419,19 +1418,17 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
         <section>
           <h3>Built-in Datatypes</h3>
           <p>
-            The possible built-in datatypes are:
+            The possible built-in datatypes, as shown on <a href="#fig-datatypes" class="sectionRef">the diagram</a>, are:
           </p>
           <ul>
-            <li>
-              the datatypes defined in [[!xmlschema11-2]] as derived from and including <code>anyAtomicType</code>, as shown in <a href="#fig-datatypes" class="sectionRef"></a>
-            </li>
+            <li>the datatypes defined in [[!xmlschema11-2]] as derived from and including <code>anyAtomicType</code></li>
             <li>the datatype <code>number</code> which is exactly equivalent to <code>double</code></li>
             <li>the datatype <code>binary</code> which is exactly equivalent to <code>base64Binary</code></li>
             <li>the datatype <code>datetime</code> which is exactly equivalent to <code>dateTime</code></li>
             <li>the datatype <code>any</code> which is exactly equivalent to <code>anyAtomicType</code></li>
-            <li>the datatype <code>xml</code>, a sub-type of <code>string</code> which indicates the value is an XML fragment</li>
-            <li>the datatype <code>html</code>, a sub-type of <code>string</code> which indicates the value is an HTML fragment</li>
-            <li>the datatype <code>json</code>, a sub-type of <code>string</code> which indicates the value is serialized JSON</li>
+            <li>the datatype <code>xml</code>, a sub-type of <code>string</code>, which indicates the value is an XML fragment</li>
+            <li>the datatype <code>html</code>, a sub-type of <code>string</code>, which indicates the value is an HTML fragment</li>
+            <li>the datatype <code>json</code>, a sub-type of <code>string</code>, which indicates the value is serialized JSON</li>
           </ul>
           <figure id="fig-datatypes" style="text-align:center">
             <img src="datatypes.svg" style="width: 50%" alt="Built-in Datatype Hierarchy diagram"/>
@@ -1747,48 +1744,48 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             The following date formats MUST be recognised by implementations:
           </p>
           <ul>
-            <li><code>yyyy-MM-dd</code> eg <code>2015-03-22</code></li>
-            <li><code>yyyyMMdd</code> eg <code>20150322</code></li>
-            <li><code>dd-MM-yyyy</code> eg <code>22-03-2015</code></li>
-            <li><code>d-M-yyyy</code> eg <code>22-3-2015</code></li>
-            <li><code>MM-dd-yyyy</code> eg <code>03-22-2015</code></li>
-            <li><code>M-d-yyyy</code> eg <code>3-22-2015</code></li>
-            <li><code>dd/MM/yyyy</code> eg <code>22/03/2015</code></li>
-            <li><code>d/M/yyyy</code> eg <code>22/3/2015</code></li>
-            <li><code>MM/dd/yyyy</code> eg <code>03/22/2015</code></li>
-            <li><code>M/d/yyyy</code> eg <code>3/22/2015</code></li>
-            <li><code>dd.MM.yyyy</code> eg <code>22.03.2015</code></li>
-            <li><code>d.M.yyyy</code> eg <code>22.3.2015</code></li>
-            <li><code>MM.dd.yyyy</code> eg <code>03.22.2015</code></li>
-            <li><code>M.d.yyyy</code> eg <code>3.22.2015</code></li>
+            <li><code>yyyy-MM-dd</code> e.g., <code>2015-03-22</code></li>
+            <li><code>yyyyMMdd</code> e.g., <code>20150322</code></li>
+            <li><code>dd-MM-yyyy</code> e.g., <code>22-03-2015</code></li>
+            <li><code>d-M-yyyy</code> e.g., <code>22-3-2015</code></li>
+            <li><code>MM-dd-yyyy</code> e.g., <code>03-22-2015</code></li>
+            <li><code>M-d-yyyy</code> e.g., <code>3-22-2015</code></li>
+            <li><code>dd/MM/yyyy</code> e.g., <code>22/03/2015</code></li>
+            <li><code>d/M/yyyy</code> e.g., <code>22/3/2015</code></li>
+            <li><code>MM/dd/yyyy</code> e.g., <code>03/22/2015</code></li>
+            <li><code>M/d/yyyy</code> e.g., <code>3/22/2015</code></li>
+            <li><code>dd.MM.yyyy</code> e.g., <code>22.03.2015</code></li>
+            <li><code>d.M.yyyy</code> e.g., <code>22.3.2015</code></li>
+            <li><code>MM.dd.yyyy</code> e.g., <code>03.22.2015</code></li>
+            <li><code>M.d.yyyy</code> e.g., <code>3.22.2015</code></li>
           </ul>
           <p>
             The following time formats MUST be recognised by implementations:
           </p>
           <ul>
-            <li><code>HH:mm:ss</code> eg <code>15:02:37</code></li>
-            <li><code>HHmmss</code> eg <code>150237</code></li>
-            <li><code>HH:mm</code> eg <code>15:02</code></li>
-            <li><code>HHmm</code> eg <code>1502</code></li>
+            <li><code>HH:mm:ss</code> e.g., <code>15:02:37</code></li>
+            <li><code>HHmmss</code> e.g., <code>150237</code></li>
+            <li><code>HH:mm</code> e.g., <code>15:02</code></li>
+            <li><code>HHmm</code> e.g., <code>1502</code></li>
           </ul>
           <p>
             The following date/time formats MUST be recognised by implementations:
           </p>
           <ul>
-            <li><code>yyyy-MM-ddTHH:mm:ss</code> eg <code>2015-03-15T15:02:37</code></li>
-            <li><code>yyyy-MM-ddTHH:mm</code> eg <code>2015-03-15T15:02</code></li>
-            <li>any of the date formats above, followed by a single space, followed by any of the time formats above, eg <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
+            <li><code>yyyy-MM-ddTHH:mm:ss</code> e.g., <code>2015-03-15T15:02:37</code></li>
+            <li><code>yyyy-MM-ddTHH:mm</code> e.g., <code>2015-03-15T15:02</code></li>
+            <li>any of the date formats above, followed by a single space, followed by any of the time formats above, e.g., <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
           </ul>
           <p>
             Implementations MUST also recognise date, time and date/time formats that end with timezone markers consisting of between one and three <code>x</code>s or <code>X</code>s, possibly after a single space. These MUST be interpreted as follows:
           </p>
           <ul>
-            <li><code>X</code> eg <code>-08</code>, <code>+0530</code> or <code>Z</code> (minutes are optional)</li>
-            <li><code>XX</code> eg <code>-0800</code>, <code>+0530</code> or <code>Z</code></li>
-            <li><code>XXX</code> eg <code>-08:00</code>, <code>+05:30</code> or <code>Z</code></li>
-            <li><code>x</code> eg <code>-08</code> or <code>+0530</code> (<code>Z</code> is not permitted)</li>
-            <li><code>xx</code> eg <code>-0800</code> or <code>+0530</code> (<code>Z</code> is not permitted)</li>
-            <li><code>xxx</code> eg <code>-08:00</code> or <code>+05:30</code> (<code>Z</code> is not permitted)</li>
+            <li><code>X</code> e.g., <code>-08</code>, <code>+0530</code> or <code>Z</code> (minutes are optional)</li>
+            <li><code>XX</code> e.g., <code>-0800</code>, <code>+0530</code> or <code>Z</code></li>
+            <li><code>XXX</code> e.g., <code>-08:00</code>, <code>+05:30</code> or <code>Z</code></li>
+            <li><code>x</code> e.g., <code>-08</code> or <code>+0530</code> (<code>Z</code> is not permitted)</li>
+            <li><code>xx</code> e.g., <code>-0800</code> or <code>+0530</code> (<code>Z</code> is not permitted)</li>
+            <li><code>xxx</code> e.g., <code>-08:00</code> or <code>+05:30</code> (<code>Z</code> is not permitted)</li>
           </ul>
           <p>
             For example, formats could include <code>yyyy-MM-ddTHH:mm:ssXXX</code> for <code>2015-03-15T15:02:37Z</code> or <code>2015-03-15T15:02:37-05:00</code>, or <code>HH:mm x</code> for <code>15:02 -05</code>.
@@ -1835,11 +1832,11 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
     <section>
       <h2>Merging Metadata</h2>
       <p>
-        When processing a tabular data file, the <cite><a href="http://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a></cite> in [[!tabular-data-model]] describes different locations for locating metadata. To property transform a tabular data file, such as a CSV, processors MUST merge metadata from these separate sources to create a single metadata document in a manner consistent with this algorithm.
+        When processing a tabular data file, the <cite><a href="http://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a></cite> section in [[!tabular-data-model]] describes different locations for locating metadata. To properly transform a tabular data file, such as a CSV, processors MUST merge metadata from these separate sources to create a single metadata document in a manner consistent with this algorithm.
       </p>
       <p>Implementations MUST merge metadata documents in a manner consistent with these rules. <a>Validators</a> MUST check and issue warnings where merge issues are found as noted below and in the relevant property definitions.</p>
       <p>
-        Merging of metadata happens in order from highest priority to lowest priority by merging the first two metadata files (<code>A</code> and <code>B</code>) together to create new merged metadata AB'. This is then used to merge in the next metadata file until all metadata have been processed to create a <a>table group description</a>. If the top-level object of either of the metadata files are <a title="table description">table descriptions</a>, these are turned into <a title="table group description">table group descriptions</a> containing a single table description (ie having a single <code>resource</code> property whose value is the same as the original table description). Ensure that <code>@context</code> definitions are moved from the <a>table description</a> to the <a>table group description</a>.
+        Merging of metadata happens in order from highest priority to lowest priority by merging the first two metadata files (<code>A</code> and <code>B</code>) together to create new merged metadata AB'. This is then used to merge in the next metadata file until all metadata have been processed to create a <a>table group description</a>. If the top-level object of either of the metadata files are <a title="table description">table descriptions</a>, these are turned into <a title="table group description">table group descriptions</a> containing a single table description (i.e., having a single <code>resource</code> property whose value is the same as the original table description). Ensure that <code>@context</code> definitions are moved from the <a>table description</a> to the <a>table group description</a>.
       </p>
       <p>
         Merging has two stages: the <a>normalization</a> of metadata documents, described in <a href="#normalization" class="sectionRef"></a> and the <a title="merged">merging</a> of those normalized documents, described in <a href="#merging" class="sectionRef"></a>.
@@ -2172,7 +2169,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
     <section>
       <h2>Security Considerations</h2>
       <p>
-        Applications that process tabular data may use that data to drive other actions, which may have security implications. These behaviours are outside the scope of this specification.
+        Applications that process tabular data may use that data to drive other actions, which may have security implications. These behaviors are outside the scope of this specification.
       </p>
       <p>
         Third party metadata provided about a tabular data file (such as a CSV file) may rename or ignore headers, or exclude rows or columns, which may lead to data being misinterpreted by applications that process it.
@@ -2191,7 +2188,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
         <li><p>Common properties and notes may contain arbitrary JSON-LD with the following restrictions:</p>
           <ul>
             <li><p>The value of any member of <code>@type</code> MUST be either a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in [[csvw-context]], a <a href="http://www.w3.org/TR/json-ld/#dfn-compact-iri" class="externalDFN">prefixed name</a> where the prefix is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in [[csvw-context]], or an absolute URL.</p></li>
-            <li><p>Values MAY be a <a href="http://www.w3.org/TR/json-ld/#dfn-string" class="externalDFN">string</a>, native JSON type (such as <a href="http://www.w3.org/TR/json-ld/#dfn-number" class="externalDFN">number</a>, <code>true</code>, or <code>false</code>.), <a href="http://www.w3.org/TR/json-ld/#dfn-value-object" class="externalDFN">value object</a>, <a href="http://www.w3.org/TR/json-ld/#dfn-node-object" class="externalDFN">node object</a> or an array of zero or more any of these.</p></li>
+            <li><p>Values MAY be a <a href="http://www.w3.org/TR/json-ld/#dfn-string" class="externalDFN">string</a>, native JSON type (such as <a href="http://www.w3.org/TR/json-ld/#dfn-number" class="externalDFN">number</a>, <code>true</code>, or <code>false</code>.), <a href="http://www.w3.org/TR/json-ld/#dfn-value-object" class="externalDFN">value object</a>, <a href="http://www.w3.org/TR/json-ld/#dfn-node-object" class="externalDFN">node object</a> or an array of zero or more of any of these.</p></li>
             <li><p>Values MUST NOT use <a href="http://www.w3.org/TR/json-ld/#dfn-list-object" class="externalDFN">list objects</a> or <a href="http://www.w3.org/TR/json-ld/#dfn-set-object" class="externalDFN">set objects</a>.</p></li>
             <li><p>Keys of <a href="http://www.w3.org/TR/json-ld/#dfn-node-object" class="externalDFN">node objects</a> MUST NOT include <code>@graph</code>,  <code>@context</code>, <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">terms</a>, or <a href="http://www.w3.org/TR/json-ld/#dfn-blank-node" class="externalDFN">blank nodes</a>.</p></li>
           </ul>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -516,7 +516,7 @@ CSVW,foaf:Project,table;data;conversion
            The <a>property value</a> of a <a>natural language property</a> is an object whose properties are language codes and where the values of those properties are an array of strings (see <cite><a href="http://www.w3.org/TR/json-ld/#language-maps">Language Maps</a></cite> in [[!JSON-LD]]).
           </p>
           <p class="note">
-            When extracting a <a>property value</a> from a metadata that have already been <a>merged</a>, a <a>natural language property</a> will already have this form.
+            When extracting a <a>property value</a> from a metadata that will have already been <a>merged</a>, a <a>natural language property</a> will already have this form.
           </p>
         </section>
         <section>


### PR DESCRIPTION
A number of small editing while proofreading; hopefully nothing controversial.

Note that I tried to systematically change "eg" to "e.g.," and 'ie" to "i.e.,". As far as I know this is the required style for W3C document (is this an American vs. British difference?). I also found traces of British English, like "behaviour"; I had to turn them into American (Sorry @JeniT  and @6a6d74, the official language for W3C documents is American English...)
