### PR TITLE
Added the effects of the datatype @id annotation to the csv2* documents

### DIFF
--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -566,11 +566,15 @@
 
       <section id="datatypes">
         <h3>Interpreting datatypes</h3>
-        <p><a title="cell value">Cell values</a> are expressed in the JSON output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the primitive types supported by JSON (as specified in [[!RFC7159]]) is provided in the table below.</p>
+        <p><a title="cell value">Cell values</a> are expressed in the JSON output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the primitive types supported by JSON (as specified in [[!RFC7159]]) is provided in the table below.</p>
 
         <div class="note">
           <p>Instances of JSON reserved characters within string values MUST be escaped as defined in [[!RFC7159]].</p>
           <p>JSON has no native support for expressing language information; therefore the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-language" class="externalDFN">language</a> of a value has no effect on the JSON output.</p>
+        </div>
+
+        <div class="note">
+          <p>The <a title="cell value">cell value's</a> annotation may include an additional restrictions to the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value expressed by the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">id</a> annotation value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. This restriction is ignored by the conversion procedure defined in this specification.</p>
         </div>
         
         <div class="note">

--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -1404,6 +1404,13 @@
       <div data-include="../acknowledgements.html"></div>
     </section>
     <section class="appendix" id="changes">
+      <section>
+        <h2>Changes since the working draft of 16 April 2015</h2>
+        <ul>
+          <li>A note has been added to the <a href="#datatypes">section on datatype</a> making it clear that the new <code>@id</code> annotation in the model is ignored for JSON.</li>
+        </ul>
+      </section>
+
       <h2>Changes since the first public working draft of 08 January 2015</h2>
 
       <p>The document has undergone substantial changes since the <a href="http://www.w3.org/TR/2015/WD-csv2json-20150108/">first public working draft</a>. Below are some of the changes made:</p>

--- a/csv2json/index.html
+++ b/csv2json/index.html
@@ -566,7 +566,7 @@
 
       <section id="datatypes">
         <h3>Interpreting datatypes</h3>
-        <p><a title="cell value">Cell values</a> are expressed in the JSON output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the primitive types supported by JSON (as specified in [[!RFC7159]]) is provided in the table below.</p>
+        <p><a title="cell value">Cell values</a> are expressed in the JSON output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-base" class="externalDFN">base</a> annotation value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the primitive types supported by JSON (as specified in [[!RFC7159]]) is provided in the table below.</p>
 
         <div class="note">
           <p>Instances of JSON reserved characters within string values MUST be escaped as defined in [[!RFC7159]].</p>
@@ -574,7 +574,7 @@
         </div>
 
         <div class="note">
-          <p>The <a title="cell value">cell value's</a> annotation may include an additional restrictions to the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value expressed by the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">id</a> annotation value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. This restriction is ignored by the conversion procedure defined in this specification.</p>
+          <p>Only the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-base" class="externalDFN">base</a> annotation value is used to determine the primitive type used wihtin the JSON output. Additional restrictions to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>, such as the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">id</a> annotation, are ignored for the purposes of conversion to JSON.</p>
         </div>
         
         <div class="note">

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -1755,6 +1755,7 @@
         <h2>Changes since the working draft of 16 April 2015</h2>
         <ul>
           <li>Added an <a href='#rel-rdb'>appendix</a> describing the relationships to the "Direct Mapping to RDF Specification" [[rdb-direct-mapping]].</li>
+          <li>The <a href="#datatypes">section on datatype</a> has been changed to allow for the reference to externally defined datatypes (as datatype IRI-s in RDF Literals) using the new <code>@id</code> annotation in the model.</li>
         </ul>
       </section>
 

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -108,7 +108,7 @@
       }
       ol.algorithm>li p {text-indent: 0em}
       ol.algorithm>li>p:first-child {position: relative; display: inline;}
-      dd a.externalDFN, p a.externalDFN, code a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
+      dd a.externalDFN, p a.externalDFN, code a.externalDFN, li a.externalDFN {border-bottom:  1px solid #99c; font-style: italic;}
       pre {overflow: auto;}
 
       dl.typography dt { font-weight: normal}
@@ -472,7 +472,12 @@
 
       <section id="datatypes">
         <h3>Interpreting datatypes</h3>
-        <p><a title="cell value">Cell values</a> are expressed in the RDF output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> used in the RDF is provided in the table below.</p>
+        <p><a title="cell value">Cell values</a> are expressed in the RDF output according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a>. The relationship between the value of the <a href="http://w3c.github.io/csvw/syntax/#dfn-cell-value-datatype" class="externalDFN">cell value's datatype</a> and the <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> used in the RDF output is as follows:</p>
+
+        <ul>
+          <li>if the datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">id</a> annotation is not <code>null</code>, then its value MUST be used as the RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a>;</li>
+          <li>else, the datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value MUST be mapped to the RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> using the table below.</li>
+        </ul>
         
         <div class="note">
           <p>A datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-format" class="externalDFN">format</a> annotation is irrelevant to the conversion procedure defined in this specification; the <a>cell value</a> has already been parsed from the contents the <a>cell</a> according to the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-format" class="externalDFN">format</a> annotation.</p>

--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -476,7 +476,7 @@
 
         <ul>
           <li>if the datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">id</a> annotation is not <code>null</code>, then its value MUST be used as the RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a>;</li>
-          <li>else, the datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-id" class="externalDFN">base</a> annotation value MUST be mapped to the RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> using the table below.</li>
+          <li>else, the datatype's <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-base" class="externalDFN">base</a> annotation value MUST be mapped to the RDF <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri" class="externalDFN">datatype IRI</a> using the table below.</li>
         </ul>
         
         <div class="note">


### PR DESCRIPTION
Added to the csv2rdf document the effect of the '@id' datatype annotation (its value must be used as the RDF datatype URI). Also added a note to the csv2json document that this annotation value is ignored for the json output.

These changes are part of handling issue #543.

/Cc @6a6d74 to review and possibly merge.
