### PR TITLE
Remove text/turtle from Link header example.

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -478,7 +478,6 @@ $ csvlint data.csv --schema:schema.json
 HTTP/1.1 200 OK
 Content-Type: text/tab-separated-values
 ...
-Link: &lt;metadata.ttl&gt;; rel="describedBy"; type="text/turtle"
 Link: &lt;metadata.json&gt;; rel="describedBy"; type="application/csvm+json"
         </pre>
         <p>


### PR DESCRIPTION
Fixes #513.
