### PR TITLE
Update namespace documents to finalize owl:imports fix.

### DIFF
--- a/ns/csvw.jsonld
+++ b/ns/csvw.jsonld
@@ -34,9 +34,6 @@
     "sioc": "http://rdfs.org/sioc/ns#",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "skosxl": "http://www.w3.org/2008/05/skos-xl#",
-    "ssn": "http://www.w3.org/ns/ssn/",
-    "sosa": "http://www.w3.org/ns/sosa/",
-    "time": "http://www.w3.org/2006/time#",
     "v": "http://rdf.data-vocabulary.org/#",
     "vcard": "http://www.w3.org/2006/vcard/ns#",
     "void": "http://rdfs.org/ns/void#",
@@ -444,11 +441,11 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used in the Metadata Vocabulary for Tabular Data [[tabular-metadata]] along with the default JSON-LD Context."
     },
-    "dc:date": "2017-05-23",
+    "dc:date": "2017-06-06",
     "owl:imports": [
       "http://www.w3.org/ns/prov"
     ],
-    "owl:versionInfo": "https://github.com/w3c/csvw/commit/94898e9f0b073aa09b3334ded2eb5ab3b87b37a9",
+    "owl:versionInfo": "https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664",
     "rdfs:seeAlso": [
       "http://www.w3.org/TR/tabular-metadata"
     ],

--- a/ns/csvw.ttl
+++ b/ns/csvw.ttl
@@ -45,9 +45,9 @@
 csvw: a owl:Ontology;
   dc:title "CSVW Namespace Vocabulary Terms"@en;
   dc:description """This document describes the RDFS vocabulary description used in the Metadata Vocabulary for Tabular Data [[tabular-metadata]] along with the default JSON-LD Context."""@en;
-  dc:date "2017-05-23"^^xsd:date;
-  dc:imports <http://www.w3.org/ns/prov>;
-  owl:versionInfo <https://github.com/w3c/csvw/commit/94898e9f0b073aa09b3334ded2eb5ab3b87b37a9>;
+  dc:date "2017-06-06"^^xsd:date;
+  owl:imports <http://www.w3.org/ns/prov>;
+  owl:versionInfo <https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664>;
   rdfs:seeAlso <http://www.w3.org/TR/tabular-metadata>;
   .
 

--- a/ns/index.html
+++ b/ns/index.html
@@ -10,7 +10,7 @@ var respecConfig = {
     localBiblio: localBibliography,
     specStatus: "base",
     shortName: "csvwns",
-    publishDate:  "2017-05-23",
+    publishDate:  "2017-06-06",
     edDraftURI: "http://w3c.github.io/csvw/ns/",
     // lcEnd: "3000-01-01",
     // crEnd: "3000-01-01",
@@ -85,11 +85,11 @@ var respecConfig = {
         These versions may also be retrieved from <code>http://www.w3.org/ns/csvw</code> using an appropiate HTTP <em>Accept</em> header.
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2017-05-23</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2017-06-06</time></dd>
         <dt>Imports:</dt>
           <dd><a href="http://www.w3.org/ns/prov" property="owl:imports">http://www.w3.org/ns/prov</a></dd>
         <dt>Version Info:</dt>
-        <dd><a href="https://github.com/w3c/csvw/commit/94898e9f0b073aa09b3334ded2eb5ab3b87b37a9" property="owl:versionInfo">https://github.com/w3c/csvw/commit/94898e9f0b073aa09b3334ded2eb5ab3b87b37a9</a></dd>
+        <dd><a href="https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664" property="owl:versionInfo">https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664</a></dd>
         <dt>See Also:</dt>
           <dd><a href="http://www.w3.org/TR/tabular-metadata" property="rdfs:seeAlso">http://www.w3.org/TR/tabular-metadata</a></dd>
       </dl>


### PR DESCRIPTION
This realizes the changes from PR #864, principally in the csvw.ttl file; also adds "sun", "sosa" and "time" namespace prefixes.

@iherman after merging, please update the files in w3.org/ns/csvw/.