### PR TITLE
Remaining editorial a11y comments

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -807,7 +807,7 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
             Boolean values may be represented in many ways aside from the standard <code>1</code> and <code>0</code> or <code>true</code> and <code>false</code>.
           </p>
           <p>
-            If the <a>datatype base</a> for a cell is <code>boolean</code>, the <a>datatype format</a> annotation provides the true and false values expected, separated by <code>|</code>. For example if <code>format</code> is <code>Y|N</code> then cells must hold either <code>Y</code> or <code>N</code> with <code>Y</code> meaning <code>true</code> and <code>N</code> meaning <code>false</code>.
+            If the <a>datatype base</a> for a cell is <code>boolean</code>, the <a>datatype format</a> annotation provides the true value followed by the false value, separated by <code>|</code>. For example if <code>format</code> is <code>Y|N</code> then cells must hold either <code>Y</code> or <code>N</code> with <code>Y</code> meaning <code>true</code> and <code>N</code> meaning <code>false</code>.
           </p>
           <p>
             The resulting <a>cell value</a> will be one or more boolean <code>true</code> or <code>false</code> values.

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -1043,7 +1043,7 @@ Content-Type: text/csv;charset=ISO-8859-1
       <section id="line-endings">
         <h3>Line Endings</h3>
         <p>
-          The ends of rows in a CSV file should be either <code>CRLF</code> (<code>U+000D U+000A</code>) or <code>LF</code> (<code>U+000A</code>). Line endings within escaped <a title="cell">cells</a> are not normalised.
+          The ends of rows in a CSV file should be <code>CRLF</code> (<code>U+000D U+000A</code>) but may be <code>LF</code> (<code>U+000A</code>). Line endings within escaped <a title="cell">cells</a> are not normalised.
         </p>
       </section>
       <section id="lines">

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -759,7 +759,7 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
             <dt><dfn title="datatype format groupChar">groupChar</dfn></dt>
             <dd>A string whose value is used to group digits within the number. The default value is <code>","</code>.</dd>
             <dt><dfn title="datatype format pattern">pattern</dfn></dt>
-            <dd>A regular expression string, in the syntax and interpreted as defined by [[!ECMASCRIPT]].</dd>
+            <dd>A regular expression string, with syntax and processing defined by [[!ECMASCRIPT]].</dd>
           </dl>
           <p class="note">
             Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
@@ -887,7 +887,7 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
             Durations MUST be formatted and interpreted as defined in [[!xmlschema11-2]], using the [[!ISO8601]] format <code>-?P<var>n</var>Y<var>n</var>M<var>n</var>DT<var>n</var>H<var>n</var>M<var>n</var>S</code>. For example, the duration <code>P1Y1D</code> is used for a year and a day; the duration <code>PT2H30M</code> for 2 hours and 30 minutes.
           </p>
           <p>
-            If the <a>datatype base</a> is a duration type, the <a>datatype format</a> annotation provides a regular expression for the string values, in the syntax and processed as defined by [[!ECMASCRIPT]].
+            If the <a>datatype base</a> is a duration type, the <a>datatype format</a> annotation provides a regular expression for the string values, with syntax and processing defined by [[!ECMASCRIPT]].
           </p>
           <p class="note">
             Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
@@ -899,7 +899,7 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
         <section>
           <h3>Formats for other types</h3>
           <p>
-            If the <a>datatype base</a> is not numeric, <code>boolean</code>, a date/time type, or a duration type, the <a>datatype format</a> annotation provides a regular expression for the string values, in the syntax and processed as defined by [[!ECMASCRIPT]].
+            If the <a>datatype base</a> is not numeric, <code>boolean</code>, a date/time type, or a duration type, the <a>datatype format</a> annotation provides a regular expression for the string values, with syntax and processing defined by [[!ECMASCRIPT]].
           </p>
           <p class="note">
             Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.


### PR DESCRIPTION
fixes #552 

@chaals please review this PR, which tackles the editorial changes:
1. ordering of true/false options in boolean formats - made this explicit
2. fixed zeugma (there were a few instances)
3. rephrased as suggested re line endings
