### PR TITLE
Use dcat:keyword instead of the non-existant dc:keywords in examples and...

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -815,7 +815,7 @@
           <tbody>
             <tr><td><var>T</var></td><td><code>http://example.org/tree-ops-ext.csv</code></td><td><var>C1</var>, <var>C2</var>, <var>C3</var>, <var>C4</var>, <var>C5</var>, <var>C6</var>, <var>C7</var>, <var>C8</var>, <var>C9</var></td><td><var>R1</var>, <var>R2</var>, <var>R3</var></td><td><strong><code>@id</code></strong></td><td><code>&lt;http://example.org/tree-ops-ext&gt;</code></td></tr>
             <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:title</code></strong></td><td><code>"Tree Operations"</code></td></tr>
-            <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:keywords</code></strong></td><td><code>["tree", "street", "maintenance"]</code></td></tr>
+            <tr><td></td><td></td><td></td><td></td><td><strong><code>dcat:keyword</code></strong></td><td><code>["tree", "street", "maintenance"]</code></td></tr>
             <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:publisher</code></strong></td><td><code>[{ "schema:name": "Example Municipality", "schema:url": { "@id": "http://example.org" } }]</code></td></tr>
             <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:license</code></strong></td><td><code>&lt;http://opendefinition.org/licenses/cc-by/&gt;</code></td></tr>
             <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:modified</code></strong></td><td><code>"2010-12-31"</code></td></tr>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -757,7 +757,7 @@
             <tbody>
               <tr><td><var>T</var></td><td><code>http://example.org/tree-ops-ext.csv</code></td><td><var>C1</var>, <var>C2</var>, <var>C3</var>, <var>C4</var>, <var>C5</var>, <var>C6</var>, <var>C7</var>, <var>C8</var>, <var>C9</var></td><td><var>R1</var>, <var>R2</var>, <var>R3</var></td><td><strong><code>@id</code></strong></td><td><code>&lt;http://example.org/tree-ops-ext&gt;</code></td></tr>
               <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:title</code></strong></td><td><code>"Tree Operations"</code></td></tr>
-              <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:keywords</code></strong></td><td><code>["tree", "street", "maintenance"]</code></td></tr>
+              <tr><td></td><td></td><td></td><td></td><td><strong><code>dcat:keyword</code></strong></td><td><code>["tree", "street", "maintenance"]</code></td></tr>
               <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:publisher</code></strong></td><td><code>[{ "schema:name": "Example Municipality", "schema:url": { "@id": "http://example.org" } }]</code></td></tr>
               <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:license</code></strong></td><td><code>&lt;http://opendefinition.org/licenses/cc-by/&gt;</code></td></tr>
               <tr><td></td><td></td><td></td><td></td><td><strong><code>dc:modified</code></strong></td><td><code>"2010-12-31"</code></td></tr>
@@ -882,7 +882,7 @@
         <div class="note">
           <p><a title="annotated table">Table</a> <var>T</var> (<code>{ "url": "http://example.org/tree-ops-ext.csv"}</code>) has been explicitly identified: <code>{ "@id": "&lt;http://exmple.org/tree-ops-ext&gt;"}</code>.</p>
           <p><a title="common properties">Common properties</a> and <a>notes</a> specified for <a title="annotated table">table</a> <var>T</var> (<code>{ "url": "http://example.org/tree-ops-ext.csv"}</code>) are included in the output.</p>
-          <p>As the metadata description file <code>http://example.org/tree-ops-ext.csv-metadata.json</code> defines a default language within the context (<code>"@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}]</code>), all <a>common properties</a> of type <code>string</code> (e.g. <code>dc:title</code>, <code>dc:keywords</code>, <code>dc:publisher</code>, <code>dc:license</code> and <code>dc:modified</code>) are expressed in the RDF output using the the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag</a>.</p>
+          <p>As the metadata description file <code>http://example.org/tree-ops-ext.csv-metadata.json</code> defines a default language within the context (<code>"@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}]</code>), all <a>common properties</a> of type <code>string</code> (e.g. <code>dc:title</code>, <code>dcat:keyword</code>, <code>dc:publisher</code>, <code>dc:license</code> and <code>dc:modified</code>) are expressed in the RDF output using the the appropriate <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag" class="externalDFN">language tag</a>.</p>
         </div>
 
       </section>

--- a/examples/tree-ops-ext-standard.json
+++ b/examples/tree-ops-ext-standard.json
@@ -3,7 +3,7 @@
     "@id": "http://example.org/tree-ops-ext",
     "url": "http://example.org/tree-ops-ext.csv",
     "dc:title": "Tree Operations",
-    "dc:keywords": [ "tree", "street", "maintenance" ],
+    "dcat:keyword": [ "tree", "street", "maintenance" ],
     "dc:publisher": [{
       "schema:name": "Example Municipality",
       "schema:url": "http://example.org"

--- a/examples/tree-ops-ext-standard.ttl
+++ b/examples/tree-ops-ext-standard.ttl
@@ -12,7 +12,7 @@ _:68fc08e5-56a0-47e2-a784-3a644d8257c4 a csvw:TableGroup ;
 <http://example.org/tree-ops-ext> a csvw:Table ;
   csvw:url <http://example.org/tree-ops-ext.csv> ;
   dc:title "Tree Operations"@en ;
-  dc:keywords "tree"@en, "street"@en, "maintenance"@en ;
+  dcat:keyword "tree"@en, "street"@en, "maintenance"@en ;
   dc:publisher [
     schema:name "Example Municipality"@en ;
     schema:url <http://example.org>

--- a/examples/tree-ops-ext.csv-metadata.json
+++ b/examples/tree-ops-ext.csv-metadata.json
@@ -3,7 +3,7 @@
   "@id": "http://example.org/tree-ops-ext",
   "url": "tree-ops-ext.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": [{
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/examples/tree-ops.csv-metadata.json
+++ b/examples/tree-ops.csv-metadata.json
@@ -2,7 +2,7 @@
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "tree-ops.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": {
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1164,7 +1164,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "tree-ops.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": {
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}
@@ -1211,7 +1211,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "tree-ops.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": {
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -1312,7 +1312,7 @@ data.parse({
           	<dl>
           		<dt><code>dc:title</code></dt>
           		<dd><code>{"@value": "Tree Operations", "@language": "en"}</code></dd>
-          		<dt><code>dc:keywords</code></dt>
+          		<dt><code>dcat:keyword</code></dt>
           		<dd><code>[{"@value": "tree", "@language", "en"}, {"@value": "street", "@language": "en"}, {"@value": "maintenance", "@language": "en"}]</code></dd>
           		<dt><code>dc:publisher</code></dt>
           		<dd><code>[{ "schema:name": "Example Municipality", "schema:url": {"@id": "http://example.org"} }]</code></dd>

--- a/tests/test011/result.json
+++ b/tests/test011/result.json
@@ -3,7 +3,7 @@
     {
       "url": "http://w3c.github.io/csvw/tests/test011/tree-ops.csv",
       "dc:title": "Tree Operations",
-      "dc:keywords": [
+      "dcat:keyword": [
         "tree",
         "street",
         "maintenance"

--- a/tests/test011/result.ttl
+++ b/tests/test011/result.ttl
@@ -22,7 +22,7 @@
     csvw:table [
       a csvw:Table;
       dc:title "Tree Operations"@en;
-      dc:keywords "tree"@en,
+      dcat:keyword "tree"@en,
         "street"@en,
         "maintenance"@en;
       dc:license <http://opendefinition.org/licenses/cc-by/>;

--- a/tests/test011/tree-ops.csv-metadata.json
+++ b/tests/test011/tree-ops.csv-metadata.json
@@ -2,7 +2,7 @@
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "tree-ops.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": {
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/tests/test027-user-metadata.json
+++ b/tests/test027-user-metadata.json
@@ -2,7 +2,7 @@
   "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
   "url": "tree-ops.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": {
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/tests/test036/result.json
+++ b/tests/test036/result.json
@@ -4,7 +4,7 @@
       "@id": "http://example.org/tree-ops-ext",
       "url": "http://w3c.github.io/csvw/tests/test036/tree-ops-ext.csv",
       "dc:title": "Tree Operations",
-      "dc:keywords": [
+      "dcat:keyword": [
         "tree",
         "street",
         "maintenance"

--- a/tests/test036/result.ttl
+++ b/tests/test036/result.ttl
@@ -40,7 +40,7 @@
 
 <http://example.org/tree-ops-ext> a csvw:Table;
    dc:title "Tree Operations"@en;
-   dc:keywords "tree"@en,
+   dcat:keyword "tree"@en,
      "street"@en,
      "maintenance"@en;
    dc:license <http://opendefinition.org/licenses/cc-by/>;

--- a/tests/test036/tree-ops-ext.csv-metadata.json
+++ b/tests/test036/tree-ops-ext.csv-metadata.json
@@ -3,7 +3,7 @@
   "@id": "http://example.org/tree-ops-ext",
   "url": "tree-ops-ext.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": [{
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}

--- a/tests/test037/tree-ops-ext.csv-metadata.json
+++ b/tests/test037/tree-ops-ext.csv-metadata.json
@@ -3,7 +3,7 @@
   "@id": "http://example.org/tree-ops-ext",
   "url": "tree-ops-ext.csv",
   "dc:title": "Tree Operations",
-  "dc:keywords": ["tree", "street", "maintenance"],
+  "dcat:keyword": ["tree", "street", "maintenance"],
   "dc:publisher": [{
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}


### PR DESCRIPTION
... tests.

Fixes #437.
