### PR TITLE
Added note on the possible metadata link header

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -450,6 +450,14 @@ Link: &lt;metadata.json&gt;; rel="describedBy"; type="application/csvm+json"
         <p>
           If the metadata file found at this location does not explicitly include a reference to the requested <a>tabular data file</a> then it MUST be ignored.
         </p>
+
+        <div class="note">
+          <p>The <code>Link</code> header of the <em>metadata file</em> MAY include references to the CSV files it describes, using the <code>describes</code> relationship. For example, in the <a href="https://raw.githubusercontent.com/w3c/csvw/gh-pages/examples/countries.json">countries' metadata example</a>, the server might return the following headers:</p>
+          <pre>Link: &lt;http://example.org/countries.csv&gt;; rel="describes"; type="text/csv"
+Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/csv"</pre>
+
+          <p>However, locating the metadata SHOULD NOT depend on this mechanism.</p>
+        </div>
       </section>
       <section>
         <h3>Standard File Metadata</h3>


### PR DESCRIPTION
This is trying to close issue #542, raised by @dret. A note has been added in the syntax document referring to the possibility of using the `describes` link header.
