### PR TITLE
integer format "0" is valid

### DIFF
--- a/tests/test157.csv
+++ b/tests/test157.csv
@@ -1,2 +1,2 @@
 integer,decimal,double
-10,10.10,10.10e10
+10.1,10.10,10.10e10

--- a/tests/test157.json
+++ b/tests/test157.json
@@ -8,7 +8,7 @@
           "rownum": 1,
           "describes": [
             {
-              "integer": "10",
+              "integer": "10.1",
               "decimal": "10.10",
               "double": "10.10e10"
             }

--- a/tests/test157.ttl
+++ b/tests/test157.ttl
@@ -14,7 +14,7 @@
         csvw:describes [
           <test157.csv#decimal> "10.10";
           <test157.csv#double> "10.10e10";
-          <test157.csv#integer> "10"
+          <test157.csv#integer> 10
         ];
         csvw:rownum 1;
         csvw:url <test157.csv#row=2>

--- a/tests/test157.ttl
+++ b/tests/test157.ttl
@@ -14,7 +14,7 @@
         csvw:describes [
           <test157.csv#decimal> "10.10";
           <test157.csv#double> "10.10e10";
-          <test157.csv#integer> 10
+          <test157.csv#integer> "10.1"
         ];
         csvw:rownum 1;
         csvw:url <test157.csv#row=2>

--- a/tests/test160.csv
+++ b/tests/test160.csv
@@ -1,2 +1,2 @@
 integer,decimal,double
-10,10.10,10.10e10
+10.1,10.10,10.10e10

--- a/tests/test160.json
+++ b/tests/test160.json
@@ -8,7 +8,7 @@
           "rownum": 1,
           "describes": [
             {
-              "integer": "10",
+              "integer": "10.1",
               "decimal": "10.10",
               "double": "10.10e10"
             }

--- a/tests/test160.ttl
+++ b/tests/test160.ttl
@@ -14,7 +14,7 @@
         csvw:describes [
         <test160.csv#decimal> "10.10";
         <test160.csv#double> "10.10e10";
-        <test160.csv#integer> "10"
+        <test160.csv#integer> "10.1"
         ];
         csvw:rownum 1;
         csvw:url <test160.csv#row=2>


### PR DESCRIPTION
In `test057` currently the JSON & TTL outputs have the integer `10` as a string rather than a number. But `10` is valid against the number format `"0"` (number formats don't specify max digits for integers), so the relevant properties in the conversions should have integer not string values.
