### PR TITLE
Adjusting the /TR uris automatically when publishing

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -6,63 +6,63 @@
     <title>Generating JSON from Tabular Data on the Web</title>
     <link href="hide.css" rel="stylesheet">
     <script type="text/javascript" src="hide.js"></script>
-    <script src="../local-biblio.js" class="remove"></script>
-    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
-	  </script>
+    <script class="remove" src="../local-biblio.js"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
-var respecConfig = {
-    localBiblio: localBibliography,
-    specStatus: "ED",
-    shortName: "csv2json",
-    // publishDate:  "2014-04-01",
-    previousPublishDate: "2015-01-08",
-    previousMaturity: "FPWD",
-    previousURI: "http://www.w3.org/TR/2015/WD-csv2json-20150108/",
-    edDraftURI: "http://w3c.github.io/csvw/csv2json/",
-    // lcEnd: "3000-01-01",
-    // crEnd: "3000-01-01",
-    editors:
-     [{
-            name: "Jeremy Tandy",
-            company: "Met Office",
-            companyURL: "http://www.metoffice.gov.uk/",
-            w3cid: "65512"
-      },{
-       name: "Ivan Herman",
-       url: "http://www.w3.org/People/Ivan",
-       company: "W3C",
-       companyURL: "http://www.w3.org",
-       w3cid: "7382"
-     }],
-    wg: "CSV on the Web Working Group",
-    wgURI: "http://www.w3.org/2013/csvw/",
-    wgPublicList: "public-csv-wg",
-    wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
-    otherLinks: [{
-      key: "Repository",
-      data: [{
-          value: "We are on Github",
-          href: "https://github.com/w3c/csvw/"
-        }, {
-          value: "File a bug",
-          href: "https://github.com/w3c/csvw/issues"
-        }]
-      } , 
-      {
-        key: "Changes",
-        data: [{
-        //     value: "Diff to previous version",
-        //     href: "diff-20140327.html"
-        //   }, {}
-           value: "Commit history",
-           href: "https://github.com/w3c/csvw/commits/gh-pages"
-         }]
-       }] ,
-    inlineCSS: true,
-    noIDLIn: true,
-    issueBase: "https://github.com/w3c/csvw/issues/",
-    noLegacyStyle: false
-    };
+      var respecConfig = {
+          localBiblio: localBibliography,
+          specStatus: "ED",
+          shortName: "csv2json",
+          // publishDate:  "2014-04-01",
+          previousPublishDate: "2015-01-08",
+          previousMaturity: "FPWD",
+          previousURI: "http://www.w3.org/TR/2015/WD-csv2json-20150108/",
+          edDraftURI: "http://w3c.github.io/csvw/csv2json/",
+          // lcEnd: "3000-01-01",
+          // crEnd: "3000-01-01",
+          editors:
+           [{
+                  name: "Jeremy Tandy",
+                  company: "Met Office",
+                  companyURL: "http://www.metoffice.gov.uk/",
+                  w3cid: "65512"
+            },{
+             name: "Ivan Herman",
+             url: "http://www.w3.org/People/Ivan",
+             company: "W3C",
+             companyURL: "http://www.w3.org",
+             w3cid: "7382"
+           }],
+          wg: "CSV on the Web Working Group",
+          wgURI: "http://www.w3.org/2013/csvw/",
+          wgPublicList: "public-csv-wg",
+          wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
+          otherLinks: [{
+            key: "Repository",
+            data: [{
+                value: "We are on Github",
+                href: "https://github.com/w3c/csvw/"
+              }, {
+                value: "File a bug",
+                href: "https://github.com/w3c/csvw/issues"
+              }]
+            } , 
+            {
+              key: "Changes",
+              data: [{
+              //     value: "Diff to previous version",
+              //     href: "diff-20140327.html"
+              //   }, {}
+                 value: "Commit history",
+                 href: "https://github.com/w3c/csvw/commits/gh-pages"
+               }]
+             }] ,
+          inlineCSS: true,
+          noIDLIn: true,
+          issueBase: "https://github.com/w3c/csvw/issues/",
+          noLegacyStyle: false
+          };
     </script>
     <style type="text/css">
       .grammar td { font-family: monospace; vertical-align: top; }
@@ -783,7 +783,7 @@ var respecConfig = {
       <section id="example-tree-ops-ext">
         <h3>Example with single table and rich annotations</h3>
         <p>
-          This example is based on <a href="http://www.w3.org/TR/csvw-ucr/#UC-PaloAltoTreeData">Use Case #11 - City of Palo Alto Tree Data</a> and comprises a single <a>annotated table</a> describing an inventory of tree maintenance operations. The input tabular data file, published at <code>http://example.org/tree-ops-ext.csv</code>, and the associated metadata description <code>http://example.org/tree-ops-ext.csv-metadata.json</code> are provided below:
+          This example is based on <a href="http://w3c.github.io/csvw/use-cases-and-requirements/#UC-PaloAltoTreeData">Use Case #11 - City of Palo Alto Tree Data</a> and comprises a single <a>annotated table</a> describing an inventory of tree maintenance operations. The input tabular data file, published at <code>http://example.org/tree-ops-ext.csv</code>, and the associated metadata description <code>http://example.org/tree-ops-ext.csv-metadata.json</code> are provided below:
         </p>
         <pre class="example"
              id="example-tree-ops-ext-csv+"
@@ -1086,7 +1086,7 @@ var respecConfig = {
       <section id="example-public-sector-roles-and-salaries">
         <h3>Example with table group comprising three interrelated tables</h3>
         <p>
-          This example is based on <a href="http://www.w3.org/TR/csvw-ucr/#UC-OrganogramData">Use Case #4 - Publication of public sector roles and salaries</a> and uses three <a title="annotated table">annotated tables</a> published within a <a>table group</a>. Information about senior roles and junior roles within a government department are published in CSV format by each department. These are validated against a centrally published <a href="http://w3c.github.io/csvw/metadata/#dfn-tableschema" class="externalDFN">schema</a> to ensure that all the data published by departments is consistent. Additionally, a list of professions is also published centrally, providing a <em>controlled vocabulary</em> against which departmental submissions are validated.
+          This example is based on <a href="http://w3c.github.io/csvw/use-cases-and-requirements/#UC-OrganogramData">Use Case #4 - Publication of public sector roles and salaries</a> and uses three <a title="annotated table">annotated tables</a> published within a <a>table group</a>. Information about senior roles and junior roles within a government department are published in CSV format by each department. These are validated against a centrally published <a href="http://w3c.github.io/csvw/metadata/#dfn-tableschema" class="externalDFN">schema</a> to ensure that all the data published by departments is consistent. Additionally, a list of professions is also published centrally, providing a <em>controlled vocabulary</em> against which departmental submissions are validated.
         </p>
 
         <p> 

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -5,73 +5,72 @@
     <meta content="width=device-width,initial-scale=1" name="viewport">
     <title>Generating RDF from Tabular Data on the Web</title>
     <link href="hide.css" rel="stylesheet">
-    <script type="text/javascript" src="hide.js">
-    </script>
-    <script src="../local-biblio.js" class="remove"></script>
-    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
-	  </script>
+    <script type="text/javascript" src="hide.js"></script>
+    <script class="remove" src="../local-biblio.js"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
-var respecConfig = {
-    localBiblio: localBibliography,
-    doRdfa: true,
-    specStatus: "ED",
-    shortName: "csv2rdf",
-    // publishDate:  "2014-04-01",
-    previousPublishDate: "2014-01-08",
-    previousMaturity: "FPWD",
-    previousURI: "http://www.w3.org/TR/2015/WD-csv2rdf-20150108/",
-    edDraftURI: "http://w3c.github.io/csvw/csv2rdf/",
-    // lcEnd: "3000-01-01",
-    // crEnd: "3000-01-01",
-    editors:
-     [{
-            name: "Jeremy Tandy",
-            company: "Met Office",
-            companyURL: "http://www.metoffice.gov.uk/",
-            w3cid: "65512"
-      },
-      {
-       name: "Ivan Herman",
-       url: "http://www.w3.org/People/Ivan",
-       company: "W3C",
-       companyURL: "http://www.w3.org",
-       w3cid: "7382"
-     }, { 
-      name: "Gregg Kellogg", 
-      url: "http://greggkellogg.net/",
-      company: "Kellogg Associates", 
-      companyURL: "http://kellogg-assoc.com/",
-      w3cid: "44770"
-    }],
-    wg: "CSV on the Web Working Group",
-    wgURI: "http://www.w3.org/2013/csvw/",
-    wgPublicList: "public-csv-wg",
-    wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
-    otherLinks: [{
-      key: "Repository",
-      data: [{
-          value: "We are on Github",
-          href: "https://github.com/w3c/csvw/"
-        }, {
-          value: "File a bug",
-          href: "https://github.com/w3c/csvw/issues"
-        }]
-      }, 
-      {
-        key: "Changes",
-        data: [{
-        //     value: "Diff to previous version",
-        //     href: "diff-20140327.html"
-        //   }, {}
-           value: "Commit history",
-           href: "https://github.com/w3c/csvw/commits/gh-pages"
-         }]
-       }] ,
-    inlineCSS: true,
-    noIDLIn: true,
-    issueBase: "https://github.com/w3c/csvw/issues/",
-    noLegacyStyle: false
-    };
+      var respecConfig = {
+          localBiblio: localBibliography,
+          doRdfa: true,
+          specStatus: "ED",
+          shortName: "csv2rdf",
+          // publishDate:  "2014-04-01",
+          previousPublishDate: "2014-01-08",
+          previousMaturity: "FPWD",
+          previousURI: "http://www.w3.org/TR/2015/WD-csv2rdf-20150108/",
+          edDraftURI: "http://w3c.github.io/csvw/csv2rdf/",
+          // lcEnd: "3000-01-01",
+          // crEnd: "3000-01-01",
+          editors:
+           [{
+                  name: "Jeremy Tandy",
+                  company: "Met Office",
+                  companyURL: "http://www.metoffice.gov.uk/",
+                  w3cid: "65512"
+            },
+            {
+             name: "Ivan Herman",
+             url: "http://www.w3.org/People/Ivan",
+             company: "W3C",
+             companyURL: "http://www.w3.org",
+             w3cid: "7382"
+           }, { 
+            name: "Gregg Kellogg", 
+            url: "http://greggkellogg.net/",
+            company: "Kellogg Associates", 
+            companyURL: "http://kellogg-assoc.com/",
+            w3cid: "44770"
+          }],
+          wg: "CSV on the Web Working Group",
+          wgURI: "http://www.w3.org/2013/csvw/",
+          wgPublicList: "public-csv-wg",
+          wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
+          otherLinks: [{
+            key: "Repository",
+            data: [{
+                value: "We are on Github",
+                href: "https://github.com/w3c/csvw/"
+              }, {
+                value: "File a bug",
+                href: "https://github.com/w3c/csvw/issues"
+              }]
+            }, 
+            {
+              key: "Changes",
+              data: [{
+              //     value: "Diff to previous version",
+              //     href: "diff-20140327.html"
+              //   }, {}
+                 value: "Commit history",
+                 href: "https://github.com/w3c/csvw/commits/gh-pages"
+               }]
+             }] ,
+          inlineCSS: true,
+          noIDLIn: true,
+          issueBase: "https://github.com/w3c/csvw/issues/",
+          noLegacyStyle: false
+          };
     </script>
     <script class="remove">
     function updateExample(doc, content) {
@@ -727,7 +726,7 @@ var respecConfig = {
       <section id="example-tree-ops-ext">
         <h3>Example with single table and rich annotations</h3>
         <p>
-          This example is based on <a href="http://www.w3.org/TR/csvw-ucr/#UC-PaloAltoTreeData">Use Case #11 - City of Palo Alto Tree Data</a> and comprises a single <a>annotated table</a> describing an inventory of tree maintenance operations. The input tabular data file, published at <code>http://example.org/tree-ops-ext.csv</code>, and the associated metadata description <code>http://example.org/tree-ops-ext.csv-metadata.json</code> are provided below:
+          This example is based on <a href="http://w3c.github.io/csvw/use-cases-and-requirements/#UC-PaloAltoTreeData">Use Case #11 - City of Palo Alto Tree Data</a> and comprises a single <a>annotated table</a> describing an inventory of tree maintenance operations. The input tabular data file, published at <code>http://example.org/tree-ops-ext.csv</code>, and the associated metadata description <code>http://example.org/tree-ops-ext.csv-metadata.json</code> are provided below:
         </p>
         <pre class="example"
              id="example-tree-ops-ext-csv+"
@@ -1037,7 +1036,7 @@ var respecConfig = {
       <section id="example-public-sector-roles-and-salaries">
         <h3>Example with table group comprising three interrelated tables</h3>
         <p>
-          This example is based on <a href="http://www.w3.org/TR/csvw-ucr/#UC-OrganogramData">Use Case #4 - Publication of public sector roles and salaries</a> and uses three <a title="annotated table">annotated tables</a> published within a <a>table group</a>. Information about senior roles and junior roles within a government department are published in CSV format by each department. These are validated against a centrally published <a href="http://w3c.github.io/csvw/metadata/#dfn-tableschema" class="externalDFN">schema</a> to ensure that all the data published by departments is consistent. Additionally, a list of professions is also published centrally, providing a <em>controlled vocabulary</em> against which departmental submissions are validated.
+          This example is based on <a href="http://w3c.github.io/csvw/use-cases-and-requirements/#UC-OrganogramData">Use Case #4 - Publication of public sector roles and salaries</a> and uses three <a title="annotated table">annotated tables</a> published within a <a>table group</a>. Information about senior roles and junior roles within a government department are published in CSV format by each department. These are validated against a centrally published <a href="http://w3c.github.io/csvw/metadata/#dfn-tableschema" class="externalDFN">schema</a> to ensure that all the data published by departments is consistent. Additionally, a list of professions is also published centrally, providing a <em>controlled vocabulary</em> against which departmental submissions are validated.
         </p>
 
         <p> 

--- a/local-biblio.js
+++ b/local-biblio.js
@@ -1,3 +1,11 @@
+var conversions = [
+  ["http://w3c.github.io/csvw/syntax/", "http://www.w3.org/TR/2015/WD-tabular-data-model-20150416/"],
+  ["http://w3c.github.io/csvw/csv2rdf/", "http://www.w3.org/TR/2015/WD-csv2rdf-20150416/"],
+  ["http://w3c.github.io/csvw/csv2json/", "http://www.w3.org/TR/2015/WD-csv2json-20150416/"],
+  ["http://w3c.github.io/csvw/metadata/", "http://www.w3.org/TR/2015/WD-tabular-metadata-20150416/"],
+  ["http://w3c.github.io/csvw/use-cases-and-requirements/", "http://www.w3.org/TR/2014/WD-csvw-ucr-20140701/"]          
+];
+
 var localBibliography = {
   "tabular-data-model": {
       "authors": [
@@ -5,7 +13,7 @@ var localBibliography = {
         "Gregg Kellogg"
       ],
       "title": "Model for Tabular Data and Metadata on the Web",
-      "href" : "http://www.w3.org/TR/2014/WD-tabular-data-model-20150108/",
+      "href" : "http://w3c.github.io/csvw/syntax/",
       "rawDate": "2015-01-08",
       "status" : "WD",
       "publisher": "W3C"
@@ -16,7 +24,7 @@ var localBibliography = {
         "Gregg Kellogg"
       ],
       "title": "Metadata Vocabulary for Tabular Data",
-      "href" : "http://www.w3.org/TR/tabular-metadata/",
+      "href" : "http://w3c.github.io/csvw/metadata/",
       "rawDate": "2015-01-08",
       "status" : "WD",
       "publisher": "W3C"
@@ -27,7 +35,7 @@ var localBibliography = {
         "Ivan Herman"
       ],
       "title": "Generating JSON from Tabular Data on the Web",
-      "href" : "http://www.w3.org/TR/2015/WD-csv2json-20150108/",
+      "href" : "http://w3c.github.io/csvw/csv2json/",
       "rawDate": "2015-01-08",
       "status" : "WD",
       "publisher": "W3C"
@@ -39,7 +47,7 @@ var localBibliography = {
         "Gregg Kellogg"
       ],
       "title": "Generating RDF from Tabular Data on the Web",
-      "href" : "http://www.w3.org/TR/2015/WD-csv2rdf-20150108/",
+      "href" : "http://w3c.github.io/csvw/csv2rdf/",
       "rawDate": "2015-01-08",
       "status" : "WD",
       "publisher": "W3C"
@@ -72,7 +80,7 @@ var localBibliography = {
     "rawDate" : "2008-11-26",
     "status" : "REC",
     "publisher" : "W3C",
-    "href" : "http://www.w3.org/TR/REC-xml/#sec-notation"
+    "href" : "http://www.w3.org/TR/xml/#sec-notation"
   },
   "Knuth" : {
     "author" : [

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -4,85 +4,85 @@
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>Metadata Vocabulary for Tabular Data</title>
-    <script src="../local-biblio.js" class="remove"></script>
-    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
-		</script>
+    <script class="remove" src="../local-biblio.js"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
-var respecConfig = {
-    localBiblio: localBibliography,
-    specStatus: "ED",
-    shortName: "tabular-metadata",
-    //publishDate:  "2014-03-27",
-    previousPublishDate: "2015-01-08",
-    previousMaturity: "WD",
-    previousURI: "http://www.w3.org/TR/2014/WD-tabular-metadata-20150108/",
-    edDraftURI: "http://w3c.github.io/csvw/metadata/",
-    // lcEnd: "3000-01-01",
-    // crEnd: "3000-01-01",
-    editors: [{
-      name: "Jeni Tennison",
-      company: "Open Data Institute",
-      companyURL: "http://theodi.org/",
-      w3cid: "33715"
-    }, { 
-      name: "Gregg Kellogg", 
-      url: "http://greggkellogg.net/",
-      company: "Kellogg Associates", 
-      companyURL: "http://kellogg-assoc.com/",
-      w3cid: "44770"
-    }],
-    authors: [{ 
-      name: "Rufus Pollock", 
-      url: "http://rufuspollock.org/",
-      company: "Open Knowledge", 
-      companyURL: "https://okfn.org/",
-      w3cid: "62304"
-    }, {
-      name: "Jeni Tennison",
-      company: "Open Data Institute",
-      companyURL: "http://theodi.org/",
-      w3cid: "33715"
-    }, { 
-      name: "Gregg Kellogg", 
-      url: "http://greggkellogg.net/",
-      company: "Kellogg Associates", 
-      companyURL: "http://kellogg-assoc.com/",
-      w3cid: "44770"
-    }, {
-       name: "Ivan Herman",
-       url: "http://www.w3.org/People/Ivan",
-       company: "W3C",
-       companyURL: "http://www.w3.org",
-       w3cid: "7382"
-     }],
-    wg: "CSV on the Web Working Group",
-    wgURI: "http://www.w3.org/2013/csvw/",
-    wgPublicList: "public-csv-wg",
-    wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
-    otherLinks: [{
-      key: "Repository",
-      data: [{
-          value: "We are on Github",
-          href: "https://github.com/w3c/csvw"
-      }, {
-          value: "File a bug",
-          href: "https://github.com/w3c/csvw"
-      }]
-      }, {
-      key: "Changes",
-        data: [{
-          value: "Diff to previous version",
-          href: "diff-20150108.html"
-        }, {
-          value: "Commit history",
-          href: "https://github.com/w3c/csvw/commits/gh-pages"
-      }]
-    }],
-    inlineCSS: true,
-    issueBase: "https://github.com/w3c/csvw/issues/",
-    noIDLIn: true,
-    noLegacyStyle: false
-    };
+      var respecConfig = {
+          localBiblio: localBibliography,
+          specStatus: "ED",
+          shortName: "tabular-metadata",
+          //publishDate:  "2014-03-27",
+          previousPublishDate: "2015-01-08",
+          previousMaturity: "WD",
+          previousURI: "http://www.w3.org/TR/2014/WD-tabular-metadata-20150108/",
+          edDraftURI: "http://w3c.github.io/csvw/metadata/",
+          // lcEnd: "3000-01-01",
+          // crEnd: "3000-01-01",
+          editors: [{
+            name: "Jeni Tennison",
+            company: "Open Data Institute",
+            companyURL: "http://theodi.org/",
+            w3cid: "33715"
+          }, { 
+            name: "Gregg Kellogg", 
+            url: "http://greggkellogg.net/",
+            company: "Kellogg Associates", 
+            companyURL: "http://kellogg-assoc.com/",
+            w3cid: "44770"
+          }],
+          authors: [{ 
+            name: "Rufus Pollock", 
+            url: "http://rufuspollock.org/",
+            company: "Open Knowledge", 
+            companyURL: "https://okfn.org/",
+            w3cid: "62304"
+          }, {
+            name: "Jeni Tennison",
+            company: "Open Data Institute",
+            companyURL: "http://theodi.org/",
+            w3cid: "33715"
+          }, { 
+            name: "Gregg Kellogg", 
+            url: "http://greggkellogg.net/",
+            company: "Kellogg Associates", 
+            companyURL: "http://kellogg-assoc.com/",
+            w3cid: "44770"
+          }, {
+             name: "Ivan Herman",
+             url: "http://www.w3.org/People/Ivan",
+             company: "W3C",
+             companyURL: "http://www.w3.org",
+             w3cid: "7382"
+           }],
+          wg: "CSV on the Web Working Group",
+          wgURI: "http://www.w3.org/2013/csvw/",
+          wgPublicList: "public-csv-wg",
+          wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
+          otherLinks: [{
+            key: "Repository",
+            data: [{
+                value: "We are on Github",
+                href: "https://github.com/w3c/csvw"
+            }, {
+                value: "File a bug",
+                href: "https://github.com/w3c/csvw"
+            }]
+            }, {
+            key: "Changes",
+              data: [{
+                value: "Diff to previous version",
+                href: "diff-20150108.html"
+              }, {
+                value: "Commit history",
+                href: "https://github.com/w3c/csvw/commits/gh-pages"
+            }]
+          }],
+          inlineCSS: true,
+          issueBase: "https://github.com/w3c/csvw/issues/",
+          noIDLIn: true,
+          noLegacyStyle: false
+          };
     </script>
     <script class="remove">
     function escapeContent(doc, content) {
@@ -841,7 +841,7 @@ CSVW,foaf:Project,table;data;conversion
           <section>
             <h4>Foreign Key Reference Between Schemas</h4>
             <p>
-              When publishing information about public sector roles and salaries, as in <a href="http://w3c.github.io/csvw/csvw-ucr/#UC-OrganogramData">Use Case 4</a>, the UK government requires departments to publish two files which are interlinked. The first lists senior grades (simplified here) e.g., at <code>HEFCE_organogram_senior_data_31032011.csv</code>:
+              When publishing information about public sector roles and salaries, as in <a href="http://w3c.github.io/csvw/use-cases-and-requirements/#UC-OrganogramData">Use Case 4</a>, the UK government requires departments to publish two files which are interlinked. The first lists senior grades (simplified here) e.g., at <code>HEFCE_organogram_senior_data_31032011.csv</code>:
             </p>
             <pre class="example">
 Post Unique Reference,              Name,Grade,             Job Title,Reports to Senior Post

--- a/publishing_process.md
+++ b/publishing_process.md
@@ -12,10 +12,11 @@ the ``/publishing-snapshot`` directory contains specific milestone publications,
 
 (Obviously, many of these steps are typically done in your local repo and then committed to github when appropriate.)
 
+1. Update the ``/local-biblio.js`` and change the URL-s in the ``conversions`` array to reflect the right URI for the ``/TR`` document. This step will ensure that the right cross references will be generated in the final document (by the ``/replace-ed-uris.js`` script). (Note that this step is very specific to this repository, and may not be relevant for others.)
 1. Create a new subdirectory in ``/publishing-snapshot``, say, ``publishing-snapshot/WD-syntax-2014-12-12``. 
-2. Copy all the auxiliary files (e.g., data files, BNF files, etc) from the main repo area.
-3. (Before you forget:-) add an entry to the new directory in ``index.html`` on the top of the repository
-4. Generate the pure HTML file:
+1. Copy all the auxiliary files (e.g., data files, BNF files, etc) from the main repo area. Note that not *all* the files are necessary for final publications; e.g., the diagrams have a ``.key`` and ``.pdf`` versions that are used in the process of creating those diagrams, but only the ``.svg`` and ``.png`` files are used in the final document.
+1. (Before you forget:-) add an entry to the new directory in ``/index.html`` on the top of the repository
+1. Generate the pure HTML file:
 	1. Finalize/change the ``index.html`` file in ``/syntax``
 	1. Commit all the files to github
 	1. From your Web browser, use the following URI: ``http://w3c.github.io/csvw/syntax/index.html?specStatus=WD;publishDate=2014-12-12`` (note the URI parameters to set the ``specStatus`` and ``publishDate`` values!). You should see the final format on your screen.

--- a/replace-ed-uris.js
+++ b/replace-ed-uris.js
@@ -1,0 +1,17 @@
+respecEvents.sub("save", function() {
+  $("a").not( $("div.head a") ).each( function(index) {
+    var href = $(this).attr("href");
+    for( var i = 0; i < conversions.length; i++ ) {
+      var to_be_replaced = conversions[i][0];
+      var replacement    = conversions[i][1];
+      if( href.indexOf(to_be_replaced) !== -1 ) {
+        var new_href = href.replace(to_be_replaced,replacement);
+        $(this).attr("href", new_href)
+        if( $(this).text().indexOf(to_be_replaced) !== -1 ) {
+          $(this).text(replacement);
+        }
+        break;
+      }
+    }
+  })
+});

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -4,79 +4,79 @@
     <meta charset="utf-8" />
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>Model for Tabular Data and Metadata on the Web</title>
-    <script src="../local-biblio.js" class="remove"></script>
-    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common">
-		</script>
+    <script class="remove" src="../local-biblio.js"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
-var respecConfig = {
-    localBiblio: localBibliography,
-    specStatus: "ED",
-    shortName: "tabular-data-model",
-    //publishDate:  "2014-03-27",
-    previousPublishDate: "2015-01-08",
-    previousMaturity: "WD",
-    previousURI: "http://www.w3.org/TR/2014/WD-tabular-data-model-20150108/",
-    edDraftURI: "http://w3c.github.io/csvw/syntax/",
-    // lcEnd: "3000-01-01",
-    // crEnd: "3000-01-01",
-    editors: [{
-      name: "Jeni Tennison",
-      company: "Open Data Institute",
-      companyURL: "http://theodi.org/",
-      w3cid: "33715"
-    }, { 
-      name: "Gregg Kellogg", 
-      url: "http://greggkellogg.net/",
-      company: "Kellogg Associates", 
-      companyURL: "http://kellogg-assoc.com/",
-      w3cid: "44770"
-    }],
-    authors: [{
-      name: "Jeni Tennison",
-      company: "Open Data Institute",
-      companyURL: "http://theodi.org/",
-      w3cid: "33715"
-    }, { 
-      name: "Gregg Kellogg", 
-      url: "http://greggkellogg.net/",
-      company: "Kellogg Associates", 
-      companyURL: "http://kellogg-assoc.com/",
-      w3cid: "44770"
-    }, {
-       name: "Ivan Herman",
-       url: "http://www.w3.org/People/Ivan",
-       company: "W3C",
-       companyURL: "http://www.w3.org",
-       w3cid: "7382"
-     }],
-    wg: "CSV on the Web Working Group",
-    wgURI: "http://www.w3.org/2013/csvw/",
-    wgPublicList: "public-csv-wg",
-    wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
-    otherLinks: [{
-      key: "Repository",
-      data: [{
-          value: "We are on Github",
-          href: "https://github.com/w3c/csvw"
-      }, {
-          value: "File a bug",
-          href: "https://github.com/w3c/csvw"
-      }]
-      }, {
-      key: "Changes",
-        data: [{
-          value: "Diff to previous version",
-          href: "diff-20150108.html"
+      var respecConfig = {
+        localBiblio: localBibliography,
+        specStatus: "ED",
+        shortName: "tabular-data-model",
+        //publishDate:  "2014-03-27",
+        previousPublishDate: "2015-01-08",
+        previousMaturity: "WD",
+        previousURI: "http://www.w3.org/TR/2014/WD-tabular-data-model-20150108/",
+        edDraftURI: "http://w3c.github.io/csvw/syntax/",
+        // lcEnd: "3000-01-01",
+        // crEnd: "3000-01-01",
+        editors: [{
+          name: "Jeni Tennison",
+          company: "Open Data Institute",
+          companyURL: "http://theodi.org/",
+          w3cid: "33715"
+        }, { 
+          name: "Gregg Kellogg", 
+          url: "http://greggkellogg.net/",
+          company: "Kellogg Associates", 
+          companyURL: "http://kellogg-assoc.com/",
+          w3cid: "44770"
+        }],
+        authors: [{
+          name: "Jeni Tennison",
+          company: "Open Data Institute",
+          companyURL: "http://theodi.org/",
+          w3cid: "33715"
+        }, { 
+          name: "Gregg Kellogg", 
+          url: "http://greggkellogg.net/",
+          company: "Kellogg Associates", 
+          companyURL: "http://kellogg-assoc.com/",
+          w3cid: "44770"
         }, {
-          value: "Commit history",
-          href: "https://github.com/w3c/csvw/commits/gh-pages"
-      }]
-    }],
-    inlineCSS: true,
-    issueBase: "https://github.com/w3c/csvw/issues/",
-    noIDLIn: true,
-    noLegacyStyle: false
-    };
+           name: "Ivan Herman",
+           url: "http://www.w3.org/People/Ivan",
+           company: "W3C",
+           companyURL: "http://www.w3.org",
+           w3cid: "7382"
+         }],
+        wg: "CSV on the Web Working Group",
+        wgURI: "http://www.w3.org/2013/csvw/",
+        wgPublicList: "public-csv-wg",
+        wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
+        otherLinks: [{
+          key: "Repository",
+          data: [{
+              value: "We are on Github",
+              href: "https://github.com/w3c/csvw"
+          }, {
+              value: "File a bug",
+              href: "https://github.com/w3c/csvw"
+          }]
+          }, {
+          key: "Changes",
+            data: [{
+              value: "Diff to previous version",
+              href: "diff-20150108.html"
+            }, {
+              value: "Commit history",
+              href: "https://github.com/w3c/csvw/commits/gh-pages"
+          }]
+        }],
+        inlineCSS: true,
+        issueBase: "https://github.com/w3c/csvw/issues/",
+        noIDLIn: true,
+        noLegacyStyle: false
+      };
     </script>
     <script class="remove">
     function escapeContent(doc, content) {
@@ -492,7 +492,7 @@ Link: &lt;metadata.json&gt;; rel="describedBy"; type="application/csvm+json"
           <li>Retrieve the metadata file yielding the metadata <code>UM<sub>M</sub></code> (which is treated as overriding metadata, see <a href="#overriding-metadata" class="sectionRef"></a>).</li>
           <li>For each <a>table</a> in <code>UM<sub>M</sub></code> in order, create one or more <a title="annotated table">annotated tables</a>:
             <ol class="algorithm">
-              <li>Extract the <a href="http://www.w3.org/TR/tabular-metadata/#dialect-descriptions">dialect description</a> (<code>DD</code>) from <code>UM<sub>M</sub></code> for the <a>table</a> associated with the tabular data file. If there is no such dialect description, extract the first available dialect description from a <a>group of tables</a> in which the tabular data file is described. Otherwise use the default dialect description.</li>
+              <li>Extract the <a href="http://w3c.github.io/csvw/metadata/#dialect-descriptions">dialect description</a> (<code>DD</code>) from <code>UM<sub>M</sub></code> for the <a>table</a> associated with the tabular data file. If there is no such dialect description, extract the first available dialect description from a <a>group of tables</a> in which the tabular data file is described. Otherwise use the default dialect description.</li>
               <li>If the tabular data file was retrieved with <code>Content-Type</code> including the <code>header=absent</code> parameter set <code>header</code> to <code>false</code> in <code>DD</code>.</li>
               <li>
                 <p>Parse the tabular data file, using <code>DD</code> as a guide, to create a basic tabular data model (<code>T</code>) and extract <a>embedded metadata</a> (<code>EM</code>), for example from the <a>header line</a>.</p>


### PR DESCRIPTION
I have added a script (`replace-ed-uri.js`) that turns all the URI-s we use for editor's drafts (i.e., `w3c.github.io/csvw/...`) into their official `/TR` addresses when publishing. This happens when the `respec` facilities are used to generate a static `Overview.html` file.

What this means is that we can use our own github URI-s for cross-references, i.e., the github "view" of all our editors' drafts are consistent; on the other hand, the `/TR` publications will be as they should be.

The "mapping" table has been added to `local-biblio.js`. Note that those URI-s should be updated before publication to use the official, dated URI-s. (I have added a note to the publishing process note on the repo) Note that I have also changed the bibliography to use the editors' draft addresses to make the editors' drafts consistent in the references, too. The references will be updated by the script, too.

(One caveat: the process occurs on the DOM tree of the page. What this means is that, when a file has been saved, the original, respec file in the browser will actually be changed to the new URI-s. A reload may be necessary.)

All four documents have been updated.

@gkellogg, it would be neat if you made a sanity check on this before merging.
