### PR TITLE
Typo, dc:imports should be owl:imports in Turtle output.

### DIFF
--- a/ns/mk_vocab.rb
+++ b/ns/mk_vocab.rb
@@ -211,7 +211,7 @@ class Vocab
     output << %(  dc:title "#{TITLE}"@en;)
     output << %(  dc:description """#{DESCRIPTION}"""@en;)
     output << %(  dc:date "#{date}"^^xsd:date;)
-    output << %(  dc:imports #{imports.map {|i| '<' + i + '>'}.join(", ")};)
+    output << %(  owl:imports #{imports.map {|i| '<' + i + '>'}.join(", ")};)
     output << %(  owl:versionInfo <#{commit}>;)
     output << %(  rdfs:seeAlso #{seeAlso.map {|i| '<' + i + '>'}.join(", ")};)
     output << "  .\n"


### PR DESCRIPTION
csvw.ttl currently uses a property dc:imports that doesn't exist in Dublin Core. I think it's just a typo and should really be owl:imports.