### PR TITLE
fixed bad outputs for invalid url properties

### DIFF
--- a/tests/test047.json
+++ b/tests/test047.json
@@ -8,7 +8,6 @@
           "rownum": 1,
           "describes": [
             {
-              "@id": "http://www.w3.org/2013/csvw/tests/test047.csv",
               "null": "empty",
               "lang": "en",
               "textDirection": "ltr",

--- a/tests/test047.ttl
+++ b/tests/test047.ttl
@@ -2,24 +2,24 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<test047.csv> <test047.csv#aboutUrl> "about";
-   <test047.csv#datatype> "string";
-   <test047.csv#default> "def";
-   <test047.csv#lang> "en";
-   <test047.csv#null> "empty";
-   <test047.csv#ordered> "true";
-   <test047.csv#propertyUrl> "prop";
-   <test047.csv#separator> "-";
-   <test047.csv#textDirection> "ltr";
-   <test047.csv#valueUrl> "value" .
-
  [
     a csvw:TableGroup;
     csvw:table [
       a csvw:Table;
       csvw:row [
         a csvw:Row;
-        csvw:describes <test047.csv>;
+        csvw:describes [
+          <test047.csv#aboutUrl> "about";
+          <test047.csv#datatype> "string";
+          <test047.csv#default> "def";
+          <test047.csv#lang> "en";
+          <test047.csv#null> "empty";
+          <test047.csv#ordered> "true";
+          <test047.csv#propertyUrl> "prop";
+          <test047.csv#separator> "-";
+          <test047.csv#textDirection> "ltr";
+          <test047.csv#valueUrl> "value"
+        ];
         csvw:rownum 1;
         csvw:url <test047.csv#row=2>
       ];

--- a/tests/test048.json
+++ b/tests/test048.json
@@ -8,18 +8,16 @@
           "rownum": 1,
           "describes": [
             {
-              "http://www.w3.org/2013/csvw/tests/test048.csv": [
-                "empty",
-                "en",
-                "ltr",
-                "-",
-                "true",
-                "def",
-                "string",
-                "about",
-                "prop",
-                "value"
-              ]
+              "null": "empty",
+              "lang": "en",
+              "textDirection": "ltr",
+              "separator": "-",
+              "ordered": "true",
+              "default": "def",
+              "datatype": "string",
+              "aboutUrl": "about",
+              "propertyUrl": "prop",
+              "valueUrl": "value"
             }
           ]
         }

--- a/tests/test048.ttl
+++ b/tests/test048.ttl
@@ -8,16 +8,18 @@
       a csvw:Table;
       csvw:row [
         a csvw:Row;
-        csvw:describes [ <test048.csv> "empty",
-            "en",
-            "ltr",
-            "-",
-            "true",
-            "def",
-            "string",
-            "about",
-            "prop",
-            "value"];
+        csvw:describes [
+          <test048.csv#aboutUrl> "about";
+          <test048.csv#datatype> "string";
+          <test048.csv#default> "def";
+          <test048.csv#lang> "en";
+          <test048.csv#null> "empty";
+          <test048.csv#ordered> "true";
+          <test048.csv#propertyUrl> "prop";
+          <test048.csv#separator> "-";
+          <test048.csv#textDirection> "ltr";
+          <test048.csv#valueUrl> "value"
+        ];
         csvw:rownum 1;
         csvw:url <test048.csv#row=2>
       ];

--- a/tests/test049.json
+++ b/tests/test049.json
@@ -8,16 +8,16 @@
           "rownum": 1,
           "describes": [
             {
-              "null": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "lang": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "textDirection": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "separator": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "ordered": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "default": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "datatype": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "aboutUrl": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "propertyUrl": "http://www.w3.org/2013/csvw/tests/test049.csv",
-              "valueUrl": "http://www.w3.org/2013/csvw/tests/test049.csv"
+              "null": "empty",
+              "lang": "en",
+              "textDirection": "ltr",
+              "separator": "-",
+              "ordered": "true",
+              "default": "def",
+              "datatype": "string",
+              "aboutUrl": "about",
+              "propertyUrl": "prop",
+              "valueUrl": "value"
             }
           ]
         }

--- a/tests/test049.ttl
+++ b/tests/test049.ttl
@@ -9,16 +9,16 @@
       csvw:row [
         a csvw:Row;
         csvw:describes [
-          <test049.csv#aboutUrl> <test049.csv>;
-          <test049.csv#datatype> <test049.csv>;
-          <test049.csv#default> <test049.csv>;
-          <test049.csv#lang> <test049.csv>;
-          <test049.csv#null> <test049.csv>;
-          <test049.csv#ordered> <test049.csv>;
-          <test049.csv#propertyUrl> <test049.csv>;
-          <test049.csv#separator> <test049.csv>;
-          <test049.csv#textDirection> <test049.csv>;
-          <test049.csv#valueUrl> <test049.csv>
+          <test049.csv#aboutUrl> "about";
+          <test049.csv#datatype> "string";
+          <test049.csv#default> "def";
+          <test049.csv#lang> "en";
+          <test049.csv#null> "empty";
+          <test049.csv#ordered> "true";
+          <test049.csv#propertyUrl> "prop";
+          <test049.csv#separator> "-";
+          <test049.csv#textDirection> "ltr";
+          <test049.csv#valueUrl> "value"
         ];
         csvw:rownum 1;
         csvw:url <test049.csv#row=2>


### PR DESCRIPTION
@gkellogg I think these bad tests were caused by something going wonky in your implementation when `aboutUrl`, `propertyUrl` or `valueUrl` is given the value `true`.
