### PR TITLE
Added a common typographical section to all the documents

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -95,6 +95,10 @@
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
       dd a.externalDFN, p a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
       pre {overflow: auto;}
+
+      dl.typography dt { font-weight: normal}
+      dl.typography dd { margin-bottom: 0.3em; margin-top: 0.2em;}
+      dl.typography a.externalDFN { border-bottom:  1px solid #99c; font-style: italic; }
     </style>
   </head>
   <body>
@@ -133,6 +137,11 @@
 
     <section id="conformance">
       <p><a href="http://w3c.github.io/csvw/syntax/#dfn-tabular-data" class="externalDFN">Tabular data</a> MUST conform to the description from [[!tabular-data-model]]. In particular note that each <a href="http://w3c.github.io/csvw/syntax/#dfn-row" class="externalDFN">row</a> MUST contain the same number of <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> (although some of these <a href="http://w3c.github.io/csvw/syntax/#dfn-cell" class="externalDFN">cells</a> may be empty). Given this constraint, not all CSV-encoded data can be considered to be tabular data. As such, the conversion procedure described in this specification cannot be applied to all CSV files.</p>
+    </section>
+    
+    <section>
+      <h2>Typographical conventions</h2>
+      <div data-include="../typographical-conventions.html"></div>
     </section>
 
     <section id="conversion">

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -110,6 +110,10 @@
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
       dd a.externalDFN, p a.externalDFN, code a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
       pre {overflow: auto;}
+
+      dl.typography dt { font-weight: normal}
+      dl.typography dd { margin-bottom: 0.3em; margin-top: 0.2em;}
+      dl.typography a.externalDFN { border-bottom:  1px solid #99c; font-style: italic; }
     </style>
   </head>
   <body>
@@ -163,6 +167,10 @@
 
     </section>
 
+    <section>
+      <h2>Typographical conventions</h2>
+      <div data-include="../typographical-conventions.html"></div>
+    </section>
 
     <section id="conversion">
       <h2>Converting Tabular Data to RDF</h2>

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -112,6 +112,10 @@
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
       pre {overflow: auto;}
       dd a.externalDFN, p a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
+
+      dl.typography dt { font-weight: normal}
+      dl.typography dd { margin-bottom: 0.3em; margin-top: 0.2em;}
+      dl.typography a.externalDFN { border-bottom:  1px solid #99c; font-style: italic; }
     </style>
   </head>
   <body>
@@ -189,6 +193,12 @@
       </dl>
 
     </section>
+
+    <section>
+      <h2>Typographical conventions</h2>
+      <div data-include="../typographical-conventions.html"></div>
+    </section>
+
     <section>
       <h2>Annotating Tables</h2>
       <p>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -106,7 +106,11 @@
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
       pre {overflow: auto;}
       dd a.externalDFN, p a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
-    </style>
+
+      dl.typography dt { font-weight: normal}
+      dl.typography dd { margin-bottom: 0.3em; margin-top: 0.2em;}
+      dl.typography a.externalDFN { border-bottom:  1px solid #99c; font-style: italic; }
+   </style>
   </head>
   <body>
     <section id="abstract">
@@ -161,6 +165,10 @@
         <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
       </dl>
 
+    </section>
+    <section>
+      <h2>Typographical conventions</h2>
+      <div data-include="../typographical-conventions.html"></div>
     </section>
     <section id="model">
       <h2>Tabular Data Models</h2>

--- a/typographical-conventions.html
+++ b/typographical-conventions.html
@@ -1,0 +1,29 @@
+      <p>The following typographic conventions are used in this specification:</p>
+
+      <dl class="typography">
+        <dt><code>markup</code></dt>
+        <dd>Markup (elements, attributes, properties), machine processable values (string, characters, media types), property name, or a file name is in red-orange monospace font.</dd>
+        <dt><var>variable</var></dt>
+        <dd>A variable in pseudo-code or in an algorithm description is in italics.</dd>
+        <dt><dfn>definition</dfn></dt>
+        <dd>A definition of a term, to be used elsewhere in this or other specifications, is in bold and italics.</dd>
+        <dt><a title="definition">definition reference</a></dt>
+        <dd>A reference to a definition <em>in this document</em> is underlined and is also an active link to the definition itself. </dd>
+        <dt><a title="definition"><code>markup definition reference</code></a></dt>
+        <dd>A references to a definition <em>in this document</em>, when the reference itself is also a markup, is underlined, red-orange monospace font, and is also an active link to the definition itself.</dd>
+        <dt><a class="externalDFN">external definition reference</a></dt>
+        <dd>A reference to a definition <em>in another document</em> is underlined, in italics, and is also an active link to the definition itself.</dd>
+        <dt><a class="externalDFN"><code> markup external definition reference</code></a></dt>
+        <dd>A reference to a definition <em>in another document</em>, when the reference itself is also a markup, is underlined, in italics red-orange monospace font, and is also an active link to the definition itself.</dd>
+        <dt><a href=".">hyperlink</a></dt>
+        <dd>A hyperlink is underlined and in blue.</dd>
+        <dt><a href=".">[reference]</a></dt>
+        <dd>A document reference (normative or informative) is enclosed in square brackets and links to the references section.</dd>
+      </dl>
+
+      <p class="note">Notes are in light green boxes with a green left border and with a "Note" header in green. Notes are normative or informative depending on the whether they are in a normative or informative section, respectively.</p>
+
+      <pre class="example">
+        Examples are in light khaki boxes, with khaki left border, and with a 
+        numbered "Example" header in khaki. Examples are always informative. 
+        The content of the example is in monospace font and may be syntax colored.</pre> 


### PR DESCRIPTION
Inspired by some other specifications, I have added a "typographical convention" section to our documents (with a common file for the conventions themselves). You can look at

https://rawgit.com/w3c/csvw/typo-conventions/csv2rdf/index.html

for what it looks like. If you guys think it is useful, merge it, if it is unnecessary, we can also dump it...
