### PR TITLE
highlighting use of default locations

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -414,7 +414,7 @@
       <ol>
         <li>metadata supplied by the user of the implementation that is processing the tabular data, see <a href="#overriding-metadata" class="sectionRef"></a>.</li>
         <li>metadata in a document linked to using a <code>Link</code> header associated with the <a>tabular data file</a>, see <a href="#link-header" class="sectionRef"></a>.</li>
-        <li>metadata located through a site-wide location configuration, see <a href="#site-wide-location-configuration" class="sectionRef"></a>.</li>
+        <li>metadata located through default paths which may be controlled by a site-wide location configuration, see <a href="#default-locations-and-site-wide-location-configuration" class="sectionRef"></a>.</li>
         <li>metadata embedded within the <a>tabular data file</a> itself, see <a href="#embedded-metadata" class="sectionRef"></a>.</li>
       </ol>
       <p>
@@ -498,12 +498,12 @@ Link: &lt;http://example.org/country_slice.csv&gt;; rel="describes"; type="text/
         </div>
       </section>
       <section>
-        <h3>Site-wide Location Configuration</h3>
+        <h3>Default Locations and Site-wide Location Configuration</h3>
         <p>
           If the user has not supplied a metadata file as overriding metadata, described in <a href="#overriding-metadata" class="sectionRef"></a>, and no applicable metadata file has been discovered through a <code>Link</code> header, described in <a href="#link-header" class="sectionRef"></a>, processors MUST attempt to locate a metadata documents through site-wide configuration.
         </p>
         <p>
-          In this case, processors MUST retrieve the file from the well-known URI <code>/.well-known/csvm</code>. (Well-known URIs are defined by [[!RFC5785]].) If no such file is located (i.e. the response results in a client error <code>4xx</code> status code or a server error <code>5xx</code> status code), processors MUST proceed as if this file were found with the content:
+          In this case, processors MUST retrieve the file from the well-known URI <code>/.well-known/csvm</code>. (Well-known URIs are defined by [[!RFC5785]].) If no such file is located (i.e. the response results in a client error <code>4xx</code> status code or a server error <code>5xx</code> status code), processors MUST proceed as if this file were found with the following content which defines default locations:
         </p>
         <pre>
 {+url}-metadata.json
@@ -535,6 +535,7 @@ csvm.json
         <p>
           If no file were found at <code>http://example.org/.well-known/csvm</code>, the processor will use the default locations and try to retrieve metadata from <code>http://example.org/south-west/devon.csv-metadata.json</code> and, if unsuccessful, <code>http://example.org/south-west/csv-metadata.json</code>.
         </p>
+      </section>
       <section>
         <h3>Embedded Metadata</h3>
         <p>


### PR DESCRIPTION
Addressing editorial issue highlighted by @dbooth-boston & @yakovsh that section on site-wide configuration of location paths didn't make it clear that the section defines some default locations for metadata.
