### PR TITLE
use a bad language tag in test109

### DIFF
--- a/tests/test109-metadata.json
+++ b/tests/test109-metadata.json
@@ -5,7 +5,7 @@
   "tableSchema": {
     "columns": [{
       "name": "GID",
-      "titles": {"not-a-language": "GID"}
+      "titles": {"a-bad-language": "GID"}
     }, {
       "name": "on_street",
       "titles": "On Street"


### PR DESCRIPTION
This test currently uses ‘not-a-language’ which is a valid language tag
according to BCP47 (‘not’ is a valid language, ‘a-language’ is a valid
extension).
