### PR TITLE
primer: gregg's editorial comments

### DIFF
--- a/primer/index.html
+++ b/primer/index.html
@@ -1174,6 +1174,9 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
   &lt;#name%20%28fr%29&gt; "Bulgarie"
 ] .
         </pre>
+        <p class="note">
+          The specifications define how to transform CSV into RDF. In this Primer all the examples use <a href="https://www.w3.org/TR/turtle/">Turtle</a> as the serialisation for that RDF. Implementations may generate other serialisations for RDF such as <a href="https://www.w3.org/TR/rdf-syntax-grammar/">RDF/XML</a> or <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a>.
+        </p>
         <p>See also:</p>
         <ul>
           <li><a href="#extra-metadata" class="sectionRef"></a></li>
@@ -2066,7 +2069,7 @@ a schema:Country
         <ul>
           <li>use the locale of the user of the browser to determine which titles to display for columns, and how to format numbers and dates within the table</li>
           <li>respect the directionality of the table and the text within the table that's indicated through the <a href="https://www.w3.org/TR/tabular-metadata/#tableDirection"><code>tableDirection</code></a> and <a href="https://www.w3.org/TR/tabular-metadata/#cell-textDirection"><code>textDirection</code></a> properties</li>
-          <li>use the <a href="https://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="https://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> properties to link out to other pages from cells within the table, and the <a href="https://www.w3.org/TR/tabular-metadata/#cell-propertyUrl"><code>propertyUrl</code></a> to link out to information about the property a column represents</li>
+          <li>use the <a href="https://www.w3.org/TR/tabular-metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="https://www.w3.org/TR/tabular-metadata/#cell-valueUrl"><code>valueUrl</code></a> properties to link out to other pages from cells within the table, and the <a href="https://www.w3.org/TR/tabular-metadata/#cell-propertyUrl"><code>propertyUrl</code></a> to link out to information about the property a column represents; these properties could also be used to embed RDFa into the HTML table, as described in [[html-rdfa]]</li>
           <li>display the metadata that's available about the table so that people get a full idea of the context of the data</li>
           <li>provide a way to access notes and annotations that have been provided about individual cells, rows or columns</li>
           <li>highlight cells that contain errors so that they're easy to spot and correct</li>
@@ -2194,9 +2197,9 @@ a schema:Country
       </section>
     </section>
     <section>
-      <h1>Multi-lingual CSVs</h1>
+      <h1>Handling language in CSVs</h1>
       <p>
-        There are a number of features in the CSV on the Web metadata documents that support scenarios encountered in CSV files that use different languages. We already discussed using varying number formats in <a href="#number-format" class="sectionRef"></a> and date formats in <a href="#date-format" class="sectionRef"></a>. Here we'll look at how to create metadata files, schemas and CSV files that work across multiple languages.
+        There are a number of features in the CSV on the Web metadata documents that support scenarios encountered in CSV files that use different languages. We already discussed using varying number formats in <a href="#number-format" class="sectionRef"></a> and date formats in <a href="#date-format" class="sectionRef"></a>. Here we'll look at how to create metadata files, schemas and CSV files that take account of and work across multiple languages.
       </p>
       <section id="metadata-language">
         <h2>How do you indicate the language used by the metadata file?</h2>


### PR DESCRIPTION
@gkellogg I've addressed most of the editorial comments from [your mail](https://lists.w3.org/Archives/Public/public-csv-wg/2016Feb/0016.html) with two exceptions:
1. I haven't added `lang` into the column descriptions despite it being obvious. I think the datatype for lat/long is obvious too, as is the fact that the country code is a primary key, and that each column has an equivalent schema.org property, and so on. I made the decision to try to keep the examples minimal rather than including everything all at once and I'm not sure why `lang` should be treated differently to any of the other properties in this regard.
2. Related, rather than trying to introduce the concepts of language for the metadata document and language for individual columns at once within [5.1](http://w3c.github.io/csvw/primer/#metadata-language) I changed the title of the section as a whole from "Multi-lingual CSVs" to "Handling language in CSVs". Hopefully that reduces your objection to the example only including one language! :)

See what you think - if you object strongly then I'll add the `lang` in as I'm not _that_ fussed.
