### PR TITLE
Add Gemfile and travis config to check REC-* 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .DS_Store
 /.tm_properties
+/Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm:
+  - 2.2.3
+script:
+  - bundle exec htmlproof ./index.html --check-html
+  - bundle exec htmlproof ./publishing-snapshots/REC-csv2json/Overview.html --check-html
+  - bundle exec htmlproof ./publishing-snapshots/REC-csv2rdf/Overview.html --check-html
+  #- bundle exec htmlproof ./publishing-snapshrts/REC-html-note/Overview.html --check-html
+  - bundle exec htmlproof ./publishing-snapshots/REC-metadata/Overview.html --check-html
+  #- bundle exec htmlproof ./publishing-snapshrts/REC-ns/Overview.html --check-html
+  - bundle exec htmlproof ./publishing-snapshots/REC-syntax/Overview.html --check-html
+  - bundle exec htmlproof ./ns/index.html --check-html
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'html-proofer'


### PR DESCRIPTION
and other documents on checkin.

@iherman, setting up the Travis configuration requires administrative rights, which I lack. Once done, this will run the checks defined in .travis.yml:

```
  - bundle exec htmlproof ./index.html --check-html
  - bundle exec htmlproof ./publishing-snapshots/REC-csv2json/Overview.html --check-html
  - bundle exec htmlproof ./publishing-snapshots/REC-csv2rdf/Overview.html --check-html
  #- bundle exec htmlproof ./publishing-snapshrts/REC-html-note/Overview.html --check-html
  - bundle exec htmlproof ./publishing-snapshots/REC-metadata/Overview.html --check-html
  #- bundle exec htmlproof ./publishing-snapshrts/REC-ns/Overview.html --check-html
  - bundle exec htmlproof ./publishing-snapshots/REC-syntax/Overview.html --check-html
  - bundle exec htmlproof ./ns/index.html --check-html
```

It will give a warning on pull requests if the tests don't pass, which they won't until issues are found. It mostly finds link issues, as the referenced docs aren't in place, but also notes what looks like some mistaken HTML in a couple of documents.

To enable, to to http://travis-ci.org, login or create a profile, linking your GitHub account. You'll then see available accounts for which you can turn on checking. When this happens, Travis will look for checkins and run the specified tests and GitHub will show the status of these checks in Pull Requests.

It would probably be better to automate creating snapshots and check the snapshots for consistency with the w3c.github.io/csvw versions of the documents, but I don't see an easy way to automate that right now.
