### PR TITLE
fix small typo in test227

### DIFF
--- a/tests/test227-metadata.json
+++ b/tests/test227-metadata.json
@@ -2,7 +2,7 @@
   "@context": "http://www.w3.org/ns/csvw",
   "rdfs:comment": "Applications MUST raise an error if minimum, minInclusive, maximum, maxInclusive, minExclusive, or maxExclusive are specified and the base datatype is not a numeric, date/time, or duration type.",
   "rdfs:label": "string datatype with maxExclusive",
-  "url": "test226.csv",
+  "url": "test227.csv",
   "tableSchema": {
     "columns": [
       {"titles": "string", "datatype": {"base": "string", "maxExclusive": 1}}


### PR DESCRIPTION
refers to test226.csv (and therefore out of sync with list of implicit
files)
