### PR TITLE
Minor editorial change on sectioning

### DIFF
--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1928,7 +1928,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
     <section class="appendix">
       <h2>IANA Considerations</h2>
       <p>This section has <strong>not yet been submitted</strong> to IANA for review, approval, and registration.</p>
-      <h3>application/csvm+json</h3>
+      <strong style="font-size:120%">application/csvm+json</strong>
       <dl>
         <dt>Type name:</dt>
         <dd>application</dd>


### PR DESCRIPTION
Only one <hx> element should appear in a section (for respec); changed the IANA consideration section accordingly.

(This created pagination issues when an ePub version of the file was generated...)
