### PR TITLE
making required an inherited property

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -834,18 +834,18 @@
         <table style="width: 100%; text-align: left">
           <thead>
             <tr><th rowspan="2">id</th><th colspan="4">core annotations</th><th colspan="5">annotations</th></tr>
-            <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>required</code></th><th><code>suppressOutput</code></th><th><code>dc:description</code></th></tr>
+            <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>suppressOutput</code></th><th><code>dc:description</code></th></tr>
           </thead>
           <tbody>
-            <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var>, <var>C3.1</var></td><td><code>GID</code></td><td><code>GID</code>, <code>Generic Identifier</code></td><td><code>true</code></td><td><code>true</code></td><td><code>An identifier for the operation on a tree.</code></td></tr>
-            <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var>, <var>C3.2</var></td><td><code>on_street</code></td><td><code>On Street</code></td><td></td><td></td><td><code>The street that the tree is on.</code></td></tr>
-            <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var>, <var>C3.3</var></td><td><code>species</code></td><td><code>Species</code></td><td></td><td></td><td><code>The species of the tree.</code></td></tr>
-            <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var>, <var>C3.4</var></td><td><code>trim_cycle</code></td><td><code>Trim Cycle</code></td><td></td><td></td><td><code>The operation performed on the tree.</code></td></tr>
-            <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var>, <var>C3.5</var></td><td><code>dbh</code></td><td><code>Diameter at Breast Ht</code></td><td></td><td></td><td><code>Diameter at Breast Height (DBH) of the tree (in feet), measured 4.5ft above ground.</code></td></tr>
-            <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var>, <var>C3.6</var></td><td><code>inventory_date</code></td><td><code>Inventory Date</code></td><td></td><td></td><td><code>The date of the operation that was performed.</code></td></tr>
-            <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var>, <var>C3.7</var></td><td><code>comments</code></td><td><code>Comments</code></td><td></td><td></td><td><code>Supplementary comments relating to the operation or tree.</code></td></tr>
-            <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var>, <var>C3.8</var></td><td><code>protected</code></td><td><code>Protected</code></td><td></td><td></td><td><code>Indication (YES / NO) whether the tree is subject to a protection order.</code></td></tr>
-            <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var>, <var>C3.9</var></td><td><code>kml</code></td><td><code>KML</code></td><td></td><td></td><td><code>KML-encoded description of tree location.</code></td></tr>
+            <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var>, <var>C3.1</var></td><td><code>GID</code></td><td><code>GID</code>, <code>Generic Identifier</code></td><td><code>true</code></td><td><code>An identifier for the operation on a tree.</code></td></tr>
+            <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var>, <var>C3.2</var></td><td><code>on_street</code></td><td><code>On Street</code></td><td></td><td><code>The street that the tree is on.</code></td></tr>
+            <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var>, <var>C3.3</var></td><td><code>species</code></td><td><code>Species</code></td><td></td><td><code>The species of the tree.</code></td></tr>
+            <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var>, <var>C3.4</var></td><td><code>trim_cycle</code></td><td><code>Trim Cycle</code></td><td></td><td><code>The operation performed on the tree.</code></td></tr>
+            <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var>, <var>C3.5</var></td><td><code>dbh</code></td><td><code>Diameter at Breast Ht</code></td><td></td><td><code>Diameter at Breast Height (DBH) of the tree (in feet), measured 4.5ft above ground.</code></td></tr>
+            <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var>, <var>C3.6</var></td><td><code>inventory_date</code></td><td><code>Inventory Date</code></td><td></td><td><code>The date of the operation that was performed.</code></td></tr>
+            <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var>, <var>C3.7</var></td><td><code>comments</code></td><td><code>Comments</code></td><td></td><td><code>Supplementary comments relating to the operation or tree.</code></td></tr>
+            <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var>, <var>C3.8</var></td><td><code>protected</code></td><td><code>Protected</code></td><td></td><td><code>Indication (YES / NO) whether the tree is subject to a protection order.</code></td></tr>
+            <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var>, <var>C3.9</var></td><td><code>kml</code></td><td><code>KML</code></td><td></td><td><code>KML-encoded description of tree location.</code></td></tr>
           </tbody>
         </table>
 
@@ -1174,25 +1174,25 @@
           <table style="width: 100%; text-align: left">
             <thead>
               <tr><th rowspan="2">id</th><th colspan="4">core annotations</th><th colspan="3">annotations</th></tr>
-              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>required</code></th></tr>
+              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th></tr>
             </thead>
             <tbody>
-              <tr><td><var>Ca1</var></td><td><var>Ta</var></td><td>1</td><td>1</td><td><var>Ca1.1</var>, <var>Ca2.1</var>, <var>Ca3.1</var>, <var>Ca4.1</var></td><td><code>name</code></td><td><code>Profession</code></td><td><code>true</code></td></tr>
+              <tr><td><var>Ca1</var></td><td><var>Ta</var></td><td>1</td><td>1</td><td><var>Ca1.1</var>, <var>Ca2.1</var>, <var>Ca3.1</var>, <var>Ca4.1</var></td><td><code>name</code></td><td><code>Profession</code></td></tr>
 
-              <tr><td><var>Cb1</var></td><td><var>Tb</var></td><td>1</td><td>1</td><td><var>Cb1.1</var>, <var>Cb2.1</var></td><td><code>ref</code></td><td><code>Post Unique Reference</code></td><td><code>true</code></td></tr>
-              <tr><td><var>Cb2</var></td><td><var>Tb</var></td><td>2</td><td>2</td><td><var>Cb1.2</var>, <var>Cb2.2</var></td><td><code>name</code></td><td><code>Name</code></td><td></td></tr>
-              <tr><td><var>Cb3</var></td><td><var>Tb</var></td><td>3</td><td>3</td><td><var>Cb1.3</var>, <var>Cb2.3</var></td><td><code>grade</code></td><td><code>Grade</code></td><td></td></tr>
-              <tr><td><var>Cb4</var></td><td><var>Tb</var></td><td>4</td><td>4</td><td><var>Cb1.4</var>, <var>Cb2.4</var></td><td><code>job</code></td><td><code>Job Title</code></td><td></td></tr>
-              <tr><td><var>Cb5</var></td><td><var>Tb</var></td><td>5</td><td>5</td><td><var>Cb1.5</var>, <var>Cb2.5</var></td><td><code>reportsTo</code></td><td><code>Reports to Senior Post</code></td><td></td></tr>
-              <tr><td><var>Cb6</var></td><td><var>Tb</var></td><td>6</td><td>6</td><td><var>Cb1.6</var>, <var>Cb2.6</var></td><td><code>profession</code></td><td><code>Profession</code></td><td></td></tr>
+              <tr><td><var>Cb1</var></td><td><var>Tb</var></td><td>1</td><td>1</td><td><var>Cb1.1</var>, <var>Cb2.1</var></td><td><code>ref</code></td><td><code>Post Unique Reference</code></td></tr>
+              <tr><td><var>Cb2</var></td><td><var>Tb</var></td><td>2</td><td>2</td><td><var>Cb1.2</var>, <var>Cb2.2</var></td><td><code>name</code></td><td><code>Name</code></td></tr>
+              <tr><td><var>Cb3</var></td><td><var>Tb</var></td><td>3</td><td>3</td><td><var>Cb1.3</var>, <var>Cb2.3</var></td><td><code>grade</code></td><td><code>Grade</code></td></tr>
+              <tr><td><var>Cb4</var></td><td><var>Tb</var></td><td>4</td><td>4</td><td><var>Cb1.4</var>, <var>Cb2.4</var></td><td><code>job</code></td><td><code>Job Title</code></td></tr>
+              <tr><td><var>Cb5</var></td><td><var>Tb</var></td><td>5</td><td>5</td><td><var>Cb1.5</var>, <var>Cb2.5</var></td><td><code>reportsTo</code></td><td><code>Reports to Senior Post</code></td></tr>
+              <tr><td><var>Cb6</var></td><td><var>Tb</var></td><td>6</td><td>6</td><td><var>Cb1.6</var>, <var>Cb2.6</var></td><td><code>profession</code></td><td><code>Profession</code></td></tr>
 
               <tr><td><var>Cc1</var></td><td><var>Tc</var></td><td>1</td><td>1</td><td><var>Cc1.1</var>, <var>Cc2.1</var></td><td><code>reportsToSenior</code></td><td><code>Reporting Senior Post</code></td><td></td></tr>
-              <tr><td><var>Cc2</var></td><td><var>Tc</var></td><td>2</td><td>2</td><td><var>Cc1.2</var>, <var>Cc2.2</var></td><td><code>grade</code></td><td><code>Grade</code></td><td></td></tr>
-              <tr><td><var>Cc3</var></td><td><var>Tc</var></td><td>3</td><td>3</td><td><var>Cc1.3</var>, <var>Cc2.3</var></td><td><code>min_pay</code></td><td><code>Payscale Minimum (£)</code></td><td></td></tr>
-              <tr><td><var>Cc4</var></td><td><var>Tc</var></td><td>4</td><td>4</td><td><var>Cc1.4</var>, <var>Cc2.4</var></td><td><code>max_pay</code></td><td><code>Payscale Maximum (£)</code></td><td></td></tr>
-              <tr><td><var>Cc5</var></td><td><var>Tc</var></td><td>5</td><td>5</td><td><var>Cc1.5</var>, <var>Cc2.5</var></td><td><code>job</code></td><td><code>Generic Job Title</code></td><td></td></tr>
-              <tr><td><var>Cc6</var></td><td><var>Tc</var></td><td>6</td><td>6</td><td><var>Cc1.6</var>, <var>Cc2.6</var></td><td><code>number</code></td><td><code>Number of Posts (FTE)</code></td><td></td></tr>
-              <tr><td><var>Cc7</var></td><td><var>Tc</var></td><td>7</td><td>7</td><td><var>Cc1.7</var>, <var>Cc2.7</var></td><td><code>profession</code></td><td><code>Profession</code></td><td></td></tr>
+              <tr><td><var>Cc2</var></td><td><var>Tc</var></td><td>2</td><td>2</td><td><var>Cc1.2</var>, <var>Cc2.2</var></td><td><code>grade</code></td><td><code>Grade</code></td></tr>
+              <tr><td><var>Cc3</var></td><td><var>Tc</var></td><td>3</td><td>3</td><td><var>Cc1.3</var>, <var>Cc2.3</var></td><td><code>min_pay</code></td><td><code>Payscale Minimum (£)</code></td></tr>
+              <tr><td><var>Cc4</var></td><td><var>Tc</var></td><td>4</td><td>4</td><td><var>Cc1.4</var>, <var>Cc2.4</var></td><td><code>max_pay</code></td><td><code>Payscale Maximum (£)</code></td></tr>
+              <tr><td><var>Cc5</var></td><td><var>Tc</var></td><td>5</td><td>5</td><td><var>Cc1.5</var>, <var>Cc2.5</var></td><td><code>job</code></td><td><code>Generic Job Title</code></td></tr>
+              <tr><td><var>Cc6</var></td><td><var>Tc</var></td><td>6</td><td>6</td><td><var>Cc1.6</var>, <var>Cc2.6</var></td><td><code>number</code></td><td><code>Number of Posts (FTE)</code></td></tr>
+              <tr><td><var>Cc7</var></td><td><var>Tc</var></td><td>7</td><td>7</td><td><var>Cc1.7</var>, <var>Cc2.7</var></td><td><code>profession</code></td><td><code>Profession</code></td></tr>
             </tbody>
           </table>
 

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -776,18 +776,18 @@
           <table style="width: 100%; text-align: left">
             <thead>
               <tr><th rowspan="2">id</th><th colspan="4">core annotations</th><th colspan="5">annotations</th></tr>
-              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>required</code></th><th><code>suppressOutput</code></th><th><code>dc:description</code></th></tr>
+              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>suppressOutput</code></th><th><code>dc:description</code></th></tr>
             </thead>
             <tbody>
-              <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var>, <var>C3.1</var></td><td><code>GID</code></td><td><code>GID</code>, <code>Generic Identifier</code></td><td><code>true</code></td><td><code>true</code></td><td><code>An identifier for the operation on a tree.</code></td></tr>
-              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var>, <var>C3.2</var></td><td><code>on_street</code></td><td><code>On Street</code></td><td></td><td></td><td><code>The street that the tree is on.</code></td></tr>
-              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var>, <var>C3.3</var></td><td><code>species</code></td><td><code>Species</code></td><td></td><td></td><td><code>The species of the tree.</code></td></tr>
-              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var>, <var>C3.4</var></td><td><code>trim_cycle</code></td><td><code>Trim Cycle</code></td><td></td><td></td><td><code>The operation performed on the tree.</code></td></tr>
-              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var>, <var>C3.5</var></td><td><code>dbh</code></td><td><code>Diameter at Breast Ht</code></td><td></td><td></td><td><code>Diameter at Breast Height (DBH) of the tree (in feet), measured 4.5ft above ground.</code></td></tr>
-              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var>, <var>C3.6</var></td><td><code>inventory_date</code></td><td><code>Inventory Date</code></td><td></td><td></td><td><code>The date of the operation that was performed.</code></td></tr>
-              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var>, <var>C3.7</var></td><td><code>comments</code></td><td><code>Comments</code></td><td></td><td></td><td><code>Supplementary comments relating to the operation or tree.</code></td></tr>
-              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var>, <var>C3.8</var></td><td><code>protected</code></td><td><code>Protected</code></td><td></td><td></td><td><code>Indication (YES / NO) whether the tree is subject to a protection order.</code></td></tr>
-              <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var>, <var>C3.9</var></td><td><code>kml</code></td><td><code>KML</code></td><td></td><td></td><td><code>KML-encoded description of tree location.</code></td></tr>
+              <tr><td><var>C1</var></td><td><var>T</var></td><td>1</td><td>1</td><td><var>C1.1</var>, <var>C2.1</var>, <var>C3.1</var></td><td><code>GID</code></td><td><code>GID</code>, <code>Generic Identifier</code></td><td><code>true</code></td><td><code>An identifier for the operation on a tree.</code></td></tr>
+              <tr><td><var>C2</var></td><td><var>T</var></td><td>2</td><td>2</td><td><var>C1.2</var>, <var>C2.2</var>, <var>C3.2</var></td><td><code>on_street</code></td><td><code>On Street</code></td><td></td><td><code>The street that the tree is on.</code></td></tr>
+              <tr><td><var>C3</var></td><td><var>T</var></td><td>3</td><td>3</td><td><var>C1.3</var>, <var>C2.3</var>, <var>C3.3</var></td><td><code>species</code></td><td><code>Species</code></td><td></td><td><code>The species of the tree.</code></td></tr>
+              <tr><td><var>C4</var></td><td><var>T</var></td><td>4</td><td>4</td><td><var>C1.4</var>, <var>C2.4</var>, <var>C3.4</var></td><td><code>trim_cycle</code></td><td><code>Trim Cycle</code></td><td></td><td><code>The operation performed on the tree.</code></td></tr>
+              <tr><td><var>C5</var></td><td><var>T</var></td><td>5</td><td>5</td><td><var>C1.5</var>, <var>C2.5</var>, <var>C3.5</var></td><td><code>dbh</code></td><td><code>Diameter at Breast Ht</code></td><td></td><td><code>Diameter at Breast Height (DBH) of the tree (in feet), measured 4.5ft above ground.</code></td></tr>
+              <tr><td><var>C6</var></td><td><var>T</var></td><td>6</td><td>6</td><td><var>C1.6</var>, <var>C2.6</var>, <var>C3.6</var></td><td><code>inventory_date</code></td><td><code>Inventory Date</code></td><td></td><td><code>The date of the operation that was performed.</code></td></tr>
+              <tr><td><var>C7</var></td><td><var>T</var></td><td>7</td><td>7</td><td><var>C1.7</var>, <var>C2.7</var>, <var>C3.7</var></td><td><code>comments</code></td><td><code>Comments</code></td><td></td><td><code>Supplementary comments relating to the operation or tree.</code></td></tr>
+              <tr><td><var>C8</var></td><td><var>T</var></td><td>8</td><td>8</td><td><var>C1.8</var>, <var>C2.8</var>, <var>C3.8</var></td><td><code>protected</code></td><td><code>Protected</code></td><td></td><td><code>Indication (YES / NO) whether the tree is subject to a protection order.</code></td></tr>
+              <tr><td><var>C9</var></td><td><var>T</var></td><td>9</td><td>9</td><td><var>C1.9</var>, <var>C2.9</var>, <var>C3.9</var></td><td><code>kml</code></td><td><code>KML</code></td><td></td><td><code>KML-encoded description of tree location.</code></td></tr>
             </tbody>
           </table>
 
@@ -1125,25 +1125,25 @@
           <table style="width: 100%; text-align: left">
             <thead>
               <tr><th rowspan="2">id</th><th colspan="4">core annotations</th><th colspan="3">annotations</th></tr>
-              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th><th><code>required</code></th></tr>
+              <tr><th>table</th><th>number</th><th>source number</th><th>cells</th><th><code>name</code></th><th><code>title</code></th></tr>
             </thead>
             <tbody>
-              <tr><td><var>Ca1</var></td><td><var>Ta</var></td><td>1</td><td>1</td><td><var>Ca1.1</var>, <var>Ca2.1</var>, <var>Ca3.1</var>, <var>Ca4.1</var></td><td><code>name</code></td><td><code>Profession</code></td><td><code>true</code></td></tr>
+              <tr><td><var>Ca1</var></td><td><var>Ta</var></td><td>1</td><td>1</td><td><var>Ca1.1</var>, <var>Ca2.1</var>, <var>Ca3.1</var>, <var>Ca4.1</var></td><td><code>name</code></td><td><code>Profession</code></td></tr>
 
-              <tr><td><var>Cb1</var></td><td><var>Tb</var></td><td>1</td><td>1</td><td><var>Cb1.1</var>, <var>Cb2.1</var></td><td><code>ref</code></td><td><code>Post Unique Reference</code></td><td><code>true</code></td></tr>
-              <tr><td><var>Cb2</var></td><td><var>Tb</var></td><td>2</td><td>2</td><td><var>Cb1.2</var>, <var>Cb2.2</var></td><td><code>name</code></td><td><code>Name</code></td><td></td></tr>
-              <tr><td><var>Cb3</var></td><td><var>Tb</var></td><td>3</td><td>3</td><td><var>Cb1.3</var>, <var>Cb2.3</var></td><td><code>grade</code></td><td><code>Grade</code></td><td></td></tr>
-              <tr><td><var>Cb4</var></td><td><var>Tb</var></td><td>4</td><td>4</td><td><var>Cb1.4</var>, <var>Cb2.4</var></td><td><code>job</code></td><td><code>Job Title</code></td><td></td></tr>
-              <tr><td><var>Cb5</var></td><td><var>Tb</var></td><td>5</td><td>5</td><td><var>Cb1.5</var>, <var>Cb2.5</var></td><td><code>reportsTo</code></td><td><code>Reports to Senior Post</code></td><td></td></tr>
-              <tr><td><var>Cb6</var></td><td><var>Tb</var></td><td>6</td><td>6</td><td><var>Cb1.6</var>, <var>Cb2.6</var></td><td><code>profession</code></td><td><code>Profession</code></td><td></td></tr>
+              <tr><td><var>Cb1</var></td><td><var>Tb</var></td><td>1</td><td>1</td><td><var>Cb1.1</var>, <var>Cb2.1</var></td><td><code>ref</code></td><td><code>Post Unique Reference</code></td></tr>
+              <tr><td><var>Cb2</var></td><td><var>Tb</var></td><td>2</td><td>2</td><td><var>Cb1.2</var>, <var>Cb2.2</var></td><td><code>name</code></td><td><code>Name</code></td></tr>
+              <tr><td><var>Cb3</var></td><td><var>Tb</var></td><td>3</td><td>3</td><td><var>Cb1.3</var>, <var>Cb2.3</var></td><td><code>grade</code></td><td><code>Grade</code></td></tr>
+              <tr><td><var>Cb4</var></td><td><var>Tb</var></td><td>4</td><td>4</td><td><var>Cb1.4</var>, <var>Cb2.4</var></td><td><code>job</code></td><td><code>Job Title</code></td></tr>
+              <tr><td><var>Cb5</var></td><td><var>Tb</var></td><td>5</td><td>5</td><td><var>Cb1.5</var>, <var>Cb2.5</var></td><td><code>reportsTo</code></td><td><code>Reports to Senior Post</code></td></tr>
+              <tr><td><var>Cb6</var></td><td><var>Tb</var></td><td>6</td><td>6</td><td><var>Cb1.6</var>, <var>Cb2.6</var></td><td><code>profession</code></td><td><code>Profession</code></td></tr>
 
-              <tr><td><var>Cc1</var></td><td><var>Tc</var></td><td>1</td><td>1</td><td><var>Cc1.1</var>, <var>Cc2.1</var></td><td><code>reportsToSenior</code></td><td><code>Reporting Senior Post</code></td><td></td></tr>
-              <tr><td><var>Cc2</var></td><td><var>Tc</var></td><td>2</td><td>2</td><td><var>Cc1.2</var>, <var>Cc2.2</var></td><td><code>grade</code></td><td><code>Grade</code></td><td></td></tr>
-              <tr><td><var>Cc3</var></td><td><var>Tc</var></td><td>3</td><td>3</td><td><var>Cc1.3</var>, <var>Cc2.3</var></td><td><code>min_pay</code></td><td><code>Payscale Minimum (£)</code></td><td></td></tr>
-              <tr><td><var>Cc4</var></td><td><var>Tc</var></td><td>4</td><td>4</td><td><var>Cc1.4</var>, <var>Cc2.4</var></td><td><code>max_pay</code></td><td><code>Payscale Maximum (£)</code></td><td></td></tr>
-              <tr><td><var>Cc5</var></td><td><var>Tc</var></td><td>5</td><td>5</td><td><var>Cc1.5</var>, <var>Cc2.5</var></td><td><code>job</code></td><td><code>Generic Job Title</code></td><td></td></tr>
-              <tr><td><var>Cc6</var></td><td><var>Tc</var></td><td>6</td><td>6</td><td><var>Cc1.6</var>, <var>Cc2.6</var></td><td><code>number</code></td><td><code>Number of Posts (FTE)</code></td><td></td></tr>
-              <tr><td><var>Cc7</var></td><td><var>Tc</var></td><td>7</td><td>7</td><td><var>Cc1.7</var>, <var>Cc2.7</var></td><td><code>profession</code></td><td><code>Profession</code></td><td></td></tr>
+              <tr><td><var>Cc1</var></td><td><var>Tc</var></td><td>1</td><td>1</td><td><var>Cc1.1</var>, <var>Cc2.1</var></td><td><code>reportsToSenior</code></td><td><code>Reporting Senior Post</code></td></tr>
+              <tr><td><var>Cc2</var></td><td><var>Tc</var></td><td>2</td><td>2</td><td><var>Cc1.2</var>, <var>Cc2.2</var></td><td><code>grade</code></td><td><code>Grade</code></td></tr>
+              <tr><td><var>Cc3</var></td><td><var>Tc</var></td><td>3</td><td>3</td><td><var>Cc1.3</var>, <var>Cc2.3</var></td><td><code>min_pay</code></td><td><code>Payscale Minimum (£)</code></td></tr>
+              <tr><td><var>Cc4</var></td><td><var>Tc</var></td><td>4</td><td>4</td><td><var>Cc1.4</var>, <var>Cc2.4</var></td><td><code>max_pay</code></td><td><code>Payscale Maximum (£)</code></td></tr>
+              <tr><td><var>Cc5</var></td><td><var>Tc</var></td><td>5</td><td>5</td><td><var>Cc1.5</var>, <var>Cc2.5</var></td><td><code>job</code></td><td><code>Generic Job Title</code></td></tr>
+              <tr><td><var>Cc6</var></td><td><var>Tc</var></td><td>6</td><td>6</td><td><var>Cc1.6</var>, <var>Cc2.6</var></td><td><code>number</code></td><td><code>Number of Posts (FTE)</code></td></tr>
+              <tr><td><var>Cc7</var></td><td><var>Tc</var></td><td>7</td><td>7</td><td><var>Cc1.7</var>, <var>Cc2.7</var></td><td><code>profession</code></td><td><code>Profession</code></td></tr>
             </tbody>
           </table>
 

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -985,10 +985,6 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
             <p>The <a>property value</a> of <code>name</code> is that defined within metadata, if it exists. Otherwise, it is the first value from the <a>property value</a> of <code>title</code>, having the same language tag as <a>default language</a> or <code>und</code> if not specified, <a href="https://tools.ietf.org/html/rfc3986#page-12" class="externalDFN">percent-encoded</a> as necessary to conform to the syntactic requirements as a string without language, as defined in [[!RFC3986]]. Otherwise, it is the string <code>"_col.<em>[N]</em>"</code> where <code><em>[N]</em></code> is the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-number" class="externalDFN">column number</a>.
             </p>
           </dd>
-          <dt id="column-required"><code>required</code></dt>
-          <dd>
-            <p>A boolean <a>atomic property</a> taking a single value which indicates whether every cell within the column must have a non-null value. The value of this property is used to create the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-required" class="externalDFN">required</a> annotation for the described column.</p>
-          </dd>
           <dt id="column-suppressOutput"><code>suppressOutput</code></dt>
           <dd>
             <p>A boolean <a>atomic property</a>. If <code>true</code>, suppresses any output that would be generated when converting cells in this column. The value of this property is used to create the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-column-suppress-output" class="externalDFN">suppress output</a> annotation for the described column.</p>
@@ -1104,6 +1100,10 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
               A value for this property is <a>compatible with</a> an inherited value if they are identical, or if the value is a subtype within the datatype hierarchy defined in <a href="#datatypes" class="sectionRef"></a>, including if the inherited value is explicitly specified as the <a href="#datatype-base"><code>base</code></a> of this value.
             </p>
             <p class="issue" data-number="223">We invite comment on whether <a href="#cell-datatype"><code>datatype</code></a> should allow for a "union" of types for a cell; this would allow for a set of datatypes that could be matched against the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell, choosing the first match; e.g., to match either a <code>date</code> or <code>datetime</code>.</p>
+          </dd>
+          <dt id="cell-required"><code>required</code></dt>
+          <dd>
+            <p>A boolean <a>atomic property</a> taking a single value which indicates whether the cell must have a non-null value. The default is <code>false</code>. A value for this property is <a>compatible with</a> an inherited value only if they are identical.</p>
           </dd>
           <dt id="cell-default"><code>default</code></dt>
           <dd>
@@ -1655,7 +1655,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
     <section>
       <h2>Parsing cells</h2>
       <p>
-        Unlike many other data formats, tabular data is designed to be read by humans. For that reason, it's common for data to be represented within tabular data in a human-readable way. The <a href="#cell-null"><code>null</code></a>, <a href="#cell-default"><code>default</code></a>, <a href="#cell-separator"><code>separator</code></a>, <a href="#cell-datatype"><code>datatype</code></a>, and <a href="#cell-lang"><code>lang</code></a> properties provide the information needed to parse the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell into its (semantic) <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value" class="externalDFN">value</a>. This is used:
+        Unlike many other data formats, tabular data is designed to be read by humans. For that reason, it's common for data to be represented within tabular data in a human-readable way. The <a href="#cell-null"><code>null</code></a>, <a href="#cell-required"><code>required</code></a>, <a href="#cell-default"><code>default</code></a>, <a href="#cell-separator"><code>separator</code></a>, <a href="#cell-datatype"><code>datatype</code></a>, and <a href="#cell-lang"><code>lang</code></a> properties provide the information needed to parse the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-string-value" class="externalDFN">string value</a> of a cell into its (semantic) <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value" class="externalDFN">value</a>. This is used:
       </p>
       <ul>
         <li>by <strong>validators</strong> to check that the data in the table is in the expected format,</li>
@@ -1678,7 +1678,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
         <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code>, <code>json</code>, <code>xml</code>, <code>html</code>, <code>anyAtomicType</code>, or <code>any</code>, replace all carriage return (<code>#xD</code>), line feed (<code>#xA</code>), and tab (<code>#x9</code>) characters with space characters.</li>
         <li>unless the <a href="#cell-datatype"><code>datatype</code></a> is <code>string</code>, <code>json</code>, <code>xml</code>, <code>html</code>, <code>anyAtomicType</code>, <code>any</code>, or <code>normalizedString</code>, strip leading and trailing whitespace from the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-string-value" class="externalDFN">string value</a> and replace all instances of two or more whitespace characters with a single space character.</li>
         <li>if the resulting string is an empty string, apply the remaining steps to the string given by the <a href="#cell-default"><code>default</code></a> property.</li>
-        <li>if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code> and the resulting string is an empty string, the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value" class="externalDFN">cell value</a> is an empty list.</li>
+        <li>if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code> and the resulting string is an empty string, the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value" class="externalDFN">cell value</a> is an empty list. If the <a href="#cell-required"><code>required</code></a> property is <code>true</code>, add an error to the list of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-errors" class="externalDFN">errors</a> for the cell.</li>
         <li>if the <a href="#cell-separator"><code>separator</code></a> property is not <code>null</code>, the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value" class="externalDFN">cell value</a> is a list of values created by:
           <ol class="algorithm">
             <li>if the normalized string is an empty string, apply the remaining steps to the string given by the <a href="#cell-default"><code>default</code></a> property.</li>
@@ -1689,7 +1689,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
           </ol>
         </li>
         <li>if the string is an empty string, apply the remaining steps to the string given by the <a href="#cell-default"><code>default</code></a> property.</li>
-        <li>if the string is the same as any one of the values of the <a href="#cell-null"><code>null</code></a> property, then the resulting value is <code>null</code>.</li>
+        <li>if the string is the same as any one of the values of the <a href="#cell-null"><code>null</code></a> property, then the resulting value is <code>null</code>. If the <a href="#cell-separator"><code>separator</code></a> property is <code>null</code> and the <a href="#cell-required"><code>required</code></a> property is <code>true</code>, add an error to the list of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-errors" class="externalDFN">errors</a> for the cell.</li>
         <li>validate the string based on the datatype, using the <a href="#datatype-format"><code>format</code></a> property if one is specified, as described below, and then against the constraints described in <a href="#datatypes" class="sectionRef"></a>; if there are any errors, add them to the list of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-errors" class="externalDFN">errors</a> for the cell; the resulting value is typed as a <code>string</code> with the language provided by the <a href="#cell-lang"><code>lang</code></a> property.</li>
         <li>otherwise, if there are no errors, parse the string using the <a href="#datatype-format"><code>format</code></a> if one is specified, as described below; the resulting value is typed according to the <a href="#cell-datatype"><code>datatype</code></a> and if the <code>datatype</code> is <code>string</code>, or there is no <code>datatype</code>, it has the language provided by the <a href="#cell-lang"><code>lang</code></a> property.</li>
       </ol>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -233,7 +233,6 @@
           <li><dfn title="column source number">source number</dfn> &mdash; the position of the column in the original <a title="table url">url</a> of the table, or <code>null</code></li>
           <li><dfn title="column name">name</dfn> &mdash; the name of the column</li>
           <li><dfn title="column titles">titles</dfn> &mdash; any number of human-readable titles for the column, each of which has an associated language</li>
-          <li><dfn title="column required">required</dfn> &mdash; a boolean that indicates whether cells within the column can be <code>null</code>; if <code>false</code> then they cannot be</li>
           <li><dfn title="column datatype">datatype</dfn> &mdash; the expected datatype for the <a title="cell value">values</a> of <a title="cell">cells</a> in this column, as defined in [[!tabular-metadata]]</li>
           <li><dfn title="column virtual">virtual</dfn> &mdash; a boolean that indicates whether the column is a <a>virtual column</a>. <dfn title="virtual column">Virtual columns</dfn> are used to extend the source data with additional empty columns to support more advanced conversions; when this annotation is <code>false</code>, the column is a <dfn>real column</dfn>, which exists in the source data for the table.</li>
           <li><dfn title="column suppress output">suppress output</dfn> &mdash; a boolean that indicates whether or not this column should be suppressed in any output generated from converting the table, as described in <a href="#converting-tables" class="sectionRef"></a></li>
@@ -551,8 +550,7 @@ Link: &lt;metadata.json&gt;; rel="describedBy"; type="application/csvm+json"
         </p>
         <ul>
           <li>if there is more than one <a>row</a> with the same <a title="row primary key">primary key</a>, that is where the <a title="cell">cells</a> listed for the primary key for the row have the same <a title="cell value">values</a> as the cells listed for the primary key for another row,</li>
-          <li>for each <a>row</a> that does not have a <a title="row referenced rows">referenced row</a> for each of the <a title="table foreign keys">foreign keys</a> on the <a>table</a> the row appears in,</li>
-          <li>for each <a>cell</a> in a <a>column</a> whose <a title="column required">required</a> annotation is <code>true</code>, or</li>
+          <li>for each <a>row</a> that does not have a <a title="row referenced rows">referenced row</a> for each of the <a title="table foreign keys">foreign keys</a> on the <a>table</a> the row appears in, or</li>
           <li>for each <a title="cell errors">error</a> on each <a>cell</a>.</li>
         </ul>
         <p class="note">
@@ -991,7 +989,6 @@ Content-Type: text/csv;header=absent
                             <li><a title="column source number">source number</a> set to <a>source column number</a></li>
                             <li><a title="column name">name</a> set to <code>null</code></li>
                             <li><a title="column titles">titles</a> set to an empty list</li>
-                            <li><a title="column required">required</a> set to <code>false</code></li>
                             <li><a title="column datatype">datatype</a> set to <code>string</code></li>
                             <li><a title="column virtual">virtual</a> set to <code>false</code></li>
                             <li><a title="column suppress output">suppress output</a> set to <code>false</code></li>


### PR DESCRIPTION
This means that errors are detected when the string values are parsed rather than having to be checked in a separate sweep. Also makes it possible for people to set `required` to `true` for all the columns in a table, for example, which makes sense and could be useful.
