### PR TITLE
Per resolution of #691, remove the at-risk marker and add two notes t…

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -416,10 +416,10 @@
         Processors MUST use the first metadata found for processing a <a>tabular data file</a> by using overriding metadata, if provided. Otherwise processors MUST attempt to locate the first metadata document from the <code>Link</code> header or the metadata located through site-wide configuration. If no metadata is supplied or found, processors MUST use <a>embedded metadata</a>. If the metadata does not originate from the embedded metadata, <a>validators</a> MUST verify that the <a href="http://w3c.github.io/csvw/metadata/#dfn-table-group-description" class="externalDFN">table group description</a> within that metadata is <a href="http://w3c.github.io/csvw/metadata/#table-group-description-compatibility" class="externalDFN">compatible</a> with that in the <a>embedded metadata</a>, as defined in [[!tabular-metadata]].
       </p>
       <p class="note">
-        When feasible, publishers processing should start with the metadata, rather than depend on mechanisms outlined in this section for locating metadata from a CSV. Otherwise, if possible, use the <code>Link</code> header on the CSV as described in <a href="#link-header" class="sectionRef"></a>.
+        When feasible, processors should start from a metadata file and publishers should link to metadata files directly, rather than depend on mechanisms outlined in this section for locating metadata from a tabular data file. Otherwise, if possible, publishers should provide a <code>Link</code> header on the tabular data file as described in <a href="#link-header" class="sectionRef"></a>.
       </p>
       <p class="note">
-        If there is no site-wide location, <a href="#site-wide-location-configuration" class="sectionRef"></a> provides default URI patterns to be used to locate metadata.</p>
+        If there is no site-wide location configuration, <a href="#site-wide-location-configuration" class="sectionRef"></a> specifies default URI patterns or paths to be used to locate metadata.</p>
       </p>
       <section>
         <h3>Overriding Metadata</h3>

--- a/syntax/index.html
+++ b/syntax/index.html
@@ -415,6 +415,12 @@
       <p>
         Processors MUST use the first metadata found for processing a <a>tabular data file</a> by using overriding metadata, if provided. Otherwise processors MUST attempt to locate the first metadata document from the <code>Link</code> header or the metadata located through site-wide configuration. If no metadata is supplied or found, processors MUST use <a>embedded metadata</a>. If the metadata does not originate from the embedded metadata, <a>validators</a> MUST verify that the <a href="http://w3c.github.io/csvw/metadata/#dfn-table-group-description" class="externalDFN">table group description</a> within that metadata is <a href="http://w3c.github.io/csvw/metadata/#table-group-description-compatibility" class="externalDFN">compatible</a> with that in the <a>embedded metadata</a>, as defined in [[!tabular-metadata]].
       </p>
+      <p class="note">
+        When feasible, publishers processing should start with the metadata, rather than depend on mechanisms outlined in this section for locating metadata from a CSV. Otherwise, if possible, use the <code>Link</code> header on the CSV as described in <a href="#link-header" class="sectionRef"></a>.
+      </p>
+      <p class="note">
+        If there is no site-wide location, <a href="#site-wide-location-configuration" class="sectionRef"></a> provides default URI patterns to be used to locate metadata.</p>
+      </p>
       <section>
         <h3>Overriding Metadata</h3>
         <p>
@@ -524,8 +530,6 @@ csvm.json
         <p>
           If no file were found at <code>http://example.org/.well-known/csvm</code>, the processor will use the default locations and try to retrieve metadata from <code>http://example.org/south-west/devon.csv-metadata.json</code> and, if unsuccessful, <code>http://example.org/south-west/csv-metadata.json</code>.
         </p>
-        <p class="issue atrisk" data-number="555">The use of a well-known location for defining URI patters used to locate metadata files is at risk. The Working Group solicits feedback on whether this mechanism is useful and whether it represents major implementation difficulties.</p>
-      </section>
       <section>
         <h3>Embedded Metadata</h3>
         <p>


### PR DESCRIPTION
…o prefer processing start with metadata, or use a Link header and to clarify that there are default URI patterns if the site-wide configuration is not found.

Fixes #691.
