### PR TITLE
Test updates for 005 125 and 195 using default value for `null`. #664.

### DIFF
--- a/tests/test005.json
+++ b/tests/test005.json
@@ -82,8 +82,7 @@
             {
               "id": "3",
               "Surname": "Bart",
-              "FamilyName": "Simpson",
-              "child_id": ""
+              "FamilyName": "Simpson"
             }
           ]
         },
@@ -94,8 +93,7 @@
             {
               "id": "4",
               "Surname": "Lisa",
-              "FamilyName": "Simpson",
-              "child_id": ""
+              "FamilyName": "Simpson"
             }
           ]
         },
@@ -106,8 +104,7 @@
             {
               "id": "5",
               "Surname": "Maggie",
-              "FamilyName": "Simpson",
-              "child_id": ""
+              "FamilyName": "Simpson"
             }
           ]
         },
@@ -118,8 +115,7 @@
             {
               "id": "6",
               "Surname": "Ned",
-              "FamilyName": "Flanders",
-              "child_id": ""
+              "FamilyName": "Flanders"
             }
           ]
         },
@@ -130,8 +126,7 @@
             {
               "id": "7",
               "Surname": "Krusty",
-              "FamilyName": "the Clown",
-              "child_id": ""
+              "FamilyName": "the Clown"
             }
           ]
         },
@@ -142,8 +137,7 @@
             {
               "id": "8",
               "Surname": "Waylon",
-              "FamilyName": "Smithers",
-              "child_id": ""
+              "FamilyName": "Smithers"
             }
           ]
         }

--- a/tests/test005.ttl
+++ b/tests/test005.ttl
@@ -72,7 +72,6 @@
         csvw:describes [
           :FamilyName "Simpson";
           :Surname "Bart";
-          :child_id "";
           :id "3"
         ];
         csvw:rownum 7;
@@ -82,7 +81,6 @@
         csvw:describes [
           :FamilyName "Simpson";
           :Surname "Lisa";
-          :child_id "";
           :id "4"
         ];
         csvw:rownum 8;
@@ -92,7 +90,6 @@
         csvw:describes [
           :FamilyName "Simpson";
           :Surname "Maggie";
-          :child_id "";
           :id "5"
         ];
         csvw:rownum 9;
@@ -102,7 +99,6 @@
         csvw:describes [
           :FamilyName "Flanders";
           :Surname "Ned";
-          :child_id "";
           :id "6"
         ];
         csvw:rownum 10;
@@ -112,7 +108,6 @@
         csvw:describes [
           :FamilyName "the Clown";
           :Surname "Krusty";
-          :child_id "";
           :id "7"
         ];
         csvw:rownum 11;
@@ -122,7 +117,6 @@
         csvw:describes [
           :FamilyName "Smithers";
           :Surname "Waylon";
-          :child_id "";
           :id "8"
         ];
         csvw:rownum 12;

--- a/tests/test041.ttl
+++ b/tests/test041.ttl
@@ -9,16 +9,16 @@
       csvw:row [
         a csvw:Row;
         csvw:describes [
-          <test041.csv#aboutUrl> "about"@und;
-          <test041.csv#datatype> "string"@und;
-          <test041.csv#default> "def"@und;
-          <test041.csv#lang> "en"@und;
-          <test041.csv#null> "empty"@und;
-          <test041.csv#ordered> "true"@und;
-          <test041.csv#propertyUrl> "prop"@und;
-          <test041.csv#separator> "-"@und;
-          <test041.csv#textDirection> "ltr"@und;
-          <test041.csv#valueUrl> "value"@und
+          <test041.csv#aboutUrl> "about";
+          <test041.csv#datatype> "string";
+          <test041.csv#default> "def";
+          <test041.csv#lang> "en";
+          <test041.csv#null> "empty";
+          <test041.csv#ordered> "true";
+          <test041.csv#propertyUrl> "prop";
+          <test041.csv#separator> "-";
+          <test041.csv#textDirection> "ltr";
+          <test041.csv#valueUrl> "value"
         ];
         csvw:rownum 1;
         csvw:url <test041.csv#row=2>

--- a/tests/test125.json
+++ b/tests/test125.json
@@ -34,7 +34,6 @@
           "describes": [
             {
               "countryCode": "AF",
-              "latitude": "",
               "longitude": 67.709953,
               "name": "Afghanistan"
             }

--- a/tests/test125.ttl
+++ b/tests/test125.ttl
@@ -32,7 +32,6 @@
         a csvw:Row;
         csvw:describes [
           <test125.csv#countryCode> "AF";
-          <test125.csv#latitude> "";
           <test125.csv#longitude> "67.709953"^^xsd:double;
           <test125.csv#name> "Afghanistan"
         ];

--- a/tests/test195.json
+++ b/tests/test195.json
@@ -9,7 +9,6 @@
           "describes": [
             {
               "NMTOKEN": "token",
-              "string": "",
               "base64Binary": "Send reinforcements",
               "hexBinary": "0FB7"
             }

--- a/tests/test195.ttl
+++ b/tests/test195.ttl
@@ -14,8 +14,7 @@
         csvw:describes [
           <test195.csv#NMTOKEN> "token"^^xsd:NMTOKEN;
           <test195.csv#base64Binary> "U2VuZCByZWluZm9yY2VtZW50cw=="^^xsd:base64Binary;
-          <test195.csv#hexBinary> "0FB7"^^xsd:hexBinary;
-          <test195.csv#string> ""
+          <test195.csv#hexBinary> "0FB7"^^xsd:hexBinary
         ];
         csvw:rownum 1;
         csvw:url <test195.csv#row=2>


### PR DESCRIPTION
Remove "und" language from 041.ttl.
