### PR TITLE
Add MAY language for using CLDR symbols and number formats as request…

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -773,13 +773,13 @@ csvm.json
             <dt><dfn title="datatype format groupChar">groupChar</dfn></dt>
             <dd>A string whose value is used to group digits within the number. The default value is <code>null</code>.</dd>
             <dt><dfn title="datatype format pattern">pattern</dfn></dt>
-            <dd>A <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns">number format pattern</a> as defined in [[!UAX35]]. Implementations MUST recognise number format patterns containing the symbols <code>0</code>, <code>#</code>, the specified <code>decimalChar</code>, the specified <code>groupChar</code>, <code>E</code>, <code>+</code>, <code>%</code> and <code>‰</code>. Implementations MAY additionally recognise number format patterns containing other <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Special_Pattern_Characters">special pattern characters</a> defined in [[!UAX35]].</dd>
+            <dd>A <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns">number format pattern</a> as defined in [[!UAX35]]. Implementations MUST recognise number format patterns containing the symbols <code>0</code>, <code>#</code>, the specified <a title="datatype format decimalChar">decimalChar</a> (or <code>"."</code> if unspecified), the specified <a title="datatype format groupChar">groupChar</a> (or <code>","</code> if unspecified), <code>E</code>, <code>+</code>, <code>%</code> and <code>‰</code>. Implementations MAY additionally recognise number format patterns containing other <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Special_Pattern_Characters">special pattern characters</a> defined in [[!UAX35]].</dd>
           </dl>
           <p>
             If the <a>datatype format</a> annotation is a single string, this is interpreted in the same way as if it were an object with a <a title="datatype format pattern">pattern</a> property whose value is that string.
           </p>
           <p>
-            If the <a title="groupChar">groupChar</a> is specified, but no <a title="datatype format pattern">pattern</a> is supplied, when parsing the <a title="cell string value">string value</a> of a cell against this format specification, implementations MUST recognise and parse numbers that consist of:
+            If the <a title="datatype format groupChar">groupChar</a> is specified, but no <a title="datatype format pattern">pattern</a> is supplied, when parsing the <a title="cell string value">string value</a> of a cell against this format specification, implementations MUST recognise and parse numbers that consist of:
           </p>
           <ol>
             <li>an optional <code>+</code> or <code>-</code> sign,</li>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -762,7 +762,7 @@ csvm.json
         <section>
           <h3>Formats for numeric types</h3>
           <p>
-            It is not uncommon for numbers within tabular data to be formatted for human consumption, which may involve using commas for decimal points, grouping digits in the number using commas, or adding currency symbols or percent signs to the number.
+            By default, numeric values must be in the formats defined in [[!xmlschema11-2]]. It is not uncommon for numbers within tabular data to be formatted for human consumption, which may involve using commas for decimal points, grouping digits in the number using commas, or adding percent signs to the number.
           </p>
           <p>
             If the <a>datatype base</a> is a numeric type, the <a>datatype format</a> annotation indicates the expected format for that number. Its value MUST be either a single string or an object with one or more of the properties:
@@ -771,19 +771,15 @@ csvm.json
             <dt><dfn title="datatype format decimalChar">decimalChar</dfn></dt>
             <dd>A string whose value is used to represent a decimal point within the number. The default value is <code>"."</code>.</dd>
             <dt><dfn title="datatype format groupChar">groupChar</dfn></dt>
-            <dd>A string whose value is used to group digits within the number. The default value is <code>","</code>.</dd>
+            <dd>A string whose value is used to group digits within the number. The default value is <code>null</code>.</dd>
             <dt><dfn title="datatype format pattern">pattern</dfn></dt>
-            <dd>A regular expression string, with syntax and processing defined by [[!ECMASCRIPT]].</dd>
+            <dd>A <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Number_Format_Patterns">number format pattern</a> as defined in [[!UAX35]]. Implementations MUST recognise number format patterns containing the symbols <code>0</code>, <code>#</code>, the specified <code>decimalChar</code>, the specified <code>groupChar</code>, <code>E</code>, <code>+</code>, <code>%</code> and <code>‰</code>. Implementations MAY additionally recognise number format patterns containing other <a href="http://www.unicode.org/reports/tr35/tr35-numbers.html#Special_Pattern_Characters">special pattern characters</a> defined in [[!UAX35]].</dd>
           </dl>
-          <p>In addition, implementations MAY support additional number symbols described by <cite><a href="http://www.unicode.org/reports/tr35/tr35-39/tr35-numbers.html#Number_Symbols">Number Symbols</a></cite> and pattern values described by <cite><a href="http://www.unicode.org/reports/tr35/tr35-39/tr35-numbers.html#Number_Format_Patterns">Number Format Patterns</a></cite> from [[CLDR]]. In this case the <a title="datatype format pattern">pattern</a> property is interpreted accordingly, rather than as a regular expression.</p>
-          <p class="note">
-            Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
-          </p>
           <p>
             If the <a>datatype format</a> annotation is a single string, this is interpreted in the same way as if it were an object with a <a title="datatype format pattern">pattern</a> property whose value is that string.
           </p>
           <p>
-            When parsing the <a title="cell string value">string value</a> of a cell against this format specification, implementations MUST recognise and parse numbers that consist of:
+            If the <a title="groupChar">groupChar</a> is specified, but no <a title="datatype format pattern">pattern</a> is supplied, when parsing the <a title="cell string value">string value</a> of a cell against this format specification, implementations MUST recognise and parse numbers that consist of:
           </p>
           <ol>
             <li>an optional <code>+</code> or <code>-</code> sign,</li>
@@ -802,15 +798,22 @@ csvm.json
             <li><code>-INF</code>.</li>
           </ol>
           <p>
-            Implementations MUST add a validation error to the <a title="cell errors">errors</a> annotation for the <a>cell</a> if the string being parsed:
+            Implementations MAY also recognise numeric values that are in any of the standard-decimal, standard-percent or standard-scientific formats listed in the <a href="http://www.unicode.org/cldr/charts/latest/by_type/numbers.number_formatting_patterns.html">Unicode Common Locale Data Repository</a>.
+          </p>
+          <p>
+            Implementations MUST add a validation error to the <a title="cell errors">errors</a> annotation for the <a>cell</a>, and set the cell <a title="cell value">value</a> to a string rather than a number if the string being parsed:
           </p>
           <ul>
-            <li>does not meet the numeric format defined above,</li>
-            <li>contains two consecutive <a title="datatype format groupChar">groupChar</a> strings,</li>
-            <li>does not match the pattern defined in the <a title="datatype format pattern">pattern</a> property, if there is one,</li>
-            <li>contains the <a title="datatype format decimalChar">decimalChar</a>, if the <a>datatype base</a> is <code>integer</code> or one of its sub-values,</li>
-            <li>contains an exponent, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-values, or</li>
-            <li>is one of the special values <code>NaN</code>, <code>INF</code>, or <code>-INF</code>, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-values.</li>
+            <li>is not in the format specified in the <a title="datatype format pattern">pattern</a>, if one is defined</li>
+            <li>otherwise, if the string
+              <ul>
+                <li>does not meet the numeric format defined above,</li>
+                <li>contains two consecutive <a title="datatype format groupChar">groupChar</a> strings,</li>
+              </ul>
+            </li>
+            <li>contains the <a title="datatype format decimalChar">decimalChar</a>, if the <a>datatype base</a> is <code>integer</code> or one of its sub-types,</li>
+            <li>contains an exponent, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-types, or</li>
+            <li>is one of the special values <code>NaN</code>, <code>INF</code>, or <code>-INF</code>, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-types.</li>
           </ul>
           <p>
             Implementations MUST use the sign, exponent, percent, and per-mille signs when parsing the <a title="cell string value">string value</a> of a cell to provide the <a title="cell value">value</a> of the cell. For example, the string value <code>"-25%"</code> must be interpreted as <code>-0.25</code> and the string value <code>"1E6"</code> as <code>1000000</code>.
@@ -831,16 +834,19 @@ csvm.json
         <section>
           <h3>Formats for dates and times</h3>
           <p>
-            Dates and times are commonly represented in tabular data in formats other than those defined in [[!xmlschema11-2]].
+            By default, dates and times are assumed to be in the format defined in [[!xmlschema11-2]]. However dates and times are commonly represented in tabular data in other formats.
           </p>
           <p>
             If the <a>datatype base</a> is a date or time type, the <a>datatype format</a> annotation indicates the expected format for that date or time.
           </p>
           <p>
-            The supported date and time formats listed here are expressed in terms of the <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table">date field symbols</a> defined in [[!UAX35]] and MUST be interpreted by implementations as defined in that specification.
+            The supported date and time format patterns listed here are expressed in terms of the <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table">date field symbols</a> defined in [[!UAX35]]. These formats MUST be recognised by implementations and MUST be interpreted as defined in that specification. Implementations MAY additionally recognise other <a href="http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns">date format patterns</a>. Implementations MUST raise an error if the date format pattern is invalid or not recognised.
+          </p>
+          <p class="note">
+            For interoperability, authors of metadata documents SHOULD use only the formats listed in this section.
           </p>
           <p>
-            The following date formats MUST be recognized by implementations:
+            The following date format patterns MUST be recognized by implementations:
           </p>
           <ul>
             <li><code>yyyy-MM-dd</code> e.g., <code>2015-03-22</code></li>
@@ -859,7 +865,7 @@ csvm.json
             <li><code>M.d.yyyy</code> e.g., <code>3.22.2015</code></li>
           </ul>
           <p>
-            The following time formats MUST be recognized by implementations:
+            The following time format patterns MUST be recognized by implementations:
           </p>
           <ul>
             <li><code>HH:mm:ss.S</code> with one or more trailing <code>S</code> characters indicating the maximum number of fractional seconds e.g., <code>HH:mm:ss.SSS</code> for <code>15:02:37.143</code></li>
@@ -869,7 +875,7 @@ csvm.json
             <li><code>HHmm</code> e.g., <code>1502</code></li>
           </ul>
           <p>
-            The following date/time formats MUST be recognized by implementations:
+            The following date/time format patterns MUST be recognized by implementations:
           </p>
           <ul>
             <li><code>yyyy-MM-ddTHH:mm:ss.S</code> with one or more trailing <code>S</code> characters indicating the maximum number of fractional seconds e.g., <code>yyyy-MM-ddTHH:mm:ss.SSS</code> for <code>2015-03-15T15:02:37.143</code></li>
@@ -878,7 +884,7 @@ csvm.json
             <li>any of the date formats above, followed by a single space, followed by any of the time formats above, e.g., <code>M/d/yyyy HH:mm</code> for <code>3/22/2015 15:02</code> or <code>dd.MM.yyyy HH:mm:ss</code> for <code>22.03.2015 15:02:37</code></li>
           </ul>
           <p>
-            Implementations MUST also recognise date, time, and date/time formats that end with timezone markers consisting of between one and three <code>x</code> or <code>X</code> characters, possibly after a single space. These MUST be interpreted as follows:
+            Implementations MUST also recognise date, time, and date/time format patterns that end with timezone markers consisting of between one and three <code>x</code> or <code>X</code> characters, possibly after a single space. These MUST be interpreted as follows:
           </p>
           <ul>
             <li><code>X</code> e.g., <code>-08</code>, <code>+0530</code>, or <code>Z</code> (minutes are optional)</li>
@@ -889,7 +895,7 @@ csvm.json
             <li><code>xxx</code> e.g., <code>-08:00</code> or <code>+05:30</code> (<code>Z</code> is not permitted)</li>
           </ul>
           <p>
-            For example, formats could include <code>yyyy-MM-ddTHH:mm:ssXXX</code> for <code>2015-03-15T15:02:37Z</code> or <code>2015-03-15T15:02:37-05:00</code>, or <code>HH:mm x</code> for <code>15:02 -05</code>.
+            For example, date format patterns could include <code>yyyy-MM-ddTHH:mm:ssXXX</code> for <code>2015-03-15T15:02:37Z</code> or <code>2015-03-15T15:02:37-05:00</code>, or <code>HH:mm x</code> for <code>15:02 -05</code>.
           </p>
           <p>
             The <a>cell value</a> will one or more dates/time values extracted using the <code>format</code>.
@@ -2280,6 +2286,7 @@ TEXTDATA =  %x20-21 / %x23-2B / %x2D-7E
           <li>The <a title="row titles">titles</a> annotation has been added to rows, and a section added describing the way in which screen readers should announce rows and columns to users</li>
           <li>A Datatype description may have an <a title="datatype id">id</a> annotation to reference an external datatype definition in XSD, OWL, or some other format.</li>
           <li>The built-in locations for locating metadata files were removed in favor of a site-wide configuration file, which uses the original values for file-specific and directory-specific metadata locations as the default value. See <a href="#site-wide-location-configuration" class="sectionRef"></a>.</li>
+          <li>The <a title="datatype format pattern">pattern</a> for numeric types is now a number format pattern rather than a regular expression.</li>
         </ul>
       </section>
       <section>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -775,6 +775,7 @@ csvm.json
             <dt><dfn title="datatype format pattern">pattern</dfn></dt>
             <dd>A regular expression string, with syntax and processing defined by [[!ECMASCRIPT]].</dd>
           </dl>
+          <p>In addition, implementations MAY support additional number symbols described by <cite><a href="http://www.unicode.org/reports/tr35/tr35-39/tr35-numbers.html#Number_Symbols">Number Symbols</a></cite> and pattern values described by <cite><a href="http://www.unicode.org/reports/tr35/tr35-39/tr35-numbers.html#Number_Format_Patterns">Number Format Patterns</a></cite> from [[CLDR]]. In this case the <a title="datatype format pattern">pattern</a> property is interpreted accordingly, rather than as a regular expression.</p>
           <p class="note">
             Authors are encouraged to be conservative in the regular expressions that they use, sticking to the basic features of regular expressions that are likely to be supported across implementations.
           </p>
@@ -806,7 +807,7 @@ csvm.json
           <ul>
             <li>does not meet the numeric format defined above,</li>
             <li>contains two consecutive <a title="datatype format groupChar">groupChar</a> strings,</li>
-            <li>does not match the regular expression defined in the <a title="datatype format pattern">pattern</a> property, if there is one,</li>
+            <li>does not match the pattern defined in the <a title="datatype format pattern">pattern</a> property, if there is one,</li>
             <li>contains the <a title="datatype format decimalChar">decimalChar</a>, if the <a>datatype base</a> is <code>integer</code> or one of its sub-values,</li>
             <li>contains an exponent, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-values, or</li>
             <li>is one of the special values <code>NaN</code>, <code>INF</code>, or <code>-INF</code>, if the <a>datatype base</a> is <code>decimal</code> or one of its sub-values.</li>


### PR DESCRIPTION
…ed in #617.

Note that if a CLDR format pattern is used, there is no way to know whether `pattern` is a regular expression or CLDR format. Also, additional symbols are not included in our namespace, and so will be lost through a hypothetical JSON-LD transformation.
