### PR TITLE
Link headers should include type

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -449,8 +449,8 @@
               <a href='test014/result.json' property='mf:result'>test014/result.json</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -524,8 +524,8 @@
               <a href='test016/result.json' property='mf:result'>test016/result.json</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -3490,8 +3490,8 @@
               <a href='test120.json' property='mf:result'>test120.json</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -3565,8 +3565,8 @@
               <a href='test122.json' property='mf:result'>test122.json</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -8432,8 +8432,8 @@
               <a href='test014/result.ttl' property='mf:result'>test014/result.ttl</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -8507,8 +8507,8 @@
               <a href='test016/result.ttl' property='mf:result'>test016/result.ttl</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -11473,8 +11473,8 @@
               <a href='test120.ttl' property='mf:result'>test120.ttl</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -11548,8 +11548,8 @@
               <a href='test122.ttl' property='mf:result'>test122.ttl</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -16371,8 +16371,8 @@
               <a href='test014/tree-ops.csv' property='mf:action'>test014/tree-ops.csv</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -16438,8 +16438,8 @@
               <a href='test016/tree-ops.csv' property='mf:action'>test016/tree-ops.csv</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -19265,8 +19265,8 @@
               <a href='test120.csv' property='mf:action'>test120.csv</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test120-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test120-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>
@@ -19332,8 +19332,8 @@
               <a href='test122.csv' property='mf:action'>test122.csv</a>
             </dd>
             <dt>Link Header</dt>
-            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"' property='csvt:httpLink'>
-              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;</code>
+            <dd content='&lt;test122-linked-metadata.json&gt;; rel="describedby"; type="application/csvm+json"' property='csvt:httpLink'>
+              <code>&lt;test122-linked-metadata.json&gt;; rel=&quot;describedby&quot;; type=&quot;application/csvm+json&quot;</code>
             </dd>
             <dt>Implicit</dt>
             <dd rel='csvt:implicit'>

--- a/tests/manifest-json.jsonld
+++ b/tests/manifest-json.jsonld
@@ -192,7 +192,7 @@
       "implicit": [
         "test014/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-json#test015",
@@ -226,7 +226,7 @@
         "test016/csv-metadata.json",
         "test016/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-json#test017",
@@ -1475,7 +1475,7 @@
       "implicit": [
         "test120-linked-metadata.json"
       ],
-      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-json#test121",
@@ -1509,7 +1509,7 @@
         "test122-metadata.json",
         "test122-linked-metadata.json"
       ],
-      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-json#test123",

--- a/tests/manifest-rdf.jsonld
+++ b/tests/manifest-rdf.jsonld
@@ -192,7 +192,7 @@
       "implicit": [
         "test014/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-rdf#test015",
@@ -226,7 +226,7 @@
         "test016/csv-metadata.json",
         "test016/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-rdf#test017",
@@ -1475,7 +1475,7 @@
       "implicit": [
         "test120-linked-metadata.json"
       ],
-      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-rdf#test121",
@@ -1509,7 +1509,7 @@
         "test122-metadata.json",
         "test122-linked-metadata.json"
       ],
-      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-rdf#test123",

--- a/tests/manifest-validation.jsonld
+++ b/tests/manifest-validation.jsonld
@@ -181,7 +181,7 @@
       "implicit": [
         "test014/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-validation#test015",
@@ -213,7 +213,7 @@
         "test016/csv-metadata.json",
         "test016/linked-metadata.json"
       ],
-      "httpLink": "<linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-validation#test017",
@@ -1443,7 +1443,7 @@
       "implicit": [
         "test120-linked-metadata.json"
       ],
-      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test120-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-validation#test121",
@@ -1475,7 +1475,7 @@
         "test122-metadata.json",
         "test122-linked-metadata.json"
       ],
-      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\""
+      "httpLink": "<test122-linked-metadata.json>; rel=\"describedby\"; type=\"application/csvm+json\""
     },
     {
       "id": "manifest-validation#test123",

--- a/tests/mk_manifest.rb
+++ b/tests/mk_manifest.rb
@@ -224,7 +224,7 @@ class Manifest
       entry["result"] = test.result_rdf if test.result_rdf && variant == :rdf
       entry["result"] = test.result_json if test.result_json && [:json, :nonnorm].include?(variant)
       entry["implicit"] = test.option[:implicit] unless test.option[:implicit].empty?
-      entry["httpLink"] = %(<#{test.link_metadata.split('/').last}>; rel="describedby") if test.link_metadata
+      entry["httpLink"] = %(<#{test.link_metadata.split('/').last}>; rel="describedby"; type="application/csvm+json") if test.link_metadata
 
       entry["option"]["metadata"] = test.user_metadata if test.user_metadata
       entry["option"]["minimal"] = true if test.option[:minimal]


### PR DESCRIPTION
According to the spec, Link headers have to have both rel=“describedby”
and type="application/csvm+json", type="application/ld+json" or
type="application/json"
