### PR TITLE
IH's review of the csv2* documents

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -93,6 +93,7 @@
       }
       ol.algorithm>li p {text-indent: 0em}
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
+      dd a.externalDFN, p a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
       pre {overflow: auto;}
     </style>
   </head>
@@ -111,13 +112,13 @@
 
       <p class="note">The conversion of CSV content to JSON is intended for web developers who need not care about the complexities of RDF [[!rdf11-concepts]]. Where the formality of RDF is required, [[!csv2rdf]] provides the procedures for mapping from CSV content to RDF which may be serialized to [[json-ld]].</p>
 
-      <p> The [[!tabular-data-model]] defines an <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model" class="externalDFN">annotated tabular data model</a> consisting of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-column" class="externalDFN">columns</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a> and <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a>, enriched with <a href="http://w3c.github.io/csvw/syntax/#dfn-annotation" class="externalDFN">annotations</a> that describe the structure of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> and the meaning of its content. A <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> is a collection of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> published as a single atomic unit.</p>
+      <p> The [[!tabular-data-model]] defines an <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model" class="externalDFN">annotated tabular data model</a> consisting of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-column" class="externalDFN">columns</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, and <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a>, enriched with <a href="http://w3c.github.io/csvw/syntax/#dfn-annotation" class="externalDFN">annotations</a> that describe the structure of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> and the meaning of its content. A <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> is a collection of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> published as a single atomic unit.</p>
 
       <p>The conversion procedure described in this specification operates on the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a>. This specification does not specify the processes needed to convert CSV-encoded data into tabular data form. Please refer to [[!tabular-data-model]] for details of <a href="http://w3c.github.io/csvw/syntax/#parsing">parsing tabular data</a>.</p>
 
       <p>Conversion applications MUST provide at least two modes of operation: <a title="standard mode">standard</a> and <a title="minimal mode">minimal</a>.</p>
 
-      <p><dfn title="standard mode">Standard mode</dfn> conversion frames the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> with details of the <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> and a <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> within which that information is provided.</p>
+      <p><dfn title="standard mode">Standard mode</dfn> conversion frames the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> with details of the <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, and a <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> within which that information is provided.</p>
 
       <p><dfn title="minimal mode">Minimal mode</dfn> conversion includes <em>only</em> the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> within the output.</p>
 
@@ -127,7 +128,7 @@
 
       <p><a href="http://w3c.github.io/csvw/metadata/#dfn-conversion-specification" class="externalDFN">Conversion specifications</a>, as defined in [[!tabular-metadata]] MAY be used to specify how <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> can be transformed into another format using a script or template. Such a <a href="http://w3c.github.io/csvw/metadata/#dfn-conversion-specification" class="externalDFN">conversion specification</a> MAY use the JSON output described in this specification as input.</p>
 
-      <p>The conversion procedure described in this specification is considered to be <em>entirely textual</em>. There is no requirement on conversion applications to check the semantic consistency of the data during the conversion, nor validate the output against JSON syntax rules. Downstream applications SHOULD be aware of the potential for syntax errors and take appropriate action.</p>
+      <p>The conversion procedure described in this specification is considered to be <em>entirely textual</em>. There is no requirement on conversion applications to check the semantic consistency of the data during the conversion, nor to validate the output against JSON syntax rules. Downstream applications SHOULD be aware of the potential for syntax errors and take appropriate action.</p>
     </section>
 
     <section id="conformance">
@@ -299,7 +300,7 @@
                   </dl>
                 </li>
                 <li>
-                  <p>Insert any <a>notes</a> and <a>common properties</a> specified for the <a title="annotated table">table</a> into <a>object</a> <var>T</var>. according to the rules provided in <a href="#json-ld-to-json"></a>.</p>
+                  <p>Insert any <a>notes</a> and <a>common properties</a> specified for the <a title="annotated table">table</a> into <a>object</a> <var>T</var> according to the rules provided in <a href="#json-ld-to-json"></a>.</p>
                   <p class="note">All other annotations for the <a title="annotated table">table</a> are ignored during the conversion; including information about <a href="http://w3c.github.io/csvw/metadata/#dfn-tableschema" class="externalDFN">table schemas</a> and <a href="http://w3c.github.io/csvw/metadata/#dfn-column-description" class="externalDFN">column descriptions</a> specified therein, <a href="http://w3c.github.io/csvw/metadata/#dfn-dialect-description" class="externalDFN">dialect descriptions</a>, <a href="http://w3c.github.io/csvw/metadata/#dfn-foreign-key-definition" class="externalDFN">foreign-key-definitions</a> etc.</p>
                 </li>
                 <li>
@@ -448,13 +449,11 @@
         <h2>Generating Nested Objects</h2>
         <p>The steps in the algorithm defined herein apply to both <a title="standard mode">standard</a> <em>and</em> <a title="minimal mode">minimal</a> modes.</p>
 
-        <p>Where the current <a>row</a> describes multiple <a title="subject">subjects</a>, it MAY be possible to organise the <a title="object">objects</a> associated with those <a title="subject">subjects</a> such that some <a title="object">objects</a> are <em>nested</em> within others; e.g. where the <a>valueUrl</a> property for one <a>cell</a> matches the <a>aboutUrl</a> property for another <a>cell</a> in the same <a>row</a>.</p>
-
-        <p>This algorithm considers a sequence of <a title="object">objects</a> generated according to <a href="#gen-subj-cells"></a>, <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var>, each of which corresponds to a <a>subject</a> described by the current <a>row</a>. It generates a new sequence of <a>root</a> <a title="object">objects</a>, <var>S<sup>R</sup><sub>1</sub></var> to <var>S<sup>R</sup><sub>m</sub></var>, that MAY include <em>nested</em> <a title="object">objects</a>.</p>
+        <p>Where the current <a>row</a> describes multiple <a title="subject">subjects</a>, it MAY be possible to organise the <a title="object">objects</a> associated with those <a title="subject">subjects</a> such that some <a title="object">objects</a> are <em>nested</em> within others; e.g. where the <a>valueUrl</a> property for one <a>cell</a> matches the <a>aboutUrl</a> property for another <a>cell</a> in the same <a>row</a>. This algorithm considers a sequence of <a title="object">objects</a> generated according to <a href="#gen-subj-cells"></a>, <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var>, each of which corresponds to a <a>subject</a> described by the current <a>row</a>. It generates a new sequence of <a>root</a> <a title="object">objects</a>, <var>S<sup>R</sup><sub>1</sub></var> to <var>S<sup>R</sup><sub>m</sub></var>, that MAY include <em>nested</em> <a title="object">objects</a>.</p>
 
         <p class="note">Where the current <a>row</a> describes only a single <a>subject</a>, this algorithm may be bypassed as no nesting is possible. In such a case, the <a>root</a> <a>object</a> <var>S<sup>R</sup><sub>1</sub></var> is identical to the original <a>object</a> <var>S<sub>1</sub></var>.</p>
 
-        <p class="note">This nesting algorithm is based on the interrelationships between <a title="subject">subjects</a> described within a given <a>row</a> that are specified using the <a>valueUrl</a> property. <a title="cell value">Cell values</a> expressing the identity of a <a>subject</a> in the current <a>row</a> (e.g. as a simple literal) will be ignored by this algorithm.</p>
+        <p class="note">This nesting algorithm is based on the interrelationships between <a title="subject">subjects</a> described within a given <a>row</a> that are specified using the <a>valueUrl</a> property. <a title="cell value">Cell values</a> expressing the identity of a <a>subject</a> in the current <a>row</a> (i.e., as a simple literal) will be ignored by this algorithm.</p>
 
         <p>The algorithm uses the following terms:</p>
         <dl>
@@ -512,14 +511,14 @@
                     <p>For <a>object</a> <var>S<sub>j</sub></var>, if the name-value pair with <a>name</a> <code>@id</code> is present and its value matches <var>V<sub>url</sub></var>, then:</p>
                     <ol class="algorithm">
                       <li>
-                        <p>If the <a>root</a> of the <a>tree</a> containing <a>vertex</a> <var>N</var> is a <a>vertex</a> that represents <a>object</a> <var>S<sub>j</sub></var>, then <a>object</a> <var>S<sub>i</sub></var> is already a <a>descendant</a> of <a>object</a> <var>S<sub>j</sub></var>; no further action can be taken for this instance of <var>V<sub>url</sub></var>.</p>
+                        <p>If the <a>root</a> of the <a>tree</a> containing <a>vertex</a> <var>N</var> is a <a>vertex</a> that represents <a>object</a> <var>S<sub>j</sub></var>, then <a>object</a> <var>S<sub>i</sub></var> is already a <a>descendant</a> of <a>object</a> <var>S<sub>j</sub></var>; no further action should be taken for this instance of <var>V<sub>url</sub></var>.</p>
                         <div class="note">
                           <p>This clause in the algorithm prevents circular loops being created.</p>
                           <p>Furthermore, because the <em>URL-list</em> contains <a title="valueUrl">valueUrls</a> that occur only once for the current <a>row</a>, <a>object</a> <var>S<sub>i</sub></var> cannot be a <a>descendant</a> of an intermediate <a title="vertex">vertices</a> in the <a>tree</a>.</p>
                         </div>
                       </li>
                       <li>
-                        <p>Else, if there is a <a>root</a> <a>vertex</a> <var>M</var> in <a>forest</a> <var>F</var> that represents <a>object</a> <var>S<sub>j</sub></var>, then set <a>vertex</a> <var>M</var> as a <a>child</a> of <a>vertex</a> <var>N</var> and remove <a>vertex</a> <var>M</var> from the list of <a title="root">roots</a> in <a>forest</a> <var>F</var> (e.g. the <a>tree</a> rooted by <var>M</var> becomes a sub-tree of <var>N</var>).</p>
+                        <p>Else, if there is a <a>root</a> <a>vertex</a> <var>M</var> in <a>forest</a> <var>F</var> that represents <a>object</a> <var>S<sub>j</sub></var>, then set <a>vertex</a> <var>M</var> as a <a>child</a> of <a>vertex</a> <var>N</var> and remove <a>vertex</a> <var>M</var> from the list of <a title="root">roots</a> in <a>forest</a> <var>F</var> (i.e., the <a>tree</a> rooted by <var>M</var> becomes a sub-tree of <var>N</var>).</p>
                       </li>
                       <li>
                         <p>Else, create a new <a>vertex</a> <var>M</var> that represents <a>object</a> <var>S<sub>j</sub></var> as a <a>child</a> of <a>vertex</a> <var>N</var>.</p>
@@ -531,8 +530,7 @@
             </ol>
           </li>
           <li>
-            <p>Each <a>vertex</a> in <a>forest</a> <var>F</var> represents an object in the original sequence of <a title="object">objects</a> <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var> and is associated with a <a>subject</a> described by the current <a>row</a>. Rearrange <a title="object">objects</a> <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var> such that they mirror the structure of the <a title="tree">trees</a> in <a>forest</a> <var>F</var>.</p> 
-            <p>If <a>vertex</a> <var>M</var>, representing <a>object</a> <var>S<sub>i</sub></var>, is a <a>child</a> of <a>vertex</a> <var>N</var>, representing <a>object</a> <var>S<sub>j</sub></var>, then the name-value pair in <a>object</a> <var>S<sub>j</sub></var> associated with the <a>edge</a> relating <var>M</var> and <var>N</var> MUST be modifed such that the (literal) value, <var>V<sub>url</sub></var>, from that name-value pair is replaced by <a>object</a> <var>S<sub>i</sub></var> thus creating a <em>nested</em> <a>object</a>.</p>
+            <p>Each <a>vertex</a> in <a>forest</a> <var>F</var> represents an object in the original sequence of <a title="object">objects</a> <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var> and is associated with a <a>subject</a> described by the current <a>row</a>. Rearrange <a title="object">objects</a> <var>S<sub>1</sub></var> to <var>S<sub>n</sub></var> such that they mirror the structure of the <a title="tree">trees</a> in <a>forest</a> <var>F</var> as follows: If <a>vertex</a> <var>M</var>, representing <a>object</a> <var>S<sub>i</sub></var>, is a <a>child</a> of <a>vertex</a> <var>N</var>, representing <a>object</a> <var>S<sub>j</sub></var>, then the name-value pair in <a>object</a> <var>S<sub>j</sub></var> associated with the <a>edge</a> relating <var>M</var> and <var>N</var> MUST be modifed such that the (literal) value, <var>V<sub>url</sub></var>, from that name-value pair is replaced by <a>object</a> <var>S<sub>i</sub></var> thus creating a <em>nested</em> <a>object</a>.</p>
             <p class="note"><a title="object">Objects</a> represented by <a>root</a> <a title="vertex">vertices</a> are referred to as <em><a>root</a> <a title="object">objects</a></em>.</p>
           </li>
           <li>
@@ -551,7 +549,7 @@
 
         <div class="note">
           <p>Instances of JSON reserved characters within string values MUST be escaped as defined in [[!RFC7159]].</p>
-          <p>JSON has no native support for expressing language information; therefore the <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property has no effect on the JSON outut.</p>
+          <p>JSON has no native support for expressing language information; therefore the <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property has no effect on the JSON output.</p>
         </div>
         
         <div class="note">
@@ -619,7 +617,7 @@
 
     <section>
       <h3>JSON-LD to JSON</h3>
-      <p>This section defines a mechanism for transforming the [[json-ld]] Dialect used for <a>common properties</a> and <a><code>notes</code></a> into <em>plain-old</em> JSON.</p>
+      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>common properties</a> and <a><code>notes</code></a> into JSON.</p>
 
       <p>Name-value pairs from <a>notes</a> and <a>common properties</a> annotations are generally copied verbatim from the metadata description subject to the exceptions below:</p>
       <ol>
@@ -961,7 +959,7 @@
 
         <div class="note">
           <p>
-            The CSV to JSON translation is limited to providing one statement, or triple, per <a>column</a> in the <a title="annotated table">table</a>. The target <code>schema.org</code> markup requires 10 statements to describe each event. As the base tabular data file contains 5 columns, an additional 5 <em>virtual <a title="column">columns</a></em> have been added in order to provide for the full complement of statements - including the relationships between the 3 resources (event, location and offer) described by each <a>row</a> of the <a title="annotated table">table</a>. Note that the <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property is set to <var>true</var> for these <em>virtual <a title="column">columns</a></em>.
+            The CSV to JSON translation is limited to providing one statement, or triple, per <a>column</a> in the <a title="annotated table">table</a>. The target <code>schema.org</code> markup requires 10 statements to describe each event. As the base tabular data file contains 5 columns, an additional 5 <em>virtual <a title="column">columns</a></em> have been added in order to provide for the full complement of statements—including the relationships between the 3 resources (event, location, and offer) described by each <a>row</a> of the <a title="annotated table">table</a>. Note that the <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property is set to <var>true</var> for these <em>virtual <a title="column">columns</a></em>.
           </p>
           <p>
             Furthermore, note that no attempt is made to reconcile between locations or offers that may be associated with more than one event; every <a>row</a> in the <a title="annotated table">table</a> will create both a new location resource and offer resource in addition to the event resource. If considered necessary, applications such as <a href="http://openrefine.org">OpenRefine</a> may be used to identify and reconcile duplicate location resources once the JSON output has been generated.
@@ -1078,7 +1076,7 @@
         </pre>
 
         <div class="note">
-          <p>The resources described by each <a>row</a> are explicitly defined using the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property - in this case three resources per <a>row</a> (event, location and offer); the <a title="object">objects</a> containing the name-values pairs associated with the <a title="cell value">cell values</a> of a <a>row</a> are related to the <a>object</a> for each <a>subject</a> in that <a>row</a> using the name-value pair with <a>name</a> <code>describes</code>.</p>
+          <p>The resources described by each <a>row</a> are explicitly defined using the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property—in this case three resources per <a>row</a> (event, location, and offer); the <a title="object">objects</a> containing the name-values pairs associated with the <a title="cell value">cell values</a> of a <a>row</a> are related to the <a>object</a> for each <a>subject</a> in that <a>row</a> using the name-value pair with <a>name</a> <code>describes</code>.</p>
         </div>
         
       </section>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -415,9 +415,7 @@
                           <dd><a>literal node</a> <var>V<sub>literal</sub></var></dd>
                         </dl>
                         <p>The <a title="literal node">literal nodes</a> derived from the <a title="cell value">cell values</a> MUST be expressed according to the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property of the cell as defined below: <a href="#datatypes">Interpreting datatypes</a>.</p> 
-                        <p class="note">In the case where the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> is not present, the
-                        conversion should default to <code>string</code>.</p> 
-
+                        <p class="note">In the case when the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> is not present, the conversion should default to <code>string</code>.</p> 
                         <p class="note">In the case where a sequence of values is provided, the <code>datatype</code> applies to all members of the sequence.</p>
                       </li>
                     </ol>
@@ -482,12 +480,12 @@
             <tr><td><code>gYearMonth</code></td><td><code>xsd:gYearMonth</code></td><td></td></tr>
             <tr><td><code>hexBinary</code></td><td><code>xsd:hexBinary</code></td><td></td></tr>
             <tr><td><code>QName</code></td><td><code>xsd:QName</code></td><td></td></tr>
-            <tr><td><code>string</code></td><td><code>xsd:string</code></td><td>Where the <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property is defined for a cell, the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> (as defined in [[!rdf11-concepts]]) MUST be provided for the string.</td></tr>
-            <tr><td><code>normalizedString</code></td><td><code>xsd:normalizedString</code></td><td>(as for <code>string</code>)</td></tr>
-            <tr><td><code>token</code></td><td><code>xsd:token</code></td><td>(as for <code>string</code>)</td></tr>
-            <tr><td><code>language</code></td><td><code>xsd:language</code></td><td>(as for <code>string</code>)</td></tr>
-            <tr><td><code>Name</code></td><td><code>xsd:Name</code></td><td>(as for <code>string</code>)</td></tr>
-            <tr><td><code>NMTOKEN</code></td><td><code>xsd:NMTOKEN</code></td><td>(as for <code>string</code>)</td></tr>
+            <tr><td><code>string</code></td><td><code>xsd:string</code> or <code>rdf:langString</code> depending on whether or not the <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property is defined for the cell.</td><td></td></tr>
+            <tr><td><code>normalizedString</code></td><td><code>xsd:normalizedString</code></td><td></td></tr>
+            <tr><td><code>token</code></td><td><code>xsd:token</code></td><td></td></tr>
+            <tr><td><code>language</code></td><td><code>xsd:language</code></td><td></td></tr>
+            <tr><td><code>Name</code></td><td><code>xsd:Name</code></td><td></td></tr>
+            <tr><td><code>NMTOKEN</code></td><td><code>xsd:NMTOKEN</code></td><td></td></tr>
             <tr><td><code>xml</code></td><td><code>rdf:XMLLiteral</code></td><td></td></tr>
             <tr><td><code>html</code></td><td><code>rdf:HTML</code></td><td></td></tr>
             <tr><td><code>json</code></td><td><code>csvw:JSON</code></td><td><code>csvw:JSON</code> is a sub-class of <code>xsd:string</code></td></tr>
@@ -495,7 +493,10 @@
           </tbody>
         </table>
 
-        <p class="note">According to [[rdf11-concepts]] <em>all</em> literals have a datatype. However, specific serializations, like Turtle [[turtle]], may provide a special syntax for literals with datatype is <code>xsd:string</code>.</p>
+        <p>In the case of <code>rdf:langString</code>, the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">language tag</a> (as defined in [[!rdf11-concepts]]) MUST be provided for the string, based on the value of <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a>.
+        (See <a href="http://www.w3.org/TR/rdf11-concepts/#h3_section-Graph-Literal">section on Graph Literals</a> in [[!rdf11-concepts]] for further details on language tagged literals.)</p>
+
+        <p class="note">According to [[rdf11-concepts]] language tags cannot be combined with any other <code>xsd</code> datatypes. If a cell has any other datatype than <code>string</code>, the value of <code>lang</code> MUST be ignored. Also, <em>all</em> literals have a datatype; however, specific serializations, like Turtle [[turtle]], MAY provide a special syntax for literals with datatype <code>xsd:string</code> or <code>rdf:langString</code>.</p>
 
       </section>
     </section>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -108,6 +108,7 @@
       }
       ol.algorithm>li p {text-indent: 0em}
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
+      dd a.externalDFN, p a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
       pre {overflow: auto;}
     </style>
   </head>
@@ -124,15 +125,15 @@
     <section id="intro">
       <h2>Introduction</h2>
 
-      <p>This document describes the processing of <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> to create an RDF subject-predicate-object triples [[!rdf11-concepts]]. Since RDF is an <em>abstract syntax</em>, these triples MAY be serialized in a <em>concrete RDF syntax</em> such as N-Triples [[n-triples]], Turtle [[turtle]], RDFa [[rdfa-primer]], JSON-LD [[json-ld]] or TriG [[trig]]. The RDF serializations offered by a conversion application is implementation dependent.</p>
+      <p>This document describes the processing of <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> to create an RDF subject-predicate-object triples [[!rdf11-concepts]]. Since RDF is an <em>abstract syntax</em>, these triples MAY be serialized in a <em>concrete RDF syntax</em> such as N-Triples [[n-triples]], Turtle [[turtle]], RDFa [[rdfa-primer]], JSON-LD [[json-ld]], or TriG [[trig]]. The RDF serializations offered by a conversion application is implementation dependent.</p>
 
-      <p> The [[!tabular-data-model]] defines an <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model" class="externalDFN">annotated tabular data model</a> consisting of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-column" class="externalDFN">columns</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a> and <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a>, enriched with <a href="http://w3c.github.io/csvw/syntax/#dfn-annotation" class="externalDFN">annotations</a> that describe the structure of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> and the meaning of its content. A <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> is a collection of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> published as a single atomic unit.</p>
+      <p> The [[!tabular-data-model]] defines an <a href="http://w3c.github.io/csvw/syntax/#dfn-annotated-tabular-data-model" class="externalDFN">annotated tabular data model</a> consisting of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-column" class="externalDFN">columns</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, and <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a>, enriched with <a href="http://w3c.github.io/csvw/syntax/#dfn-annotation" class="externalDFN">annotations</a> that describe the structure of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> and the meaning of its content. A <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> is a collection of <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> published as a single atomic unit.</p>
 
       <p>The conversion procedure described in this specification operates on the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a>. This specification does not specify the processes needed to convert CSV-encoded data into tabular data form. Please refer to [[!tabular-data-model]] for details of <a href="http://w3c.github.io/csvw/syntax/#parsing">parsing tabular data</a>.</p>
 
       <p>Conversion applications MUST provide at least two modes of operation: <a title="standard mode">standard</a> and <a title="minimal mode">minimal</a>.</p>
 
-      <p><dfn title="standard mode">Standard mode</dfn> conversion frames the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> with details of the <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a> and a <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> within which that information is provided.</p>
+      <p><dfn title="standard mode">Standard mode</dfn> conversion frames the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> with details of the <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">rows</a>, <a href="http://w3c.github.io/csvw/syntax/#dfn-table" class="externalDFN">tables</a>, and a <a href="http://w3c.github.io/csvw/syntax/#dfn-group-of-tables" class="externalDFN">table group</a> within which that information is provided.</p>
 
       <p><dfn title="minimal mode">Minimal mode</dfn> conversion includes <em>only</em> the information gleaned from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> of the <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a>.</p>
 
@@ -142,7 +143,7 @@
 
       <p><a href="http://w3c.github.io/csvw/metadata/#dfn-conversion-specification" class="externalDFN">Conversion specifications</a>, as defined in [[!tabular-metadata]] MAY be used to specify how <a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">tabular data</a> can be transformed into another format using a script or template. Such a <a href="http://w3c.github.io/csvw/metadata/#dfn-conversion-specification" class="externalDFN">conversion specification</a> MAY use the RDF output described in this specification as input.</p>
 
-      <p>The conversion procedure described in this specification is considered to be <em>entirely textual</em>. There is no requirement on conversion applications to check the semantic consistency of the data during the conversion, nor validate the triples against RDF syntax rules. Downstream applications SHOULD be aware of the potential for syntax errors and take appropriate action.</p>
+      <p>The conversion procedure described in this specification is considered to be <em>entirely textual</em>. There is no requirement on conversion applications to check the semantic consistency of the data during the conversion, nor to validate the triples against RDF syntax rules. Downstream applications SHOULD be aware of the potential for syntax errors and take appropriate action.</p>
     </section>
     
     <section id="conformance">
@@ -205,7 +206,7 @@
           <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-node" class="externalDFN">node</a> is defined in [[!rdf11-concepts]] as a subject or an object of an RDF triple. When in subject position, it can be either a <a>blank node</a> or identified with a URL; when in object position, it can be a <a>blank node</a>, a <a title="literal node">literal</a>, or identified with a URL.</dd>
 
           <dt><dfn>notes</dfn></dt>
-          <dd>A list of <a href="http://w3c.github.io/csvw/syntax/#dfn-table-notes" class="externalDFN">notes</a>, as defined in [[!tabular-data-model]], attached to an <a title="annotated table">annotated table</a>or <a>table group</a> using the <code>notes</code> property. This may be an empty list.</dd>
+          <dd>A list of <a href="http://w3c.github.io/csvw/syntax/#dfn-table-notes" class="externalDFN">notes</a>, as defined in [[!tabular-data-model]], attached to an <a title="annotated table">annotated table</a> or <a>table group</a> using the <code>notes</code> property. This may be an empty list.</dd>
 
           <dt><dfn>predicate</dfn></dt>
           <dd>A <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-predicate" class="externalDFN">predicate</a> is defined in [[!rdf11-concepts]] as an IRI that denotes the property used to relate <a title="node">nodes</a> within an RDF triple.</dd>
@@ -251,7 +252,7 @@
         <ol class="algorithm">
           <li>
             In <strong><a>standard mode</a></strong> only, establish a new <a>node</a> <var>G</var>.
-            If the <a>table group</a> has an <a>identifier</a> then <a>node</a> <var>G</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>G</var> MUST be a <a>blank node</a>.
+            If the <a>table group</a> has an <a>identifier</a> then <a>node</a> <var>G</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>G</var> MUST be a new <a>blank node</a>.
           </li>
           <li>
             <p>In <strong><a>standard mode</a></strong> only, specify the type of <a>node</a> <var>G</var> as <code>csvw:TableGroup</code>; emit the following triple:</p>
@@ -272,7 +273,7 @@
             <ol class="algorithm">
               <li>
                 <p>In <strong><a>standard mode</a></strong> only, establish a new <a>node</a> <var>T</var> which represents the current <a title="annotated table">table</a>.</p>
-                <p>If the <a title="annotated table">table</a> has an <a>identifier</a> then <a>node</a> <var>T</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>T</var> MUST be a <a>blank node</a>.</p>
+                <p>If the <a title="annotated table">table</a> has an <a>identifier</a> then <a>node</a> <var>T</var> MUST be identified accordingly; else if <a>identifier</a> is <code>null</code>, then <a>node</a> <var>T</var> MUST be a new <a>blank node</a>.</p>
               </li>
               <li>
                 <p>In <strong><a>standard mode</a></strong> only, relate the <a title="annotated table">table</a> to the <a>table group</a>; emit the following triple:</p>
@@ -414,6 +415,9 @@
                           <dd><a>literal node</a> <var>V<sub>literal</sub></var></dd>
                         </dl>
                         <p>The <a title="literal node">literal nodes</a> derived from the <a title="cell value">cell values</a> MUST be expressed according to the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property of the cell as defined below: <a href="#datatypes">Interpreting datatypes</a>.</p> 
+                        <p class="note">In the case where the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> is not present, the
+                        conversion should default to <code>string</code>.</p> 
+
                         <p class="note">In the case where a sequence of values is provided, the <code>datatype</code> applies to all members of the sequence.</p>
                       </li>
                     </ol>
@@ -490,6 +494,9 @@
             <tr><td><code>time</code></td><td><code>xsd:time</code></td><td></td></tr>
           </tbody>
         </table>
+
+        <p class="note">According to [[rdf11-concepts]] <em>all</em> literals have a datatype. However, specific serializations, like Turtle [[turtle]], may provide a special syntax for literals with datatype is <code>xsd:string</code>.</p>
+
       </section>
     </section>
 
@@ -501,7 +508,7 @@
         <dd><code>http://www.w3.org/ns/prov#</code></dd>
       </dl>
       
-      <p>Conversion applications MAY include provenance information in the RDF output describing how and when the output was created; e.g. using terms from the PROV Ontology [[prov-o]]. Information that may be of interest to downstream applications includes:</p>
+      <p>Conversion applications MAY include provenance information in the RDF output describing how and when the output was created; e.g., using terms from the PROV Ontology [[prov-o]]. Information that may be of interest to downstream applications includes:</p>
       <ul>
         <li>the source tabular data file;</li>
         <li>the metadata description file(s) used;</li>
@@ -512,9 +519,9 @@
       <p>In order to faciliate the provision of such information, this specification introduces two instances of <a href="http://www.w3.org/TR/prov-o/#Role"><code>prov:Role</code></a>:</p>
       <dl>
         <dt><code>csvw:csvEncodedTabularData</code></dt>
-        <dd>defines the role of the source tabular data file</dd>
+        <dd>Defines the role of the source tabular data file.</dd>
         <dt><code>csvw:tabularMetadata</code></dt>
-        <dd>defines the role of the metadata description file</dd>
+        <dd>Defines the role of the metadata description file.</dd>
       </dl>
 
       An illustrative example of provenance information is provided below in Turtle [[turtle]] syntax, the conversion application used is identified as <code>http://example.org/my-csv2rdf-application</code>:
@@ -529,7 +536,7 @@
 
     <section>
       <h3>JSON-LD to RDF</h3>
-      <p>This section defines a mechanism for transforming the [[json-ld]] Dialect used for <a>common properties</a> and <a><code>notes</code></a> into RDF in a manner consistent with the <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a></cite> defined in [[!json-ld-api]]. Converters MAY use any algorithm which results in equivalent triples.</p>
+      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>common properties</a> and <a><code>notes</code></a> into RDF in a manner consistent with the <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a></cite> defined in [[!json-ld-api]]. Converters MAY use any algorithm which results in equivalent triples.</p>
       <p>Given a <var>subject</var>, <var>property</var> and <var>value</var> in <a href="http://w3c.github.io/csvw/metadata/#dfn-normalization">normalized</a> form:</p>
       <ol class="algorithm">
         <li><var>Property</var> is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the [[csvw-context]], a <a>prefixed name</a>, or an absolute URL; expand to an absolute URL by replacing a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> with the URI from the term definition in [[csvw-context]] or a <a>prefixed name</a> as described in <a href="#names-of-common-properties" class="sectionRef"></a>.</li>
@@ -543,6 +550,7 @@
             <dt>object</dt>
             <dd><a>literal node</a> <var>lit</var></dd>
           </dl>
+          <p class="note">If neither <code>@language</code> nor <code>@type</code> is present, the literal <var>lit</var> has the datatype <code>xsd:string</code>.</p>
         </li>
         <li>Else, if <var>value</var> is an object:
           <ol class="algorithm">
@@ -575,6 +583,7 @@
             <li>If <var>value</var> is <code>true</code> or <code>false</code>, create an RDF Literal <var>lit</var> using the strings "true" or "false", accordingly with datatype <code>xsd:boolean</code></li>
             <li>Else, if <var>value</var> is a JSON number with a non-zero fractional part, create an RDF Literal <var>lit</var> using the canonical representation for <var>value</var> with datatype <code>xsd:double</code>.</li>
             <li>Else, if <var>value</var> is a JSON number with no non-zero fractional part, create an RDF Literal <var>lit</var> using the canonical representation for <var>value</var> with datatype <code>xsd:integer</code>.</li>
+            <li>Otherwise, create an RDF Literal <var>lit</var> using the canonical representation for <var>value</var> with datatype <code>xsd:string</code>.</li>
           </ol>
           <p>Emit the following triple:</p>
           <dl class="triple">
@@ -910,7 +919,7 @@
 
         <div class="note">
           <p>
-            The CSV to RDF translation is limited to providing one statement, or triple, per <a>column</a> in the <a title="annotated table">table</a>. The target <code>schema.org</code> markup requires 10 statements to describe each event. As the base tabular data file contains 5 columns, an additional 5 <em>virtual <a title="column">columns</a></em> have been added in order to provide for the full complement of statements - including the relationships between the 3 resources (event, location and offer) described by each <a>row</a> of the <a title="annotated table">table</a>. Note that the <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property is set to <var>true</var> for these <em>virtual <a title="column">columns</a></em>.
+            The CSV to RDF translation is limited to providing one statement, or triple, per <a>column</a> in the <a title="annotated table">table</a>. The target <code>schema.org</code> markup requires 10 statements to describe each event. As the base tabular data file contains 5 columns, an additional 5 <em>virtual <a title="column">columns</a></em> have been added in order to provide for the full complement of statements—including the relationships between the 3 resources (event, location, and offer) described by each <a>row</a> of the <a title="annotated table">table</a>. Note that the <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property is set to <var>true</var> for these <em>virtual <a title="column">columns</a></em>.
           </p>
           <p>
             Furthermore, note that no attempt is made to reconcile between locations or offers that may be associated with more than one event; every <a>row</a> in the <a title="annotated table">table</a> will create both a new location resource and offer resource in addition to the event resource. If considered necessary, applications such as <a href="http://openrefine.org">OpenRefine</a> may be used to identify and reconcile duplicate location resources once the RDF output has been generated.
@@ -1011,7 +1020,7 @@
         </pre>
 
         <div class="note">
-          <p>Three resources are defined for each row within the table; event, location and offer.</p>
+          <p>Three resources are defined for each row within the table; event, location, and offer.</p>
           <p>Each <a>column</a> explicitly defines both <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> properties which are inherited by the column's <a title="cell">cells</a>.</p>
           <p><a title="column">Columns</a> <var>C6</var>, <var>C7</var> and <var>C8</var> (<code>{ "name": "type_event"}</code>, <code>{ "name": "type_place"}</code> and <code>{ "name": "type_offer"}</code>) define the semantic types of the resources described by each <a>row</a>: <code>schema:MusicEvent</code>, <code>schema:Place</code> and <code>schema:Offer</code> respectively.</p>
           <p><a title="column">Column</a> <var>C9</var> (<code>{ "name": "location"}</code>) uses the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> to assert the relationship between the event and location resources.</p>
@@ -1028,7 +1037,7 @@
         </pre>
 
         <div class="note">
-          <p>The resources described by each <a>row</a> are explcitly defined using the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property - in this case three resources per <a>row</a> (event, location and offer); the relationship between the <a>row</a> and each <a>subject</a> resource is asserted using the <code>csvw:describes</code> property; e.g. for <a>row</a> <var>R1</var> we state <code>[] csvw:describes t1:event-1, t1:place-1, t1:offer-1 .</code></p>
+          <p>The resources described by each <a>row</a> are explcitly defined using the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property—in this case three resources per <a>row</a> (event, location, and offer); the relationship between the <a>row</a> and each <a>subject</a> resource is asserted using the <code>csvw:describes</code> property; e.g. for <a>row</a> <var>R1</var> we state <code>[] csvw:describes t1:event-1, t1:place-1, t1:offer-1 .</code></p>
         </div>
         
       </section>


### PR DESCRIPTION
I have found a bunch of small things that I handled. This included updating the style (that @gkellogg did) for the external definitions to be in line with what the metadata and syntax document is using.

The biggest 'issue' was in the csv2rdf document where the plain literals were a bit glossed over (ie, if no datatype is specified). In fact, per rdf1.1 plain literals do not exist; instead, the default datatype is always `xsd:string` (and serialization may have a special syntax for plain literals). I have modified the conversion accordingly; would be good if @gkellogg and @6a6d74 had a look at it whether it is fine as is.
