### PR TITLE
added clause to deal with non-core annotations ...

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -633,7 +633,9 @@
 
     <section>
       <h3>JSON-LD to JSON</h3>
-      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>non-core annotations</a> and <a>notes</a> into JSON.</p>
+      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>non-core annotations</a> and <a>notes</a> originating from the processing of metadata (as defined in [[!tabular-metadata]]) into JSON.</p>
+
+      <p class="note">Conversion applications may have other means to create <a title="annotated table">annotated tables</a>, e.g., through some application specific API-s. In such cases the exact format for non-core annotations or notes may be different. Specifications for such annotation processes should specify how these annotations should be converted into RDF.</p>
 
       <p>Name-value pairs from <a>notes</a> and <a>non-core annotations</a> annotations are generally copied verbatim from the metadata description subject to the exceptions below:</p>
       <ol>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -558,7 +558,10 @@
 
     <section>
       <h3>JSON-LD to RDF</h3>
-      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>non-core annotations</a> and <a>notes</a> into RDF in a manner consistent with the <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a></cite> defined in [[!json-ld-api]]. Converters MAY use any algorithm which results in equivalent triples.</p>
+      <p>This section defines a mechanism for transforming the [[json-ld]] <a href="http://w3c.github.io/csvw/metadata/#json-ld-dialect">dialect</a> used for <a>non-core annotations</a> and <a>notes</a> originating from the processing of metadata (as defined in [[!tabular-metadata]]) into RDF in a manner consistent with the <cite><a href="http://www.w3.org/TR/json-ld-api/#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF Algorithm</a></cite> defined in [[!json-ld-api]]. Converters MAY use any algorithm which results in equivalent triples.</p>
+
+      <p class="note">Conversion applications may have other means to create <a title="annotated table">annotated tables</a>, e.g., through some application specific API-s. In such cases the exact format for non-core annotations or notes may be different. Specifications for such annotation processes should specify how these annotations should be converted into RDF.</p>
+
       <p>Given a <var>subject</var>, <var>property</var> and <var>value</var> in <a href="http://w3c.github.io/csvw/metadata/#dfn-normalization" class="externalDFN">normalized</a> form:</p>
       <ol class="algorithm">
         <li><var>Property</var> is a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> defined in the [[csvw-context]], a <a>prefixed name</a>, or an absolute URL; expand to an absolute URL by replacing a <a href="http://www.w3.org/TR/json-ld/#dfn-term" class="externalDFN">term</a> with the URI from the term definition in [[csvw-context]] or a <a>prefixed name</a> as described in <a href="#names-of-common-properties" class="sectionRef"></a>.</li>


### PR DESCRIPTION
arising from anything other than metadata descriptions defined in
Tabular Metadata.

Suggested fix for ISSUE #485 
