### PR TITLE
Fix broken link in Presenting Tables to Column and row labelling 

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -928,7 +928,7 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
         </p>
         <ul>
           <li>use the <a title="table direction">direction</a> annotation on each <a>table</a>, and the <a title="cell text direction">text direction</a> annotation on each cell, to determine the ordering of columns and characters within cells, as described in <a href="#bidirectional-tables" class="sectionRef"></a></li>
-          <li>use the <a title="column titles">titles</a> annotation on each <a>column</a> to provide a header for the column, selecting the first title in a language based on the user's locale and preferences, as described in <a href="#row-and-column-labelling" class="sectionRef"></a></li>
+          <li>use the <a title="column titles">titles</a> annotation on each <a>column</a> to provide a header for the column, selecting the first title in a language based on the user's locale and preferences, as described in <a href="#column-and-row-labelling" class="sectionRef"></a></li>
           <li>add links to headers based on the <a title="cell property URL">property URLs</a> of the cells in the first row of the table</li>
           <li>present <a title="cell value">cell values</a>, particularly boolean, numeric and date/time values, in a lexical form based on the user's locale and preferences</li>
           <li>add links to the presentation of rows and cells based on the <a title="cell about URL">about URL</a> and <a title="cell value URL">value URL</a> annotations on cells</li>


### PR DESCRIPTION
(was row and column labeling). Issue #621.
