### PR TITLE
Fix example 8 in schema document

### DIFF
--- a/syntax/index.html
+++ b/syntax/index.html
@@ -586,7 +586,7 @@ csvm.json
       </p>
       <pre class="example highlight" title="Metadata file referencing multiple tabular data files sharing a schema">
 {
-  "tableSchema": "government-spending.csv",
+  "tableSchema": "government-spending.json",
   "tables": [{
     "url": "http://example.org/east-sussex-2015-03.csv",
   }, {
@@ -596,7 +596,7 @@ csvm.json
 }
       </pre>
       <p>
-        the validator would validate all the listed tables, using the locally defined schema at <code>government-spending.csv</code>. It would also use the metadata embedded in the referenced CSV files; for example, when processing <code>http://example.org/east-sussex-2015-03.csv</code>, it would use <a>embedded metadata</a> within that file to verify that the CSV is <a href="http://w3c.github.io/csvw/metadata/#table-group-description-compatibility" class="externalDFN">compatible</a> with the metadata.
+        the validator would validate all the listed tables, using the locally defined schema at <code>government-spending.json</code>. It would also use the metadata embedded in the referenced CSV files; for example, when processing <code>http://example.org/east-sussex-2015-03.csv</code>, it would use <a>embedded metadata</a> within that file to verify that the CSV is <a href="http://w3c.github.io/csvw/metadata/#table-group-description-compatibility" class="externalDFN">compatible</a> with the metadata.
       </p>
       <p>
         If a validator is passed a <a>tabular data file</a> <code>http://example.org/east-sussex-2015-03.csv</code>, the validator would use the metadata located from the CSV file: the first metadata file found through the <code>Link</code> headers found when retrieving that file, or located through a site-wide location configuration.


### PR DESCRIPTION
 to reference government-spending.json instead of government-spending.csv.

Fixes #854.