### PR TITLE
Fix examples using `"tableSchema": [...]`

### DIFF
--- a/csv2rdf/index.html
+++ b/csv2rdf/index.html
@@ -1677,7 +1677,7 @@
     }, {
       "url": "http://foo.example.org/CSV/Addresses",
       "aboutUrl" : "http://foo.example.org/CSV/Addresses/ID={ID}",
-      "tableSchema": [{
+      "tableSchema": {
         "columns": [{
           "name": "ID",
           "datatype": "integer"
@@ -1691,7 +1691,7 @@
           "propertyUrl": "rdf:type",
           "valueUrl" : "http://foo.example.org/CSV/Addresses"
         }],
-    }]
+    }
 }</pre>
       </section>
 

--- a/metadata/index.html
+++ b/metadata/index.html
@@ -1807,7 +1807,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": { "http://www.w3.org/ns/csvw", { "@language": "en" } },
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:title": "The title of this Table"</strong>
 }
         </pre>
@@ -1816,7 +1816,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
 {
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:title": {"@value": "The title of this Table", "@language": "en"}</strong>
 }
         </pre>
@@ -1826,7 +1826,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": { "http://www.w3.org/ns/csvw", { "@language": "en" } },
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:title": {"@value": "The title of this Table"}</strong>
 }
         </pre>
@@ -1836,7 +1836,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": { "http://www.w3.org/ns/csvw", { "@language": "en" } },
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:title": [
     "The title of this Table",
     {"@value": "Der Titel dieser Tabelle", "@language": "de"}
@@ -1850,7 +1850,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
 {
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:title": [
     {"@value": "The title of this Table", "@language": "en"}
     {"@value": "Der Titel dieser Tabelle", "@language": "de"}
@@ -1863,7 +1863,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": [ "http://www.w3.org/ns/csvw", { "@base": "http://example.com/" } ],
   "@type": "Table",
   "url": "table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"schema:url": {"@id": "table.csv"}</strong>
 }
         </pre>
@@ -1873,7 +1873,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": "http://www.w3.org/ns/csvw",
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"schema:url": {"@id": "http://example.com/table.csv"}</strong>
 }
         </pre>
@@ -1883,7 +1883,7 @@ Reporting Senior Post,Grade,Payscale Minimum (£),Payscale Maximum (£),Generic 
   "@context": "http://www.w3.org/ns/csvw",
   "@type": "Table",
   "url": "http://example.com/table.csv",
-  "tableSchema": [...],
+  "tableSchema": {...},
   <strong>"dc:publisher": [{
     "schema:name": "Example Municipality",
     "schema:url": {"@id": "http://example.org"}


### PR DESCRIPTION
to `"tableSchema": {...}`, which is more appropriate given that tableSchema is single-valued.

Fixes #855.