### PR TITLE
Primer metadata examples

### DIFF
--- a/primer/index.html
+++ b/primer/index.html
@@ -62,7 +62,7 @@
           issueBase: "https://github.com/w3c/csvw/issues/",
           noIDLIn: true,
           noLegacyStyle: false,
-          group: "wg/csvw"
+          group: "wg/csv"
           };
     </script>
     <script class="remove">

--- a/primer/index.html
+++ b/primer/index.html
@@ -5,31 +5,31 @@
     <meta content="width=device-width,initial-scale=1" name="viewport" />
     <title>CSV on the Web: A Primer</title>
     <script class="remove" src="../local-biblio.js"></script>
-    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
       var respecConfig = {
-          specStatus: "ED",
+          specStatus: "CG-DRAFT",
           shortName: "tabular-data-primer",
           //publishDate:  "2014-03-27",
           previousPublishDate: "2016-02-25",
           previousMaturity: "WG-NOTE",
-          previousURI: "http://www.w3.org/TR/2016/NOTE-tabular-data-primer-20160225/",
-          edDraftURI: "http://w3c.github.io/csvw/primer/",
-          //testSuiteURI: "http://www.w3.org/2013/csvw/tests/",
-          //implementationReportURI: "http://www.w3.org/2013/csvw/tests/reports/index.html",
+          previousURI: "https://www.w3.org/TR/2016/NOTE-tabular-data-primer-20160225/",
+          edDraftURI: "https://w3c.github.io/csvw/primer/",
+          //testSuiteURI: "https://www.w3.org/2013/csvw/tests/",
+          //implementationReportURI: "https://www.w3.org/2013/csvw/tests/reports/index.html",
           // lcEnd: "3000-01-01",
           //crEnd: "2015-10-30",
           editors: [{
             name: "Jeni Tennison",
             company: "Open Data Institute",
-            companyURL: "http://theodi.org/",
+            companyURL: "https://theodi.org/",
             w3cid: "33715"
           }],
           wg: "CSV on the Web Working Group",
-          wgURI: "http://www.w3.org/2013/csvw/",
+          wgURI: "https://www.w3.org/2013/csvw/",
           wgPublicList: "public-csv-wg",
-          wgPatentURI: "http://www.w3.org/2004/01/pp-impl/68238/status",
+          wgPatentURI: "https://www.w3.org/2004/01/pp-impl/68238/status",
           otherLinks: [{
             key: "Repository",
             data: [{
@@ -52,7 +52,7 @@
                       "Gregg Kellogg"
                     ],
                     "title": "Embedding Tabular Metadata in HTML",
-                    "href" : "http://www.w3.org/TR/csvw-html/",
+                    "href" : "https://www.w3.org/TR/csvw-html/",
                     "rawDate": "2016-02-25",
                     "status" : "NOTE",
                     "publisher": "W3C"
@@ -61,7 +61,8 @@
           inlineCSS: true,
           issueBase: "https://github.com/w3c/csvw/issues/",
           noIDLIn: true,
-          noLegacyStyle: false
+          noLegacyStyle: false,
+          group: "csvw"
           };
     </script>
     <script class="remove">
@@ -85,7 +86,7 @@
         But CSV is also a poor format for data. There is no mechanism within CSV to indicate the type of data in a particular column, or whether values in a particular column must be unique. It is therefore hard to validate and prone to errors such as missing values or differing data types within a column.
       </p>
       <p>
-        The <a href="http://www.w3.org/2013/csvw">CSV on the Web Working Group</a> has developed standard ways to express useful metadata about CSV files and other kinds of tabular data. This primer takes you through the ways in which these standards work together, covering:
+        The <a href="https://www.w3.org/2013/csvw">CSV on the Web Working Group</a> has developed standard ways to express useful metadata about CSV files and other kinds of tabular data. This primer takes you through the ways in which these standards work together, covering:
       </p>
       <ul>
         <li>What we mean by "tabular data" and "CSV"</li>
@@ -100,13 +101,13 @@
     </section>
     <section id="sotd">
       <p>
-        The <a href="http://www.w3.org/2013/csvw">CSV on the Web Working Group</a> was <a href="http://www.w3.org/2013/05/lcsv-charter.html">chartered</a> to produce a recommendation "Access methods for CSV Metadata" as well as recommendations for "Metadata vocabulary for CSV data" and "Mapping mechanism to transforming CSV into various formats (e.g. RDF, JSON, or XML)". This non-normative document is a primer that describes how these standards work together for new readers. The normative standards are:
+        The <a href="https://www.w3.org/2013/csvw">CSV on the Web Working Group</a> was <a href="https://www.w3.org/2013/05/lcsv-charter.html">chartered</a> to produce a recommendation "Access methods for CSV Metadata" as well as recommendations for "Metadata vocabulary for CSV data" and "Mapping mechanism to transforming CSV into various formats (e.g. RDF, JSON, or XML)". This non-normative document is a primer that describes how these standards work together for new readers. The normative standards are:
       </p>
       <ul>
-        <li><a href="http://w3c.github.io/csvw/syntax/">Model for Tabular Data and Metadata on the Web</a></li>
-        <li><a href="http://w3c.github.io/csvw/metadata/">Metadata Vocabulary for Tabular Data</a></li>
-        <li><a href="http://w3c.github.io/csvw/csv2json/">Generating JSON from Tabular Data on the Web</a></li>
-        <li><a href="http://w3c.github.io/csvw/csv2rdf/">Generating RDF from Tabular Data on the Web</a></li>
+        <li><a href="https://w3c.github.io/csvw/syntax/">Model for Tabular Data and Metadata on the Web</a></li>
+        <li><a href="https://w3c.github.io/csvw/metadata/">Metadata Vocabulary for Tabular Data</a></li>
+        <li><a href="https://w3c.github.io/csvw/csv2json/">Generating JSON from Tabular Data on the Web</a></li>
+        <li><a href="https://w3c.github.io/csvw/csv2rdf/">Generating RDF from Tabular Data on the Web</a></li>
       </ul>
     </section>
     <section>
@@ -167,7 +168,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <ul>
           <li><a href="#dialects" class="sectionRef"></a></li>
           <li><a href="#tables-from-html" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#model">Tabular Data Models</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#model">Tabular Data Models</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="metadata">
@@ -180,12 +181,12 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv"
 }
         </pre>
         <p>
-          Metadata files must always include the <a href="http://w3c.github.io/csvw/metadata/#top-level-properties"><code>@context</code></a> property with a value <code>"http://www.w3.org/ns/csvw"</code>: this enables implementations to tell that these are CSV metadata files. The <a href="http://w3c.github.io/csvw/metadata/#table-url"><code>url</code></a> property points to the CSV file that the metadata file describes.
+          Metadata files must always include the <a href="https://w3c.github.io/csvw/metadata/#top-level-properties"><code>@context</code></a> property with a value <code>"https://www.w3.org/ns/csvw"</code>: this enables implementations to tell that these are CSV metadata files. The <a href="https://w3c.github.io/csvw/metadata/#table-url"><code>url</code></a> property points to the CSV file that the metadata file describes.
         </p>
         <p class="note">
           These metadata documents should be served from a web server with a media type of <code>application/csvm+json</code> if possible.
@@ -206,7 +207,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
   {
-    "@context": "http://www.w3.org/ns/csvw",
+    "@context": "https://www.w3.org/ns/csvw",
     <strong>"tables": [{
       "url": "countries.csv"
     }, {
@@ -217,14 +218,14 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
   }
         </pre>
         <p>
-          Here, the <a href="http://w3c.github.io/csvw/metadata/#table-group-tables"><code>tables</code></a> property holds an array of table descriptions, each with the URL of the CSV file that it's describing. The metadata file as a whole describes a group of tables. This is usually used when the tables relate to each other in some way: perhaps they're data in the same format from different periods of time, or perhaps they reference each other.
+          Here, the <a href="https://w3c.github.io/csvw/metadata/#table-group-tables"><code>tables</code></a> property holds an array of table descriptions, each with the URL of the CSV file that it's describing. The metadata file as a whole describes a group of tables. This is usually used when the tables relate to each other in some way: perhaps they're data in the same format from different periods of time, or perhaps they reference each other.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#dialects" class="sectionRef"></a></li>
           <li><a href="#well-known-location" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a> in [[tabular-data-model]]</a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#metadata-format">Metadata Format</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a> in [[tabular-data-model]]</a></li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#metadata-format">Metadata Format</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="column-info">
@@ -243,7 +244,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv"
   <strong>"tableSchema": {
     "columns": [{
@@ -272,8 +273,8 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           <li><a href="#validating-csvs" class="sectionRef"></a></li>
           <li><a href="#shared-schemas" class="sectionRef"></a></li>
           <li><a href="#column-title-languages" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#schemas">Schemas</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#columns">Columns</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#schemas">Schemas</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#columns">Columns</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="tools">
@@ -282,7 +283,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           This Note can't keep an up-to-date list of the tools that implement or otherwise use CSV on the Web. Instead, look at:
         </p>
         <ul>
-          <li><a href="http://w3c.github.io/csvw/tests/reports/index.html">CSV on the Web implementation reports</a></li>
+          <li><a href="https://w3c.github.io/csvw/tests/reports/index.html">CSV on the Web implementation reports</a></li>
           <li><a href="https://www.w3.org/community/csvw/category/tools/">Entries tagged as CSV on the Web tools on the CSV on the Web Community Group blog</a></li>
         </ul>
       </section>
@@ -299,7 +300,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   <strong>"dc:title": "Unemployment in Europe (monthly)"
   "dc:description": "Harmonized unemployment data for European countries."
   "dc:creator": "Eurostat",</strong>
@@ -317,14 +318,14 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
 }
 </pre>
         <p>
-          This example uses <a href="http://dublincore.org/documents/dcmi-terms/">Dublin Core</a> as a vocabulary for providing metadata. You can tell that's the vocabulary that's being used because the terms like <code>dc:title</code> and <code>dc:description</code> begin with the prefix <code>dc</code>, which stands for Dublin Core.
+          This example uses <a href="https://dublincore.org/documents/dcmi-terms/">Dublin Core</a> as a vocabulary for providing metadata. You can tell that's the vocabulary that's being used because the terms like <code>dc:title</code> and <code>dc:description</code> begin with the prefix <code>dc</code>, which stands for Dublin Core.
         </p>
         <p>
-          There are several different metadata vocabularies in common use around the web. Some people use <a href="http://dublincore.org/documents/dcmi-terms/">Dublin Core</a>. Some people use <a href="http://schema.org">schema.org</a>. Some people use <a href="http://www.w3.org/TR/vocab-dcat/">DCAT</a>. All of these vocabularies can be used independently or together. A publisher could alternatively use:
+          There are several different metadata vocabularies in common use around the web. Some people use <a href="https://dublincore.org/documents/dcmi-terms/">Dublin Core</a>. Some people use <a href="https://schema.org">schema.org</a>. Some people use <a href="https://www.w3.org/TR/vocab-dcat/">DCAT</a>. All of these vocabularies can be used independently or together. A publisher could alternatively use:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   <strong>"schema:name": "Unemployment in Europe (monthly)",
   "schema:description": "Harmonized unemployment data for European countries."
   "schema:creator": { "schema:name": "Eurostat" },</strong>
@@ -342,17 +343,17 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
 }
 </pre>
         <p class="note">
-          It's not clear at the moment which metadata vocabulary will give publishers the most benefits. Search engines are likely to recognise <a href="http://schema.org">schema.org</a>. RDF-based systems are more likely to recognise Dublin Core.
+          It's not clear at the moment which metadata vocabulary will give publishers the most benefits. Search engines are likely to recognise <a href="https://schema.org">schema.org</a>. RDF-based systems are more likely to recognise Dublin Core.
         </p>
         <p>
-          More generally, you can use prefixed properties like these on any of the objects in a metadata document. The prefixes that are recognised are those used in the <a href="http://www.w3.org/2011/rdfa-context/rdfa-1.1">RDFa 1.1 Initial Context</a>. Other properties must be named with full URLs.
+          More generally, you can use prefixed properties like these on any of the objects in a metadata document. The prefixes that are recognised are those used in the <a href="https://www.w3.org/2011/rdfa-context/rdfa-1.1">RDFa 1.1 Initial Context</a>. Other properties must be named with full URLs.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#structured-metadata" class="sectionRef"></a></li>
           <li><a href="#metadata-language" class="sectionRef"></a></li>
           <li><a href="#multilingual-metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="documentation-columns">
@@ -362,7 +363,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv"
   "tableSchema": {
     "columns": [{
@@ -393,8 +394,8 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <p>See also:</p>
         <ul>
           <li><a href="#units-of-measure" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#columns">Columns</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#columns">Columns</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="structured-metadata">
@@ -404,7 +405,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "schema:name": "Unemployment in Europe (monthly)",
   "schema:description": "Harmonized unemployment data for European countries."
   <strong>"schema:creator": { "schema:name": "Eurostat" },</strong>
@@ -425,7 +426,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
             <pre class="example">
 "schema:creator": {
   "schema:name": "Eurostat",
-  "schema:url": "http://ec.europa.eu/eurostat",
+  "schema:url": "https://ec.europa.eu/eurostat",
   "schema:contactPoint": [{
     "schema:telephone": "+44 20 300 63103",
     "schema:availableLanguage": "English"
@@ -449,7 +450,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           </li>
           <li>Use an <code>@id</code> property to provide values that are URLs for things about which more information is available at that URL. For example, rather than providing all the information about Eurostat embedded within the metadata, you could just reference out to it:
             <pre class="example">
-"schema:creator": { "@id": "http://ec.europa.eu/eurostat" }
+"schema:creator": { "@id": "https://ec.europa.eu/eurostat" }
 </pre>
             or you could include the <code>@id</code> along with other basic properties to make it more readable for humans.
           </li>
@@ -458,13 +459,13 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <ul>
           <li><a href="#extra-metadata" class="sectionRef"></a></li>
           <li><a href="#data-cube" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="cell-annotations">
         <h2>How should you annotate individual cells?</h2>
         <p>
-          There's no standardised facility in the CSV on the Web specifications for annotating individual cells, but there is a hook that will enable best practice about how to do that to emerge: the <a href="http://w3c.github.io/csvw/metadata/#table-notes"><code>notes</code></a> property on a table description can contain objects that represent annotations.
+          There's no standardised facility in the CSV on the Web specifications for annotating individual cells, but there is a hook that will enable best practice about how to do that to emerge: the <a href="https://w3c.github.io/csvw/metadata/#table-notes"><code>notes</code></a> property on a table description can contain objects that represent annotations.
         </p>
         <p>
           The <a href="https://www.w3.org/annotation/">W3C Web Annotation Working Group</a> is working on a vocabulary for annotations themselves. This vocabulary includes the concept of a <em>target</em> for an annotation and its <em>body</em> (the content of the annotation).
@@ -482,11 +483,11 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           the cell containing <code>Belgique</code> is at <code>#cell=3,4</code>. It's also possible to refer to ranges of cells with this syntax and to use <code>*</code> to refer to the last row in the file. For example, to target a comment on all the locations in the CSV file you could use the fragment identifier <code>#cell=2,6-*,7</code>.
         </p>
         <p>
-          To create comments, then, the <a href="http://w3c.github.io/csvw/metadata/#table-notes"><code>notes</code></a> property can hold an array of objects that use the Web Annotation structure. For example:
+          To create comments, then, the <a href="https://w3c.github.io/csvw/metadata/#table-notes"><code>notes</code></a> property can hold an array of objects that use the Web Annotation structure. For example:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "notes": [{
     "type": "Annotation",
@@ -504,7 +505,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <p>See also:</p>
         <ul>
           <li><a href="#html-display" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#table-notes">Table <code>notes</code></a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#table-notes">Table <code>notes</code></a> in [[tabular-metadata]]</li>
         </ul>
       </section>
     </section>
@@ -531,11 +532,11 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
 "bg","eu","Bulgaria","Bulgarie","Bulgarien","42.72567375","25.4823218"
 </pre>
         <p>
-          The first five columns are strings and the last two are numbers. You can indicate this with the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property for each column:
+          The first five columns are strings and the last two are numbers. You can indicate this with the <a href="https://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property for each column:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv"
   "tableSchema": {
     "columns": [{
@@ -579,14 +580,14 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           <li><a href="#enumerations" class="sectionRef"></a></li>
           <li><a href="#mixed-datatypes" class="sectionRef"></a></li>
           <li><a href="#sequence-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#datatypes">Datatypes</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#datatypes">Datatypes</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="new-datatypes">
         <h2>How do you define new datatypes?</h2>
         <p>
-          You can define new datatypes based on the built-in datatypes using an object as the value of the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property rather than a string. For example:
+          You can define new datatypes based on the built-in datatypes using an object as the value of the <a href="https://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property rather than a string. For example:
         </p>
         <pre class="example">
 "datatype": {
@@ -595,7 +596,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
   "maximum": "5"
 }</pre>
         <p>
-          The <a href="http://w3c.github.io/csvw/metadata/#datatype-base"><code>base</code></a> property must be an existing datatype. The other properties on the new datatype define extra restrictions on values of the new datatype. You can give the new datatype a name and description to provide extra documentation for people using the data:
+          The <a href="https://w3c.github.io/csvw/metadata/#datatype-base"><code>base</code></a> property must be an existing datatype. The other properties on the new datatype define extra restrictions on values of the new datatype. You can give the new datatype a name and description to provide extra documentation for people using the data:
         </p>
         <pre class="example">
 "datatype": {
@@ -616,8 +617,8 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           <li><a href="#boolean-format" class="sectionRef"></a></li>
           <li><a href="#units-of-measure" class="sectionRef"></a></li>
           <li><a href="#geospatial" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#derived-datatypes">Derived Datatypes</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#derived-datatypes">Derived Datatypes</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="string-restriction">
@@ -636,7 +637,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
 }
   </pre>
         <p>
-          It's also possible to restrict the length of a string-based datatype using the <a href="http://w3c.github.io/csvw/metadata/#datatype-length"><code>length</code></a> or <a href="http://w3c.github.io/csvw/metadata/#datatype-minLength"><code>minLength</code></a> and/or <a href="http://w3c.github.io/csvw/metadata/#datatype-maxLength"><code>maxLength</code></a> properties. For example the following says that the column holding the English names of countries must have values between 3 and 128 characters long:
+          It's also possible to restrict the length of a string-based datatype using the <a href="https://w3c.github.io/csvw/metadata/#datatype-length"><code>length</code></a> or <a href="https://w3c.github.io/csvw/metadata/#datatype-minLength"><code>minLength</code></a> and/or <a href="https://w3c.github.io/csvw/metadata/#datatype-maxLength"><code>maxLength</code></a> properties. For example the following says that the column holding the English names of countries must have values between 3 and 128 characters long:
         </p>
         <pre class="example">{
   "titles": "name (en)",
@@ -654,14 +655,14 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
           <li><a href="#enumeration-regexp" class="sectionRef"></a></li>
           <li><a href="#column-language" class="sectionRef"></a></li>
           <li><a href="#geospatial" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-other-types">Formats for other types</a> in [[tabular-data-model]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#length-constraints">Length Constraints</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-other-types">Formats for other types</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#length-constraints">Length Constraints</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="number-restriction">
         <h2>How do you restrict the size of numbers a column contains?</h2>
         <p>
-          The size of numbers in a column can be restricted using the <a href="http://w3c.github.io/csvw/metadata/#datatype-minimum"><code>minimum</code></a> and <a href="http://w3c.github.io/csvw/metadata/#datatype-maximum"><code>maximum</code></a> properties and/or the <a href="http://w3c.github.io/csvw/metadata/#datatype-minExclusive"><code>minExclusive</code></a> and <a href="http://w3c.github.io/csvw/metadata/#datatype-maxExclusive"><code>maxExclusive</code></a> properties. In our example, one column contains latitudes, which can range between -90 and +90:
+          The size of numbers in a column can be restricted using the <a href="https://w3c.github.io/csvw/metadata/#datatype-minimum"><code>minimum</code></a> and <a href="https://w3c.github.io/csvw/metadata/#datatype-maximum"><code>maximum</code></a> properties and/or the <a href="https://w3c.github.io/csvw/metadata/#datatype-minExclusive"><code>minExclusive</code></a> and <a href="https://w3c.github.io/csvw/metadata/#datatype-maxExclusive"><code>maxExclusive</code></a> properties. In our example, one column contains latitudes, which can range between -90 and +90:
         </p>
         <pre class="example">{
   "titles": "latitude",
@@ -675,13 +676,13 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <ul>
           <li><a href="#number-precision" class="sectionRef"></a></li>
           <li><a href="#number-format" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#value-constraints">Value Constraints</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#value-constraints">Value Constraints</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="number-precision">
         <h2>How do you ensure that decimal numbers have a particular precision or leading zeros?</h2>
         <p>
-          In the example we're using, the latitudes are provided to between six and eight decimal places and there are no leading or trailing zeros. You can use the <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to provide a pattern that matches these numbers. In the pattern, <code>0</code> represents a required digit and <code>#</code> represents an optional digit. For the <code>latitude</code>, the definition looks like:
+          In the example we're using, the latitudes are provided to between six and eight decimal places and there are no leading or trailing zeros. You can use the <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to provide a pattern that matches these numbers. In the pattern, <code>0</code> represents a required digit and <code>#</code> represents an optional digit. For the <code>latitude</code>, the definition looks like:
         </p>
         <pre class="example">{
   "titles": "latitude",
@@ -693,22 +694,22 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
   }
 }</pre>
         <p>
-          The <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property can also be used to indicate that values in a column should have leading zeros. For example, if a column were supposed to hold a three digit number you could use the pattern <code>000</code>.
+          The <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property can also be used to indicate that values in a column should have leading zeros. For example, if a column were supposed to hold a three digit number you could use the pattern <code>000</code>.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#number-restriction" class="sectionRef"></a></li>
           <li><a href="#number-format" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-numeric-types">Formats for numeric types</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-numeric-types">Formats for numeric types</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="number-format">
         <h2>How do you validate numbers that aren't in standard numeric formats?</h2>
         <p>
-          Sometimes numbers within a CSV file won't be in a standard numeric format. For example, they might include commas as grouping characters (eg <code>12,345,678</code>) or as decimal points (eg <code>12,3</code>). In these cases, you can use the <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property with an object value.
+          Sometimes numbers within a CSV file won't be in a standard numeric format. For example, they might include commas as grouping characters (eg <code>12,345,678</code>) or as decimal points (eg <code>12,3</code>). In these cases, you can use the <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property with an object value.
         </p>
         <p>
-          To match numbers with grouping separators as in <code>12,345,678</code> you should specify <code>","</code> as the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-format-groupchar"><code>groupChar</code></a> for the format. The <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-format-pattern"><code>pattern</code></a> property then holds the pattern that indicates how many digits should be in each group. This example validates numbers with groups of three digits separated by commas:
+          To match numbers with grouping separators as in <code>12,345,678</code> you should specify <code>","</code> as the <a href="https://w3c.github.io/csvw/syntax/#dfn-datatype-format-groupchar"><code>groupChar</code></a> for the format. The <a href="https://w3c.github.io/csvw/syntax/#dfn-datatype-format-pattern"><code>pattern</code></a> property then holds the pattern that indicates how many digits should be in each group. This example validates numbers with groups of three digits separated by commas:
         </p>
         <pre class="example">
 "datatype": {
@@ -719,7 +720,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
   }</strong>
 }</pre>
         <p>
-          To match numbers with decimal separators other than <code>.</code>, as in <code>12,3</code>, you should specify <code>","</code> as the <a href="http://w3c.github.io/csvw/syntax/#dfn-datatype-format-decimalchar"><code>decimalChar</code></a> for the format. This example validates numbers with commas as decimal points:
+          To match numbers with decimal separators other than <code>.</code>, as in <code>12,3</code>, you should specify <code>","</code> as the <a href="https://w3c.github.io/csvw/syntax/#dfn-datatype-format-decimalchar"><code>decimalChar</code></a> for the format. This example validates numbers with commas as decimal points:
         </p>
         <pre class="example">
 "datatype": {
@@ -744,13 +745,13 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <ul>
           <li><a href="#number-restriction" class="sectionRef"></a></li>
           <li><a href="#number-precision" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-numeric-types">Formats for numeric types</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-numeric-types">Formats for numeric types</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="date-restriction">
         <h2>How do you restrict what kind of dates and times a column contains?</h2>
         <p>
-          Dates and times are treated similarly to numbers. You can use the <a href="http://w3c.github.io/csvw/metadata/#datatype-minimum"><code>minimum</code></a>, <a href="http://w3c.github.io/csvw/metadata/#datatype-maximum"><code>maximum</code></a>, <a href="http://w3c.github.io/csvw/metadata/#datatype-minExclusive"><code>minExclusive</code></a> and/or <a href="http://w3c.github.io/csvw/metadata/#datatype-maxExclusive"><code>maxExclusive</code></a> properties to restrict their values.
+          Dates and times are treated similarly to numbers. You can use the <a href="https://w3c.github.io/csvw/metadata/#datatype-minimum"><code>minimum</code></a>, <a href="https://w3c.github.io/csvw/metadata/#datatype-maximum"><code>maximum</code></a>, <a href="https://w3c.github.io/csvw/metadata/#datatype-minExclusive"><code>minExclusive</code></a> and/or <a href="https://w3c.github.io/csvw/metadata/#datatype-maxExclusive"><code>maxExclusive</code></a> properties to restrict their values.
         </p>
         <p>
           For example, to indicate that the column should contain dates later than 1st January 2000, you can use the datatype:
@@ -774,13 +775,13 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <p>See also:</p>
         <ul>
           <li><a href="#date-format" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#value-constraints">Value Constraints</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#value-constraints">Value Constraints</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="date-format">
         <h2>How do you validate dates that aren't in standard date or time formats?</h2>
         <p>
-          Dates and times in CSV files often come in formats other than the standard <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format. You can use the <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to indicate the expected format of the date or time.
+          Dates and times in CSV files often come in formats other than the standard <a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format. You can use the <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to indicate the expected format of the date or time.
         </p>
         <p>
           For example, to recognise dates in the usual UK format such as 31/10/2015 for 31st October 2015, you could use:
@@ -834,7 +835,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <p>See also:</p>
         <ul>
           <li><a href="#date-restriction" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-dates-and-times">Formats for dates and times</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-dates-and-times">Formats for dates and times</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="boolean-format">
@@ -850,7 +851,7 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
         <p>See also:</p>
         <ul>
           <li><a href="#string-restriction" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-booleans">Formats for booleans</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-booleans">Formats for booleans</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="enumerations">
@@ -886,12 +887,12 @@ cell in column 1 and row 3,cell in column 2 and row 3,cell in column 3 and row 3
   }
 }</pre>
           <p>
-            As described in <a href="#string-restriction" class="sectionRef"></a>, the <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property contains a regular expression. List the options separated by <code>|</code> and ensure that you escape any of the characters in the options that have special meaning in regular expressions.
+            As described in <a href="#string-restriction" class="sectionRef"></a>, the <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property contains a regular expression. List the options separated by <code>|</code> and ensure that you escape any of the characters in the options that have special meaning in regular expressions.
           </p>
           <p>See also:</p>
           <ul>
             <li><a href="#string-restriction" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#formats-for-other-types">Formats for other types</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#formats-for-other-types">Formats for other types</a> in [[tabular-data-model]]</li>
           </ul>
         </section>
         <section id="enumeration-reference">
@@ -908,11 +909,11 @@ non-eu
             We can then provide definitions for both the <code>countries.csv</code> and <code>country-groups.csv</code> files, and state that the <code>country group</code> column in <code>countries.csv</code> references the <code>group</code> column in <code>country_groups.csv</code>. This reference from one file to another is called a <dfn>foreign key</dfn>.
           </p>
           <p>
-            To use a foreign key, both files must be referenced in the same metadata document, and both columns must be given names. Column names are only used inside the metadata document and you can only use (ASCII) letters, numbers, <code>.</code> and <code>_</code> within them. So the basic metadata document, before adding the foreign key, should look like:
+            To use a <a>foreign key</a>, both files must be referenced in the same metadata document, and both columns must be given names. Column names are only used inside the metadata document and you can only use (ASCII) letters, numbers, <code>.</code> and <code>_</code> within them. So the basic metadata document, before adding the <a>foreign key</a>, should look like:
           </p>
           <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "tables": [{
     "url": "countries.csv",
     "tableSchema": {
@@ -945,11 +946,11 @@ non-eu
 }
 </pre>
           <p>
-            The foreign key is defined in the schema for the <code>countries.csv</code> table, as follows:
+            The <a>foreign key</a> is defined in the schema for the <code>countries.csv</code> table, as follows:
           </p>
           <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "tables": [{
     "url": "countries.csv",
     "tableSchema": {
@@ -989,7 +990,7 @@ non-eu
 }
 </pre>
           <p>
-            The <a href="http://w3c.github.io/csvw/metadata/#schema-foreignKeys"><code>foreignKeys</code></a> property can hold several foreign keys. Each contains a <a href="http://w3c.github.io/csvw/metadata/#foreign-key-column-reference"><code>columnReference</code></a> to a column or list of columns in one CSV file, and a <a href="http://w3c.github.io/csvw/metadata/#foreign-key-reference"><code>reference</code></a> which defines a column or list of columns in another CSV file.
+            The <a href="https://w3c.github.io/csvw/metadata/#schema-foreignKeys"><code>foreignKeys</code></a> property can hold several <a>foreign keys</a>. Each contains a <a href="https://w3c.github.io/csvw/metadata/#foreign-key-column-reference"><code>columnReference</code></a> to a column or list of columns in one CSV file, and a <a href="https://w3c.github.io/csvw/metadata/#foreign-key-reference"><code>reference</code></a> which defines a column or list of columns in another CSV file.
           </p>
           <p>
             The advantage of this method of listing the values allowed in a column is that the CSV file that contains the list of possible values can also provide additional information about those values. For example, we can provide expansions of what <code>eu</code> and <code>non-eu</code> mean in different languages:
@@ -1002,7 +1003,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           <p>See also:</p>
           <ul>
             <li><a href="#shared-schemas" class="sectionRef"></a></li>
-            <li><a href="http://w3c.github.io/csvw/metadata/#schema-examples">Foreign key examples</a> in [[tabular-metadata]]</li>
+            <li><a href="https://w3c.github.io/csvw/metadata/#schema-examples">Foreign key examples</a> in [[tabular-metadata]]</li>
           </ul>
         </section>
       </section>
@@ -1012,7 +1013,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           Sometimes a column that contains numbers will contain special values, such as <code>X</code> or <code>NK</code>, when a value is unknown or redacted. If these columns are simply classified as numeric then the non-numeric values will be classed as errors.
         </p>
         <p>
-          To avoid values being classified as errors when they are being used to indicate missing values, list those values as null values using the <a href="http://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> property. This can take either a single string or an array of strings. For example, the <code>latitude</code> column might usually be numeric but hold an <code>X</code> if there is no indicative point for the country:
+          To avoid values being classified as errors when they are being used to indicate missing values, list those values as null values using the <a href="https://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> property. This can take either a single string or an array of strings. For example, the <code>latitude</code> column might usually be numeric but hold an <code>X</code> if there is no indicative point for the country:
         </p>
         <pre class="example">{
   "titles": "latitude",
@@ -1024,13 +1025,13 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
   }
 }</pre>
         <p class="note">
-          The <a href="http://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> property can also be useful when a column contains values that are of the right type but used to indicate a missing value. It's not uncommon, for example, for publishers to use the value <code>99</code> in a column that contains integers to indicate that a value is missing.
+          The <a href="https://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> property can also be useful when a column contains values that are of the right type but used to indicate a missing value. It's not uncommon, for example, for publishers to use the value <code>99</code> in a column that contains integers to indicate that a value is missing.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#string-restriction" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-null"><code>null</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#parsing-cells">Parsing Cells</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-null"><code>null</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#parsing-cells">Parsing Cells</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="sequence-values">
@@ -1045,7 +1046,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
 "bg","eu","Bulgaria","Bulgarie","Bulgarien","42.72567375 25.4823218"
 </pre>
         <p>
-          In this scenario, the <a href="http://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code></a> property can be used to indicate that the values in a column are lists themselves, and what separator is used between the items in the list. For example:
+          In this scenario, the <a href="https://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code></a> property can be used to indicate that the values in a column are lists themselves, and what separator is used between the items in the list. For example:
         </p>
         <pre class="example">{
   "titles": "latlong",
@@ -1057,19 +1058,19 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
   }
 }</pre>
         <p>
-          When <a href="http://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code></a> is specified, the <a href="http://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property applies to each of the values in the list. There's no way to indicate that the values in the list have different datatypes, or set limits on the length of the list.
+          When <a href="https://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code></a> is specified, the <a href="https://w3c.github.io/csvw/metadata/#cell-datatype"><code>datatype</code></a> property applies to each of the values in the list. There's no way to indicate that the values in the list have different datatypes, or set limits on the length of the list.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#list-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#parsing-cells">Parsing Cells</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-separator"><code>separator</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#parsing-cells">Parsing Cells</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="required-values">
         <h2>How do you ensure every row has a value for a column?</h2>
         <p>
-          By default, a validator won't give any errors if a value is missing in a column. If you want to ensure that a value is provided for every row in the column, use the <a href="http://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a> property for that column, with the value <code>true</code>.
+          By default, a validator won't give any errors if a value is missing in a column. If you want to ensure that a value is provided for every row in the column, use the <a href="https://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a> property for that column, with the value <code>true</code>.
         </p>
         <p>
           In our example, we might say that all the columns are required except the French and German names (applications being expected to default to the English name if the translation is missing):
@@ -1099,12 +1100,12 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
 }
 </pre>
         <p class="note">
-          Setting <a href="http://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a> to <code>true</code> means that you can't have any null values in a column. If, in this example, <code>latitude</code> and <code>longitude</code> had <code>null</code> set to <code>X</code> then those columns couldn't contain an <code>X</code>. It doesn't usually make sense to specify both <a href="http://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a>.
+          Setting <a href="https://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a> to <code>true</code> means that you can't have any null values in a column. If, in this example, <code>latitude</code> and <code>longitude</code> had <code>null</code> set to <code>X</code> then those columns couldn't contain an <code>X</code>. It doesn't usually make sense to specify both <a href="https://w3c.github.io/csvw/metadata/#cell-null"><code>null</code></a> and <a href="https://w3c.github.io/csvw/metadata/#cell-required"><code>required</code></a>.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#unique-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-required"><code>required</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-required"><code>required</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="unique-values">
@@ -1141,7 +1142,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           <li><a href="#enumeration-reference" class="sectionRef"></a></li>
           <li><a href="#required-values" class="sectionRef"></a></li>
           <li><a href="#shared-schemas" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#schema-primaryKey"><code>primaryKey</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#schema-primaryKey"><code>primaryKey</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
     </section>
@@ -1203,7 +1204,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           and the RDF output would be:
         </p>
         <pre class="example">
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+@prefix xsd: &lt;https://www.w3.org/2001/XMLSchema#&gt; .
 
 [
   &lt;#country&gt; "at";
@@ -1245,7 +1246,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           <li><a href="#data-cube" class="sectionRef"></a></li>
           <li><a href="#extension-transformations" class="sectionRef"></a></li>
           <li><a href="https://www.w3.org/TR/csv2json/#minimal-mode">Minimal Mode</a> in [[csv2json]]</li>
-          <li><a href="http://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
+          <li><a href="https://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
         </ul>
       </section>
       <section id="transformation-values">
@@ -1255,7 +1256,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "tableSchema": {
     "columns": [{
@@ -1314,8 +1315,8 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           and the RDF will look like:
         </p>
         <pre class="example">
-@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+@prefix rdf: &lt;https://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix xsd: &lt;https://www.w3.org/2001/XMLSchema#&gt; .
 
 [
   &lt;#country&gt; "at";
@@ -1353,7 +1354,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           <li><a href="#column-language" class="sectionRef"></a></li>
           <li><a href="#uom-datatypes" class="sectionRef"></a></li>
           <li><a href="https://www.w3.org/TR/csv2json/#datatypes">Datatypes</a> in [[csv2json]]</li>
-          <li><a href="http://w3c.github.io/csvw/csv2rdf/#datatypes">Datatypes</a> in [[csv2rdf]]</li>
+          <li><a href="https://w3c.github.io/csvw/csv2rdf/#datatypes">Datatypes</a> in [[csv2rdf]]</li>
         </ul>
       </section>
       <section id="missing-values">
@@ -1379,7 +1380,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
   &lt;#name%20%28fr%29&gt; "Autriche"@fr
 ] .</pre>
         <p>
-          If you want a value to appear even when the value is missing in the CSV, you can provide that value as the <a href="http://w3c.github.io/csvw/metadata/#cell-default"><code>default</code></a> for the column. This value must be supplied as a string but will be treated exactly as if it had appeared within the CSV file. For example, if you supply a non-numeric string for a numeric column, as in:
+          If you want a value to appear even when the value is missing in the CSV, you can provide that value as the <a href="https://w3c.github.io/csvw/metadata/#cell-default"><code>default</code></a> for the column. This value must be supplied as a string but will be treated exactly as if it had appeared within the CSV file. For example, if you supply a non-numeric string for a numeric column, as in:
         </p>
         <pre class="example">{
   "titles": "latitude",
@@ -1394,7 +1395,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           <li><a href="#required-values" class="sectionRef"></a></li>
           <li><a href="#mixed-datatypes" class="sectionRef"></a></li>
           <li><a href="https://www.w3.org/TR/csv2json/#minimal-mode">Minimal Mode</a> in [[csv2json]]</li>
-          <li><a href="http://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
+          <li><a href="https://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
         </ul>
       </section>
       <section id="property-names">
@@ -1403,7 +1404,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           By default, the properties in the JSON and RDF come from the titles of the columns (the headers in the CSV file). In RDF, since the properties are URIs, the names are URL-encoded and turned into fragment identifiers in a URL based on the location of the CSV file being transformed. Hence in the previous examples there have been property names like <code>"name (en)"</code> in JSON and <code>#name%20%28en%29</code> in RDF.
         </p>
         <p>
-          You can override this default by supplying a <a href="http://w3c.github.io/csvw/metadata/#column-name"><code>name</code></a> for the column. That name will be used instead of the title of the column when creating the property. So if you have:
+          You can override this default by supplying a <a href="https://w3c.github.io/csvw/metadata/#column-name"><code>name</code></a> for the column. That name will be used instead of the title of the column when creating the property. So if you have:
         </p>
         <pre class="example">
 {
@@ -1415,7 +1416,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
           then the property will be called <code>english_name</code> in the JSON output and <code>#english_name</code> in the RDF output.
         </p>
         <p>
-          You can also use the <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> property to supply a prefixed name or a URL for the property. For example, to use <code>schema:latitude</code> as the name for the <code>latitude</code> property in both the JSON and the RDF output, you could use:
+          You can also use the <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> property to supply a prefixed name or a URL for the property. For example, to use <code>schema:latitude</code> as the name for the <code>latitude</code> property in both the JSON and the RDF output, you could use:
         </p>
         <pre class="example">{
   "titles": "latitude",
@@ -1423,7 +1424,7 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
   "datatype": "number"
 }</pre>
         <p>
-          The <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> property can be used to map several columns in the CSV file onto properties with the same name. In our example, each country has several names which are all really the same property; the schema could look like:
+          The <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> property can be used to map several columns in the CSV file onto properties with the same name. In our example, each country has several names which are all really the same property; the schema could look like:
         </p>
         <pre class="example">{
   "titles": "name (en)",
@@ -1451,67 +1452,67 @@ non-eu,"Non EU countries","Pays hors Union européenne",Nicht-EU-Länder
 schema:name "Belgium"@en, "Belgique"@fr, "Belgien"@de
         </pre>
         <p>
-          If there isn't a relevant property in one of the vocabularies that is built-in to CSV on the Web (those listed as part of the <a href="https://www.w3.org/2011/rdfa-context/rdfa-1.1">RDFa 1.1 initial context</a>), the <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> can hold a URL template. Usually this template won't include any substitutable parts because it's generally the case that the property should be the same for the whole column. For example, you might have:
+          If there isn't a relevant property in one of the vocabularies that is built-in to CSV on the Web (those listed as part of the <a href="https://www.w3.org/2011/rdfa-context/rdfa-1.1">RDFa 1.1 initial context</a>), the <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> can hold a URL template. Usually this template won't include any substitutable parts because it's generally the case that the property should be the same for the whole column. For example, you might have:
         </p>
         <pre class="example">{
   "titles": "country group",
-  <strong>"propertyUrl": "http://example.org/def/countryGroup"</strong>
+  <strong>"propertyUrl": "https://example.org/def/countryGroup"</strong>
 }</pre>
         <p>
           In this case, the result of a transformation to JSON will contain:
         </p>
         <pre class="example">
-"http://example.org/def/countryGroup": "eu"
+"https://example.org/def/countryGroup": "eu"
         </pre>
         <p>
           and the RDF similarly:
         </p>
         <pre class="example">
-&lt;http://example.org/def/countryGroup&gt; "eu"
+&lt;https://example.org/def/countryGroup&gt; "eu"
         </pre>
         <p>See also:</p>
         <ul>
           <li><a href="#required-values" class="sectionRef"></a></li>
           <li><a href="#column-title-languages" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#column-name"><code>name</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#column-name"><code>name</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="value-urls">
         <h2>How do you map values into URLs?</h2>
         <p>
-          Sometimes a column contains a value that can be programmatically mapped into a URL. In this case, the <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> property contains a template for the URL that it should be mapped into.
+          Sometimes a column contains a value that can be programmatically mapped into a URL. In this case, the <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> property contains a template for the URL that it should be mapped into.
         </p>
         <p>
-          For example, say that there were pages for each country on the web at e.g. <code>http://example.org/country/at</code>. In that case, the URL for the country could be generated with the URL template <code>http://example.org/country/{country}</code>. Within this template, <code>{country}</code> inserts the value from the column named <code>country</code> into the URL. So the metadata could contain:
+          For example, say that there were pages for each country on the web at e.g. <code>https://example.org/country/at</code>. In that case, the URL for the country could be generated with the URL template <code>https://example.org/country/{country}</code>. Within this template, <code>{country}</code> inserts the value from the column named <code>country</code> into the URL. So the metadata could contain:
         </p>
         <pre class="example">{
   "titles": "country",
   <strong>"name": "country",
-  "valueUrl": "http://example.org/country/{country}",</strong>
+  "valueUrl": "https://example.org/country/{country}",</strong>
   "propertyUrl": "schema:url"
 }</pre>
         <p>
           The JSON output would then contain:
         </p>
         <pre class="example">
-"schema:url": "http://example.org/country/at"
+"schema:url": "https://example.org/country/at"
         </pre>
         <p>
           and the RDF output:
         </p>
         <pre class="example">
-schema:url &lt;http://example.org/country/at&gt;
+schema:url &lt;https://example.org/country/at&gt;
         </pre>
         <p>
           If you want to preserve the original value from the column <em>and</em> use it to create a URL, you may want to introduce a virtual column. For example, with the latitude and longitude of each country available, you might want to provide a link to a map centered on the country within Google Maps. The URLs for these look like <a href="https://www.google.com/maps/@50.501045,4.476674,7z">https://www.google.com/maps/@50.501045,4.476674,7z</a>, and a template like <code>https://www.google.com/maps/@{lat},{long},7z</code>.
         </p>
         <p>
-          To add a property that points to this URL, add a virtual column at the end of the column definitions within the schema. A virtual column definition looks just like a normal column definition but with the <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property set to <code>true</code>:
+          To add a property that points to this URL, add a virtual column at the end of the column definitions within the schema. A virtual column definition looks just like a normal column definition but with the <a href="https://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property set to <code>true</code>:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "tableSchema": {
     "columns": [{
@@ -1561,23 +1562,23 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
           <li><a href="#row-types" class="sectionRef"></a></li>
           <li><a href="#nested-structures" class="sectionRef"></a></li>
           <li><a href="#uom-structured-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="row-identifiers">
         <h2>How do you include an identifier for the thing described by each row?</h2>
         <p>
-          By default, the things described by each row don't have identifiers associated with them in either JSON or RDF outputs. You can add an identifier for the row by setting the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property. Usually that's done at the top level of the schema.
+          By default, the things described by each row don't have identifiers associated with them in either JSON or RDF outputs. You can add an identifier for the row by setting the <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> property. Usually that's done at the top level of the schema.
         </p>
         <p>
-          For example, say each row in <code>countries.csv</code> was about a country whose identifier looked like <code>http://example.org/country/{code}</code> where <code>code</code> was the value within the first column of the CSV file (the <code>country</code> column). The <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> could be set to the generate this URL for each row using a URL template:
+          For example, say each row in <code>countries.csv</code> was about a country whose identifier looked like <code>https://example.org/country/{code}</code> where <code>code</code> was the value within the first column of the CSV file (the <code>country</code> column). The <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> could be set to the generate this URL for each row using a URL template:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "tableSchema": {
-    <strong>"aboutUrl": "http://example.org/country/{code}",</strong>
+    <strong>"aboutUrl": "https://example.org/country/{code}",</strong>
     "columns": [{
       "titles": "country",
       <strong>"name": "code"</strong>
@@ -1606,14 +1607,14 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
           In the JSON, these identifiers are turned into <code>@id</code> properties on the objects generated for each row:
         </p>
         <pre class="example">[{
-  <strong>"@id": "http: //example.org/country/at",</strong>
+  <strong>"@id": "https: //example.org/country/at",</strong>
   "code": "at",
   "country group": "eu",
   "name (en)": "Austria",
   "name (fr)": "Autriche",
   "name (de)": "Österreich"
 },{
-  <strong>"@id": "http: //example.org/country/be",</strong>
+  <strong>"@id": "https: //example.org/country/be",</strong>
   "code": "be",
   "country group": "eu",
   "name (en)": "Belgium",
@@ -1622,7 +1623,7 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
   "latitude": 50.501045,
   "longitude": 4.47667405
 },{
-  <strong>"@id": "http: //example.org/country/bg",</strong>
+  <strong>"@id": "https: //example.org/country/bg",</strong>
   "code": "bg",
   "country group": "eu",
   "name (en)": "Bulgaria",
@@ -1635,10 +1636,10 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
           In the RDF, these identifiers become the identifiers for the entities that the properties relate to, rather than those being blank nodes:
         </p>
         <pre class="example">
-@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+@prefix rdf: &lt;https://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix xsd: &lt;https://www.w3.org/2001/XMLSchema#&gt; .
 
-&lt;http://example.org/country/at&gt;
+&lt;https://example.org/country/at&gt;
    &lt;#code&gt; "at";
    &lt;#country%20group&gt; "eu";
    &lt;#latitude&gt; 4.76965545e1;
@@ -1647,7 +1648,7 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
    &lt;#name%20%28en%29&gt; "Austria"@en;
    &lt;#name%20%28fr%29&gt; "Autriche"@fr .
 
-&lt;http://example.org/country/be&gt;
+&lt;https://example.org/country/be&gt;
    &lt;#code&gt; "be";
    &lt;#country%20group&gt; "eu";
    &lt;#latitude&gt; 5.0501045e1;
@@ -1656,7 +1657,7 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
    &lt;#name%20%28en%29&gt; "Belgium"@en;
    &lt;#name%20%28fr%29&gt; "Belgique"@fr .
 
-&lt;http://example.org/country/bg&gt;
+&lt;https://example.org/country/bg&gt;
    &lt;#code&gt; "bg";
    &lt;#country%20group&gt; "eu";
    &lt;#latitude&gt; 4.272567375e1;
@@ -1671,7 +1672,7 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
           <li><a href="#row-types" class="sectionRef"></a></li>
           <li><a href="#nested-structures" class="sectionRef"></a></li>
           <li><a href="#uom-structured-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="row-types">
@@ -1680,7 +1681,7 @@ schema:hasMap &lt;https://www.google.com/maps/@42.72567375,25.4823218,7z&gt;
           Whether generating JSON or RDF it can be useful to indicate that each row contains data about a particular type of thing, such as a Person or a Country. There isn't usually a column within tabular data that indicates the type of the row (because it's generally the same for every row, so including it would be superfluous), so you have to add it as a virtual column.
         </p>
         <p>
-          The virtual column needs to come after the descriptions of columns actually within the data. It should have its <a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property set to <code>true</code> and its <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> set to <code>rdf:type</code> to indicate that the virtual column will indicate the type of entity the row is about. The <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> property can then be set to the prefixed name or URL of the type of the entity. For example, when each row represents a Country, you might use:
+          The virtual column needs to come after the descriptions of columns actually within the data. It should have its <a href="https://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code></a> property set to <code>true</code> and its <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> set to <code>rdf:type</code> to indicate that the virtual column will indicate the type of entity the row is about. The <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> property can then be set to the prefixed name or URL of the type of the entity. For example, when each row represents a Country, you might use:
         </p>
         <pre class="example">{
   "virtual": true,
@@ -1702,8 +1703,8 @@ a schema:Country
         <p>See also:</p>
         <ul>
           <li><a href="#nested-structures" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#dfn-virtual-columns">virtual columns</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#column-virtual"><code>virtual</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#dfn-virtual-columns">virtual columns</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="extra-metadata">
@@ -1716,7 +1717,7 @@ a schema:Country
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   <strong>"schema:name": "Countries",
   "schema:description": "European countries for which comparative statistics are collected by Eurostat.",
@@ -1781,10 +1782,10 @@ a schema:Country
           Similarly, the output of the full RDF would look like:
         </p>
         <pre class="example">
-@prefix csvw: &lt;http://www.w3.org/ns/csvw#&gt; .
-@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
-@prefix schema: &lt;http://schema.org/&gt; .
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+@prefix csvw: &lt;https://www.w3.org/ns/csvw#&gt; .
+@prefix rdf: &lt;https://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix schema: &lt;https://schema.org/&gt; .
+@prefix xsd: &lt;https://www.w3.org/2001/XMLSchema#&gt; .
 
  [
     a csvw:TableGroup;
@@ -1846,15 +1847,15 @@ a schema:Country
           <li><a href="#structured-metadata" class="sectionRef"></a></li>
           <li><a href="#data-cube" class="sectionRef"></a></li>
           <li><a href="#multilingual-metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#common-properties">Common Properties</a> in [[tabular-metadata]]</li>
           <li><a href="https://www.w3.org/TR/csv2json/#standard-mode">Standard Mode</a> in [[csv2json]]</li>
-          <li><a href="http://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
+          <li><a href="https://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
         </ul>
       </section>
       <section id="suppressing-output">
         <h2>How can you remove output from a transformation result?</h2>
         <p>
-          By default, the output from a JSON or RDF transformation will include all the data from all the columns of all the tables in the metadata document. It may be that you're not interested in some of that within the output of your transformation. In that case, you can use the <a href="http://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code></a> property in the metadata to exclude the data that you're not interested in.
+          By default, the output from a JSON or RDF transformation will include all the data from all the columns of all the tables in the metadata document. It may be that you're not interested in some of that within the output of your transformation. In that case, you can use the <a href="https://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code></a> property in the metadata to exclude the data that you're not interested in.
         </p>
         <p>
           For example, perhaps I'm not interested in the non-English names of countries in my output. In that case, I could suppress them as follows:
@@ -1865,11 +1866,11 @@ a schema:Country
   <strong>"suppressOutput": true</strong>
 }</pre>
         <p>
-          Similarly, when generating the output for a set of tables, you can suppress the output from a whole table by adding the <a href="http://w3c.github.io/csvw/metadata/#table-suppressOutput"><code>suppressOutput</code></a> property to the description of that table:
+          Similarly, when generating the output for a set of tables, you can suppress the output from a whole table by adding the <a href="https://w3c.github.io/csvw/metadata/#table-suppressOutput"><code>suppressOutput</code></a> property to the description of that table:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "tables": [{
     "url": "countries.csv"
   }, {
@@ -1882,8 +1883,8 @@ a schema:Country
         <p>See also:</p>
         <ul>
           <li><a href="#nested-structures" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code> property for columns</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#table-suppressOutput"><code>suppressOutput</code> property for tables</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code> property for columns</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#table-suppressOutput"><code>suppressOutput</code> property for tables</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="nested-structures">
@@ -1898,7 +1899,7 @@ a schema:Country
 "bg","eu","Bulgaria","Bulgarie","Bulgarien","42.72567375","25.4823218"
 </pre>
         <p>
-          if modelled according to the <a href="http://schema.org">schema.org</a> vocabulary, would look like:
+          if modelled according to the <a href="https://schema.org">schema.org</a> vocabulary, would look like:
         </p>
         <pre class="example">[{
   "@type": "schema:Country",
@@ -1926,17 +1927,17 @@ a schema:Country
   }
 }]</pre>
         <p>
-          Generating JSON in this shape requires the judicious use of virtual columns, <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a>: if you create a column whose <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> corresponds to the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> of another column, you will create nested properties.
+          Generating JSON in this shape requires the judicious use of virtual columns, <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a>: if you create a column whose <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> corresponds to the <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> of another column, you will create nested properties.
         </p>
         <p>
-          In this example, we can use two <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a>s: one in the form <code>http://example.org/country/{code}</code> for the Country and one in the form <code>http://example.org/country/{code}#geo</code> for the geo-coordinates of the country. The names are properties of the former while the longitude and latitude are properties of the latter. A virtual column can add the association between the two objects, with a <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> of <code>schema:geo</code>, like so:
+          In this example, we can use two <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a>s: one in the form <code>https://example.org/country/{code}</code> for the Country and one in the form <code>https://example.org/country/{code}#geo</code> for the geo-coordinates of the country. The names are properties of the former while the longitude and latitude are properties of the latter. A virtual column can add the association between the two objects, with a <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> of <code>schema:geo</code>, like so:
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "tableSchema": {
-    "aboutUrl": "http://example.org/country/{code}",
+    "aboutUrl": "https://example.org/country/{code}",
     "columns": [{
       "titles": "country",
       "name": "code",
@@ -1959,12 +1960,12 @@ a schema:Country
     },{
       "titles": "latitude",
       "datatype": "number",
-      <strong>"aboutUrl": "http://example.org/country/{code}#geo",</strong>
+      <strong>"aboutUrl": "https://example.org/country/{code}#geo",</strong>
       "propertyUrl": "schema:latitude"
     },{
       "titles": "longitude",
       "datatype": "number",
-      <strong>"aboutUrl": "http://example.org/country/{code}#geo",</strong>
+      <strong>"aboutUrl": "https://example.org/country/{code}#geo",</strong>
       "propertyUrl": "schema:longitude"
     },{
       "virtual": true,
@@ -1973,47 +1974,47 @@ a schema:Country
     },<strong>{
       "virtual": true,
       "propertyUrl": "schema:geo",
-      "valueUrl": "http://example.org/country/{code}#geo"
+      "valueUrl": "https://example.org/country/{code}#geo"
     }</strong>,{
       "virtual": true,
-      "aboutUrl": "http://example.org/country/{code}#geo",
+      "aboutUrl": "https://example.org/country/{code}#geo",
       "propertyUrl": "rdf:type",
       "valueUrl": "schema:GeoCoordinates"
     }]
   }
 }</pre>
         <p class="note">
-          Note also in this example the use of <a href="http://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code></a> to remove properties that we're not interested in, and the use of virtual columns to add type information to both types of generated object.
+          Note also in this example the use of <a href="https://w3c.github.io/csvw/metadata/#column-suppressOutput"><code>suppressOutput</code></a> to remove properties that we're not interested in, and the use of virtual columns to add type information to both types of generated object.
         </p>
         <p>
           The result of this transformation is close to what we were aiming for, though with the addition of <code>@id</code> properties:
         </p>
         <pre class="example">[{
-  "@id": "http://example.org/country/at",
+  "@id": "https://example.org/country/at",
   "@type": "schema:Country",
   "schema:name": ["Austria", "Autriche", "Österreich"],
   "schema:geo": {
-    "@id": "http://example.org/country/at#geo",
+    "@id": "https://example.org/country/at#geo",
     "@type": "schema:GeoCoordinates",
     "schema:latitude": 47.6965545,
     "schema:longitude": 13.34598005
   }
 }, {
-  "@id": "http://example.org/country/be",
+  "@id": "https://example.org/country/be",
   "@type": "schema:Country",
   "schema:name": ["Belgium", "Belgique", "Belgien"],
   "schema:geo": {
-    "@id":"http://example.org/country/be#geo",
+    "@id":"https://example.org/country/be#geo",
     "@type": "schema:GeoCoordinates",
     "schema:latitude": 50.501045,
     "schema:longitude": 4.47667405
   }
 }, {
-  "@id": "http://example.org/country/bg",
+  "@id": "https://example.org/country/bg",
   "@type": "schema:Country",
   "schema:name": ["Bulgaria", "Bulgarie", "Bulgarien"],
   "schema:geo": {
-    "@id": "http://example.org/country/bg#geo",
+    "@id": "https://example.org/country/bg#geo",
     "@type": "schema:GeoCoordinates",
     "schema:latitude": 42.72567375,
     "schema:longitude": 25.4823218
@@ -2023,31 +2024,31 @@ a schema:Country
           The same metadata will generate similar RDF, though the nesting structure is not so obvious because of the way RDF works:
         </p>
         <pre class="example">
-@prefix rdf: &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
-@prefix schema: &lt;http://schema.org/&gt; .
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
+@prefix rdf: &lt;https://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix schema: &lt;https://schema.org/&gt; .
+@prefix xsd: &lt;https://www.w3.org/2001/XMLSchema#&gt; .
 
-&lt;http://example.org/country/at&gt; a schema:Country;
-   schema:geo &lt;http://example.org/country/at#geo&gt;;
+&lt;https://example.org/country/at&gt; a schema:Country;
+   schema:geo &lt;https://example.org/country/at#geo&gt;;
    schema:name "Austria"@en, "Autriche"@fr, "Österreich"@de .
 
-&lt;http://example.org/country/be&gt; a schema:Country;
-   schema:geo &lt;http://example.org/country/be#geo&gt;;
+&lt;https://example.org/country/be&gt; a schema:Country;
+   schema:geo &lt;https://example.org/country/be#geo&gt;;
    schema:name "Belgium"@en, "Belgique"@fr, "Belgien"@de .
 
-&lt;http://example.org/country/bg&gt; a schema:Country;
-   schema:geo &lt;http://example.org/country/bg#geo&gt;;
+&lt;https://example.org/country/bg&gt; a schema:Country;
+   schema:geo &lt;https://example.org/country/bg#geo&gt;;
    schema:name "Bulgaria"@en, "Bulgarie"@fr, "Bulgarien"@de .
 
-&lt;http://example.org/country/at#geo&gt; a schema:GeoCoordinates;
+&lt;https://example.org/country/at#geo&gt; a schema:GeoCoordinates;
    schema:latitude 4.76965545e1;
    schema:longitude 1.334598005e1 .
 
-&lt;http://example.org/country/be#geo&gt; a schema:GeoCoordinates;
+&lt;https://example.org/country/be#geo&gt; a schema:GeoCoordinates;
    schema:latitude 5.0501045e1;
    schema:longitude 4.47667405e0 .
 
-&lt;http://example.org/country/bg#geo&gt; a schema:GeoCoordinates;
+&lt;https://example.org/country/bg#geo&gt; a schema:GeoCoordinates;
    schema:latitude 4.272567375e1;
    schema:longitude 2.54823218e1 .
            </pre>
@@ -2065,7 +2066,7 @@ a schema:Country
       <section id="list-values">
         <h2>How do you indicate that values should be mapped to a list rather than repeating properties in RDF?</h2>
         <p>
-          If you are used to using RDF you'll know that there's a big difference between having a property that has multiple values (ie multiple triples with the same subject and property) and a property that has a <code>rdf:List</code> as a value. Sometimes one is appropriate, sometimes the other. The <a href="http://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property enables you to indicate which to use for values that are sequences in the original data.
+          If you are used to using RDF you'll know that there's a big difference between having a property that has multiple values (ie multiple triples with the same subject and property) and a property that has a <code>rdf:List</code> as a value. Sometimes one is appropriate, sometimes the other. The <a href="https://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property enables you to indicate which to use for values that are sequences in the original data.
         </p>
         <p>
           Let's use as an example the version of our data in which the latitude and longitude are in the same property:
@@ -2099,7 +2100,7 @@ a schema:Country
           This shows the <code>#latlong</code> property having two values: <code>4.76965545e1</code> and <code>1.334598005e1</code>. These values could easily get mixed up such that the first was taken to be the longitude and the second the latitude rather than the other way around.
         </p>
         <p>
-          To avoid this mix-up occurring, set the <a href="http://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property to <code>true</code>:
+          To avoid this mix-up occurring, set the <a href="https://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property to <code>true</code>:
         </p>
         <pre class="example">{
   "titles": "latlong",
@@ -2119,18 +2120,18 @@ a schema:Country
   <strong>&lt;#latlong&gt; ( 4.76965545e1, 1.334598005e1 );</strong>
 ] .</pre>
         <p class="note">
-          The <a href="http://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property makes no difference to JSON output because sequences in CSV are always transformed into arrays in JSON.
+          The <a href="https://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code></a> property makes no difference to JSON output because sequences in CSV are always transformed into arrays in JSON.
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#sequence-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-ordered"><code>ordered</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="json-ld">
         <h2>How should you transform CSV into JSON-LD?</h2>
         <p>
-          As illustrated above, it is possible to transform CSV into something that looks like JSON-LD by transforming it into JSON. You can add <code>@id</code> properties for identifiers using <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and add <code>@type</code> properties for types using virtual columns.
+          As illustrated above, it is possible to transform CSV into something that looks like JSON-LD by transforming it into JSON. You can add <code>@id</code> properties for identifiers using <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and add <code>@type</code> properties for types using virtual columns.
         </p>
         <p>
           However, if you're really after JSON-LD as an output, the best route is to transform into RDF and emit that RDF as JSON-LD. This will give you more control over the context that's used to determine the properties and structure of the output.
@@ -2139,7 +2140,7 @@ a schema:Country
         <ul>
           <li><a href="#row-identifiers" class="sectionRef"></a></li>
           <li><a href="#row-types" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
+          <li><a href="https://w3c.github.io/csvw/csv2rdf/#conversion">Converting Tabular Data to RDF</a> in [[csv2rdf]]</li>
         </ul>
       </section>
       <section id="html-display">
@@ -2149,13 +2150,13 @@ a schema:Country
         </p>
         <ul>
           <li>use the locale of the user of the browser to determine which titles to display for columns, and how to format numbers and dates within the table</li>
-          <li>respect the directionality of the table and the text within the table that's indicated through the <a href="http://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> properties</li>
-          <li>use the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> properties to link out to other pages from cells within the table, and the <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> to link out to information about the property a column represents; these properties could also be used to embed RDFa into the HTML table, as described in [[html-rdfa]]</li>
+          <li>respect the directionality of the table and the text within the table that's indicated through the <a href="https://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> and <a href="https://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> properties</li>
+          <li>use the <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> and <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> properties to link out to other pages from cells within the table, and the <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> to link out to information about the property a column represents; these properties could also be used to embed RDFa into the HTML table, as described in [[html-rdfa]]</li>
           <li>display the metadata that's available about the table so that people get a full idea of the context of the data</li>
           <li>provide a way to access notes and annotations that have been provided about individual cells, rows or columns</li>
           <li>highlight cells that contain errors so that they're easy to spot and correct</li>
           <li>provide links to other related resources indicated through the metadata supplied for the table</li>
-          <li>keep columns that are used to provide a title for each row (using <a href="http://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a>) visible; for screen readers, use these to label the rows so that people can navigate through the table easily</li>
+          <li>keep columns that are used to provide a title for each row (using <a href="https://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a>) visible; for screen readers, use these to label the rows so that people can navigate through the table easily</li>
           <li>link out to the original CSV file so that people can download it</li>
         </ul>
         <p>See also:</p>
@@ -2168,7 +2169,7 @@ a schema:Country
           <li><a href="#column-language" class="sectionRef"></a></li>
           <li><a href="#table-direction" class="sectionRef"></a></li>
           <li><a href="#row-titles" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#presenting-tables">Presenting Tables</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#presenting-tables">Presenting Tables</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="data-cube">
@@ -2196,21 +2197,21 @@ a schema:Country
       <section id="extension-transformations">
         <h2>How can you transform CSV into other formats?</h2>
         <p>
-          While there are only specifications for transforming CSV into JSON and RDF, there is an extension mechanism within CSV metadata to indicate other transformations that could be applied to CSV files. The <a href="http://w3c.github.io/csvw/metadata/#table-transformations"><code>transformations</code></a> property on a table description holds an array of descriptions of transformations that processors could carry out. There's no guarantees that a given processor will recognise them, but over time it might be that there begins to be recognised practices for how such transformations might work.
+          While there are only specifications for transforming CSV into JSON and RDF, there is an extension mechanism within CSV metadata to indicate other transformations that could be applied to CSV files. The <a href="https://w3c.github.io/csvw/metadata/#table-transformations"><code>transformations</code></a> property on a table description holds an array of descriptions of transformations that processors could carry out. There's no guarantees that a given processor will recognise them, but over time it might be that there begins to be recognised practices for how such transformations might work.
         </p>
         <p>
           The transformations must have the following properties:
         </p>
         <dl>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#transformation-targetFormat"><code>targetFormat</code></a></dt>
-          <dd>gives a URL for the format that the transformation transforms into, for example <code>http://www.iana.org/assignments/media-types/application/xml</code> for XML</dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#transformation-url"><code>url</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#transformation-targetFormat"><code>targetFormat</code></a></dt>
+          <dd>gives a URL for the format that the transformation transforms into, for example <code>https://www.iana.org/assignments/media-types/application/xml</code> for XML</dd>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#transformation-url"><code>url</code></a></dt>
           <dd>points to a script or template that can be used to transform the CSV into that format</dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#transformation-scriptFormat"><code>scriptFormat</code></a></dt>
-          <dd>gives a URL for the format that the script is in, for example <code>https://mustache.github.io/</code> for Mustache or <code>http://www.iana.org/assignments/media-types/application/javascript</code> for Javascript</li>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#transformation-scriptFormat"><code>scriptFormat</code></a></dt>
+          <dd>gives a URL for the format that the script is in, for example <code>https://mustache.github.io/</code> for Mustache or <code>https://www.iana.org/assignments/media-types/application/javascript</code> for Javascript</li>
         </dl>
         <p>
-          You can also supply a <a href="http://w3c.github.io/csvw/metadata/#transformation-title"><code>titles</code></a> property to provide a human-readable description of the output of the transformation, and a <a href="http://w3c.github.io/csvw/metadata/#transformation-source"><code>source</code></a> property to indicate that the <em>input</em> to the transformation isn't the original CSV or tabular data, but <code>json</code> or <code>rdf</code>.
+          You can also supply a <a href="https://w3c.github.io/csvw/metadata/#transformation-title"><code>titles</code></a> property to provide a human-readable description of the output of the transformation, and a <a href="https://w3c.github.io/csvw/metadata/#transformation-source"><code>source</code></a> property to indicate that the <em>input</em> to the transformation isn't the original CSV or tabular data, but <code>json</code> or <code>rdf</code>.
         </p>
         <p>
           For example, if I wanted to convert the data that we've been using into XML, I could create a Mustache template like this at <code>xml-template.mustache</code>:
@@ -2235,10 +2236,10 @@ a schema:Country
           In the metadata for the CSV file I could then include:
         </p>
         <pre class="example">{
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "url": "countries.csv",
   "transformations": [{
-    "targetFormat": "http://www.iana.org/assignments/media-types/application/xml",
+    "targetFormat": "https://www.iana.org/assignments/media-types/application/xml",
     "titles": "Simple XML version",
     "url": "xml-template.mustache",
     "scriptFormat": "https://mustache.github.io/",
@@ -2276,7 +2277,7 @@ a schema:Country
         <p>See also:</p>
         <ul>
           <li><a href="#extra-metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#transformation-definitions">Transformation Definitions</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#transformation-definitions">Transformation Definitions</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
     </section>
@@ -2291,14 +2292,14 @@ a schema:Country
           The metadata file will often contain natural language text, such as titles and descriptions of columns and tables. Unless you specify otherwise, implementations will assume all this text is in an undefined language (<code>und</code>). If you want to specify what natural language is in use within the metadata file, you have to change the way the <code>@context</code> is specified. Instead of the normal value:
         </p>
         <pre class="example">
-"@context": "http://www.w3.org/ns/csvw"
+"@context": "https://www.w3.org/ns/csvw"
 </pre>
         <p>
           The <code>@context</code> should take an array, where the first value is the usual URL as a string and the second is an object with a <code>@language</code> property set to the language being used within the metadata file. This example, which has English-language titles and descriptions, illustrates:
         </p>
         <pre class="example">
 {
-  <strong>"@context": [ "http://www.w3.org/ns/csvw", { "@language": "en "} ],</strong>
+  <strong>"@context": [ "https://www.w3.org/ns/csvw", { "@language": "en "} ],</strong>
   "dc:title": "Countries"
   "url": "countries.csv"
   "tableSchema": {
@@ -2331,7 +2332,7 @@ a schema:Country
         <ul>
           <li><a href="#metadata" class="sectionRef"></a></li>
           <li><a href="#extra-metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#context-language">default language</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#context-language">default language</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="multilingual-metadata">
@@ -2369,13 +2370,13 @@ a schema:Country
         <ul>
           <li><a href="#metadata-language" class="sectionRef"></a></li>
           <li><a href="#extra-metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#values-of-common-properties">Values of Common Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#values-of-common-properties">Values of Common Properties</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="column-title-languages">
         <h2>How do you provide titles for columns in different languages?</h2>
         <p>
-          You can use an object as the value for the <a href="http://w3c.github.io/csvw/metadata/#column-titles"><code>titles</code></a> property for a column to provide titles in different languages. Within the object, each property is a language and the value is the title in that language:
+          You can use an object as the value for the <a href="https://w3c.github.io/csvw/metadata/#column-titles"><code>titles</code></a> property for a column to provide titles in different languages. Within the object, each property is a language and the value is the title in that language:
         </p>
         <pre class="example">
 "titles": {
@@ -2390,7 +2391,7 @@ a schema:Country
         <ul>
           <li><a href="#html-display" class="sectionRef"></a></li>
           <li><a href="#shared-schemas" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#natural-language-properties">Natural Language Properties</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#natural-language-properties">Natural Language Properties</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="column-language">
@@ -2405,11 +2406,11 @@ a schema:Country
 "bg","eu","Bulgaria","Bulgarie","Bulgarien","42.72567375 25.4823218"
 </pre>
         <p>
-          Use the <a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property on the column description to indicate the language of text in that column:
+          Use the <a href="https://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code></a> property on the column description to indicate the language of text in that column:
         </p>
         <pre class="example">
 {
-  <strong>"@context": [ "http://www.w3.org/ns/csvw", { "@language": "en "} ],</strong>
+  <strong>"@context": [ "https://www.w3.org/ns/csvw", { "@language": "en "} ],</strong>
   "dc:title": "Countries"
   "url": "countries.csv"
   "tableSchema": {
@@ -2448,7 +2449,7 @@ a schema:Country
         <ul>
           <li><a href="#transformation-values" class="sectionRef"></a></li>
           <li><a href="#html-display" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-language"><code>lang</code> property</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="table-direction">
@@ -2457,7 +2458,7 @@ a schema:Country
           Implementations that display tables according to the specs should mostly be able to guess whether a table should be displayed left-to-right or right-to-left based on the content of the table. Implementations will look at the content of the cells to work out which way to display their content and will look at the content of the table as a whole to work out whether to display the first column on the right or left of the page.
         </p>
         <p>
-          If you want to override the display of a particular column then you can use the <a href="http://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> property on a column description to explicitly be <code>rtl</code> or <code>ltr</code>:
+          If you want to override the display of a particular column then you can use the <a href="https://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> property on a column description to explicitly be <code>rtl</code> or <code>ltr</code>:
         </p>
         <pre class="example">
 {
@@ -2467,24 +2468,24 @@ a schema:Country
 }
         </pre>
         <p>
-          If you want to override the display of the table overall then you can use the <a href="http://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> property on the description of the table, or for all tables in the group.
+          If you want to override the display of the table overall then you can use the <a href="https://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> property on the description of the table, or for all tables in the group.
         </p>
         <pre class="example">
 {
-  <strong>"@context": "http://www.w3.org/ns/csvw",</strong>
+  <strong>"@context": "https://www.w3.org/ns/csvw",</strong>
   "url": "results.csv",
   <strong>"tableDirection": "rtl"</strong>
 }
 </pre>
         <p>
-          The value of the <a href="http://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> property is inherited to all columns in the table, so any text within this table will similarly be displayed right-to-left. This can be overridden by setting <a href="http://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> to <code>ltr</code> or <code>auto</code> (in which case the direction of the text within each cell will be determined by its contents).
+          The value of the <a href="https://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code></a> property is inherited to all columns in the table, so any text within this table will similarly be displayed right-to-left. This can be overridden by setting <a href="https://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code></a> to <code>ltr</code> or <code>auto</code> (in which case the direction of the text within each cell will be determined by its contents).
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#html-display" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#bidirectional-tables">Bidirectional Tables</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#cell-textDirection"><code>textDirection</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#tableDirection"><code>tableDirection</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#bidirectional-tables">Bidirectional Tables</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
     </section>
@@ -2506,30 +2507,30 @@ a schema:Country
         <pre class="example">
 {
   "titles": "distance",
-  "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure": {
-    "@id": "http://qudt.org/vocab/unit#Kilometer"
+  "https://purl.org/linked-data/sdmx/2009/attribute#unitMeasure": {
+    "@id": "https://qudt.org/vocab/unit#Kilometer"
   }
 }</pre>
         <p>
-          to which you could even add more detail if you wanted (this is replicating the canonical definition of <a href="http://qudt.org/1.1/vocab/OVG_units-qudt-(v1.1).ttl">definition of <code>unit:Kilometer</code></a> from the <a href="http://qudt.org/">Quanitites, Units, Dimensions and Data Types (QUDT) Ontologies</a>):
+          to which you could even add more detail if you wanted (this is replicating the canonical definition of <a href="https://qudt.org/1.1/vocab/OVG_units-qudt-(v1.1).ttl">definition of <code>unit:Kilometer</code></a> from the <a href="https://qudt.org/">Quanitites, Units, Dimensions and Data Types (QUDT) Ontologies</a>):
         </p>
         <pre class="example">
  {
   "titles": "distance",
-  "http://purl.org/linked-data/sdmx/2009/attribute#unitMeasure": {
-    "@id": "http://qudt.org/vocab/unit#Kilometre",
+  "https://purl.org/linked-data/sdmx/2009/attribute#unitMeasure": {
+    "@id": "https://qudt.org/vocab/unit#Kilometre",
     "@type": [
-      "http://qudt.org/schema/qudt#SIUnit",
-      "http://qudt.org/schema/qudt#DerivedUnit",
-      "http://qudt.org/schema/qudt#LengthUnit"
+      "https://qudt.org/schema/qudt#SIUnit",
+      "https://qudt.org/schema/qudt#DerivedUnit",
+      "https://qudt.org/schema/qudt#LengthUnit"
     ],
     "rdfs:label": "Kilometer",
-    "http://qudt.org/schema/qudt#abbreviation": "km",
-    "http://qudt.org/schema/qudt#code": "1091",
-    "http://qudt.org/schema/qudt#conversionMultiplier": 1000,
-    "http://qudt.org/schema/qudt#conversionOffset": 0.0,
-    "http://qudt.org/schema/qudt#symbol": "km",
-    "skos:exactMatch": { "@id": "http://dbpedia.org/resource/Kilometre" }
+    "https://qudt.org/schema/qudt#abbreviation": "km",
+    "https://qudt.org/schema/qudt#code": "1091",
+    "https://qudt.org/schema/qudt#conversionMultiplier": 1000,
+    "https://qudt.org/schema/qudt#conversionOffset": 0.0,
+    "https://qudt.org/schema/qudt#symbol": "km",
+    "skos:exactMatch": { "@id": "https://dbpedia.org/resource/Kilometre" }
   }
 }       </pre>
         <section id="uom-structured-values">
@@ -2542,7 +2543,7 @@ a schema:Country
 
 &lt;#row-1-distance&gt;
   schema:value 3.5 ;
-  schema:unitCode &lt;http://qudt.org/vocab/unit#Kilometer&gt; ;
+  schema:unitCode &lt;https://qudt.org/vocab/unit#Kilometer&gt; ;
   .
 </pre>
           <p>
@@ -2552,14 +2553,14 @@ a schema:Country
 "distance": {
   "@id": "#row-1-distance",
   "schema:value": 3.5
-  "schema:unitCode": "http://qudt.org/vocab/unit#Kilometer"
+  "schema:unitCode": "https://qudt.org/vocab/unit#Kilometer"
 }
 </pre>
           <p class="note">
-            You may want to use different properties than <code>schema:value</code> and <code>schema:unitCode</code>; if so, just use different <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a>s.
+            You may want to use different properties than <code>schema:value</code> and <code>schema:unitCode</code>; if so, just use different <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a>s.
           </p>
           <p>
-            You need to decide on a pattern for the URLs for the values themselves, and set the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> for the relevant column create that URL. In this example, the URLs that look like <code>#row-1-distance</code> can be generated with the pattern <code>#row-{_row}-distance</code>. The <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> for the column needs to be <code>schema:value</code> as the value in the column provides the value for that property. So the column description looks like:
+            You need to decide on a pattern for the URLs for the values themselves, and set the <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> for the relevant column create that URL. In this example, the URLs that look like <code>#row-1-distance</code> can be generated with the pattern <code>#row-{_row}-distance</code>. The <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> for the column needs to be <code>schema:value</code> as the value in the column provides the value for that property. So the column description looks like:
           </p>
           <pre class="example">
 {
@@ -2573,7 +2574,7 @@ a schema:Country
             You then need to use virtual columns (descriptions of additional columns that don't exist in the source CSV) to generate the relationship between the thing whose distance is being measured and the structured value, and the additional property providing the unit for the structured value.
           </p>
           <p>
-            To generate the relationship being the thing that has the distance and the structured value, the virtual column's <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> needs to hold the same URL template as you used before:
+            To generate the relationship being the thing that has the distance and the structured value, the virtual column's <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> needs to hold the same URL template as you used before:
           </p>
           <pre class="example">
 {
@@ -2582,14 +2583,14 @@ a schema:Country
   "valueUrl": "#row-{_row}-distance"
 }</pre>
           <p>
-            To create the units property, you need another virtual column where the <a href="http://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> of that virtual column generates the URL for the structured value, the <a href="http://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> is <code>schema:unitCode</code> and the <a href="http://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> is the URL representing the unit (in this case <code>http://qudt.org/vocab/unit#Kilometre</code>):
+            To create the units property, you need another virtual column where the <a href="https://w3c.github.io/csvw/metadata/#cell-aboutUrl"><code>aboutUrl</code></a> of that virtual column generates the URL for the structured value, the <a href="https://w3c.github.io/csvw/metadata/#cell-propertyUrl"><code>propertyUrl</code></a> is <code>schema:unitCode</code> and the <a href="https://w3c.github.io/csvw/metadata/#cell-valueUrl"><code>valueUrl</code></a> is the URL representing the unit (in this case <code>https://qudt.org/vocab/unit#Kilometre</code>):
           </p>
           <pre class="example">
 {
   "name": "distance_unit",
   "aboutUrl": "#row-{_row}-distance",
   "propertyUrl": "schema:unitCode",
-  "valueUrl": "http://qudt.org/vocab/unit#Kilometer"
+  "valueUrl": "https://qudt.org/vocab/unit#Kilometer"
 }</pre>
           <p>
             If it's necessary to add more detail about the unit (e.g. the fact that it's a unit of length) this can be done with additional virtual columns:
@@ -2598,9 +2599,9 @@ a schema:Country
 {
   "name": "kilometer_abbreviation",
   "virtual": true,
-  "aboutUrl": "http://qudt.org/vocab/unit#Kilometer",
+  "aboutUrl": "https://qudt.org/vocab/unit#Kilometer",
   "propertyUrl": "rdf:type",
-  "valueUrl": "http://qudt.org/schema/qudt#LengthUnit"
+  "valueUrl": "https://qudt.org/schema/qudt#LengthUnit"
 }</pre>
           <p>
             Usually, however, processors should recognise or be able to resolve the URL for the unit to understand that it's a unit of length, if this is important for onward processing.
@@ -2610,7 +2611,7 @@ a schema:Country
             <li><a href="#value-urls" class="sectionRef"></a></li>
             <li><a href="#row-identifiers" class="sectionRef"></a></li>
             <li><a href="#nested-structures" class="sectionRef"></a></li>
-            <li><a href="http://qudt.org/">Quanitites, Units, Dimensions and Data Types (QUDT) Ontologies</a></li>
+            <li><a href="https://qudt.org/">Quanitites, Units, Dimensions and Data Types (QUDT) Ontologies</a></li>
           </ul>
         </section>
         <section id="uom-datatypes">
@@ -2622,7 +2623,7 @@ a schema:Country
 {
   "titles": "distance",
   "datatype": {
-    "@id": "http://example.org/unit/kilometre",
+    "@id": "https://example.org/unit/kilometre",
     "rdfs:label": "Kilometre",
     "base": "number"
   }
@@ -2631,9 +2632,9 @@ a schema:Country
             When values are generated in RDF for this column, they will be assigned the relevant datatype, for example:
           </p>
           <pre class="example">
-[] :distance "3.5"^^&lt;http://example.org/unit/kilometre&gt; .
+[] :distance "3.5"^^&lt;https://example.org/unit/kilometre&gt; .
 
-&lt;http://example.org/unit/kilometre&gt; rdfs:label "Kilometre" .
+&lt;https://example.org/unit/kilometre&gt; rdfs:label "Kilometre" .
 </pre>
           <p>
             Again, it is possible to include additional information about the unit being used as the datatype within the definition of the datatype:
@@ -2642,8 +2643,8 @@ a schema:Country
 {
   "titles": "distance",
   "datatype": {
-    "@id": "http://example.org/unit/kilometre",
-    <strong>"@type": "http://example.org/quantity/length",</strong>
+    "@id": "https://example.org/unit/kilometre",
+    <strong>"@type": "https://example.org/quantity/length",</strong>
     "rdfs:label": "Kilometre",
     "base": "number",
     <strong>"skos:notation": "km"</strong>
@@ -2653,7 +2654,7 @@ a schema:Country
           <ul>
             <li><a href="#new-datatypes" class="sectionRef"></a></li>
             <li><a href="#transformation-values" class="sectionRef"></a></li>
-            <li><a href="http://w3c.github.io/csvw/csv2rdf/#datatypes">Interpreting Datatypes</a> in [[csv2rdf]]</li>
+            <li><a href="https://w3c.github.io/csvw/csv2rdf/#datatypes">Interpreting Datatypes</a> in [[csv2rdf]]</li>
           </ul>
         </section>
       </section>
@@ -2682,7 +2683,7 @@ a schema:Country
     "minimum": "-90",
     "maximum": "90"
   },
-  "aboutUrl": "http://example.org/country/{code}#geo",
+  "aboutUrl": "https://example.org/country/{code}#geo",
   "propertyUrl": "schema:latitude"
 }, {
   "titles": "longitude",
@@ -2692,15 +2693,15 @@ a schema:Country
     "minimum": "-180",
     "maximum": "180"
   },
-  "aboutUrl": "http://example.org/country/{code}#geo",
+  "aboutUrl": "https://example.org/country/{code}#geo",
   "propertyUrl": "schema:longitude"
 }, {
   "virtual": true,
   "propertyUrl": "schema:geo",
-  "valueUrl": "http://example.org/country/{code}#geo"
+  "valueUrl": "https://example.org/country/{code}#geo"
 }, {
   "virtual": true,
-  "aboutUrl": "http://example.org/country/{code}#geo",
+  "aboutUrl": "https://example.org/country/{code}#geo",
   "propertyUrl": "rdf:type",
   "valueUrl": "schema:GeoCoordinates"
 }, {
@@ -2712,7 +2713,7 @@ a schema:Country
           You can put latitude and longitude into a single column, with a character separator between the numbers as shown in <a href="#sequence-values" class="sectionRef"></a>. However, this makes it harder to accurately validate the individual coordinates. They also cannot be separated out into separate property values when converting to JSON or RDF. So this is a more restrictive method and best avoided.
         </p>
         <p>
-          CSV files may also need to contain geometries beyond individual points. There are no built-in formats for geometries recognised by implementations of CSV on the Web. Geometries may be expressed using <a href="http://geojson.org">GeoJSON</a>, <a href="http://www.opengeospatial.org/standards/gml">GML</a>, <a href="http://www.opengeospatial.org/standards/kml">KML</a> or <a href="https://en.wikipedia.org/wiki/Well-known_text">OGC Well-Known Text (WKT)</a> representations. In each case, schemas may indicate that columns containing geometries adhere to a particular type:
+          CSV files may also need to contain geometries beyond individual points. There are no built-in formats for geometries recognised by implementations of CSV on the Web. Geometries may be expressed using <a href="https://geojson.org">GeoJSON</a>, <a href="https://www.opengeospatial.org/standards/gml">GML</a>, <a href="https://www.opengeospatial.org/standards/kml">KML</a> or <a href="https://en.wikipedia.org/wiki/Well-known_text">OGC Well-Known Text (WKT)</a> representations. In each case, schemas may indicate that columns containing geometries adhere to a particular type:
         </p>
         <ul>
           <li><code>json</code> if the format is JSON-based such as GeoJSON</li>
@@ -2720,11 +2721,11 @@ a schema:Country
           <li><code>string</code> if the format is text-based such as OGC WKT</li>
         </ul>
         <p>
-          You can use the <a href="http://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to further constrain the content of columns containing these values. For example, you could use:
+          You can use the <a href="https://w3c.github.io/csvw/metadata/#datatype-format"><code>format</code></a> property to further constrain the content of columns containing these values. For example, you could use:
         </p>
         <pre class="example">
 "datatype": {
-  "@id": "http://geojson.org/",
+  "@id": "https://geojson.org/",
   "base": "json",
   "format": "\\{ ?\"type\": ?\"Polygon\",.+\\}"
 }
@@ -2734,9 +2735,9 @@ a schema:Country
         </p>
         <pre class="example">
 "datatype": {
-  "@id": "http://www.iana.org/assignments/media-types/application/gml+xml",
+  "@id": "https://www.iana.org/assignments/media-types/application/gml+xml",
   "base": "xml",
-  "format": ".*\\&lt;gml:Point xmlns:gml=\"http://www\.opengis\.net/ont/gml" srsName=\"([^\"])+\".*\\&gt;.+\\&lt;/gml:Point\\&gt;"
+  "format": ".*\\&lt;gml:Point xmlns:gml=\"https://www\.opengis\.net/ont/gml" srsName=\"([^\"])+\".*\\&gt;.+\\&lt;/gml:Point\\&gt;"
 }
         </pre>
         <p>
@@ -2744,9 +2745,9 @@ a schema:Country
         </p>
         <pre class="example">
 "datatype": {
-  "@id": "http://www.iana.org/assignments/media-types/application/vnd.google-earth.kml+xml",
+  "@id": "https://www.iana.org/assignments/media-types/application/vnd.google-earth.kml+xml",
   "base": "xml",
-  "format": ".*\\&lt;kml xmlns=\"http://www\\.opengis\\.net/kml/2.2\"\\&gt;.+\\&lt;/kml\\&gt;"
+  "format": ".*\\&lt;kml xmlns=\"https://www\\.opengis\\.net/kml/2.2\"\\&gt;.+\\&lt;/kml\\&gt;"
 }
         </pre>
         <p>
@@ -2756,7 +2757,7 @@ a schema:Country
 "datatype": {
   "base": "string",
   "format": "POLYGON \\(\\(\\d+(\\.\\d+)? \\d+(\\.\\d+)?(, \\d+(\\.\\d+)? \\d+(\\.\\d+)?)+\\)\\)"
-  "rdfs:seeAlso": "http://www.opengeospatial.org/standards/sfa"
+  "rdfs:seeAlso": "https://www.opengeospatial.org/standards/sfa"
 }
         </pre>
         <p>
@@ -2769,17 +2770,17 @@ a schema:Country
         <ul>
           <li><a href="#new-datatypes" class="sectionRef"></a></li>
           <li><a href="#sequence-values" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#datatypes">Datatypes</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#datatypes">Datatypes</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#datatypes">Datatypes</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="shared-schemas">
         <h2>How can you specify a single schema for multiple CSV files?</h2>
         <p>
-          CSV on the Web is designed to enable you to reuse the same schema when publishing multiple CSV files, even if those files are created by different organisations and therefore reside in different places. Rather than embedding a schema within the description of a table, the <a href="http://w3c.github.io/csvw/metadata/#table-schema"><code>tableSchema</code></a> property can point out to a schema held somewhere else.
+          CSV on the Web is designed to enable you to reuse the same schema when publishing multiple CSV files, even if those files are created by different organisations and therefore reside in different places. Rather than embedding a schema within the description of a table, the <a href="https://w3c.github.io/csvw/metadata/#table-schema"><code>tableSchema</code></a> property can point out to a schema held somewhere else.
         </p>
         <p>
-          For example, if you were a statistical agency and wanted municipalities to publish their unemployment figures using the same schema, you could specify the columns that you wanted included within the schema you specified at <code>http://example.org/schema/unemployment.json</code>:
+          For example, if you were a statistical agency and wanted municipalities to publish their unemployment figures using the same schema, you could specify the columns that you wanted included within the schema you specified at <code>https://example.org/schema/unemployment.json</code>:
         </p>
         <pre class="example">
 {
@@ -2795,7 +2796,7 @@ a schema:Country
 }
 </pre>
         <p>
-          Experience shows that publishers of data in CSV files often use their own headings for the columns. So long as these don't change the meaning of the column, as a statistical agency you probably don't care. The <a href="http://w3c.github.io/csvw/metadata/#column-titles"><code>titles</code></a> property allows you to provide multiple alternative titles that people may use in an array:
+          Experience shows that publishers of data in CSV files often use their own headings for the columns. So long as these don't change the meaning of the column, as a statistical agency you probably don't care. The <a href="https://w3c.github.io/csvw/metadata/#column-titles"><code>titles</code></a> property allows you to provide multiple alternative titles that people may use in an array:
         </p>
         <pre class="example">
 {
@@ -2817,7 +2818,7 @@ a schema:Country
           In cases where the data is being gathered from multiple countries, it may also be useful to specify multiple possible titles in different languages, as described in <a href="#column-title-languages" class="sectionRef"></a>.
         </p>
         <p>
-          It will help consistency and processing of the data if the municipalities use a consistent set of codes to indicate which municipality the data relates to. As the statistical agency, you can supply the relevant codes in a CSV file, e.g. <code>http://example.org/ref/municipalities.csv</code>:
+          It will help consistency and processing of the data if the municipalities use a consistent set of codes to indicate which municipality the data relates to. As the statistical agency, you can supply the relevant codes in a CSV file, e.g. <code>https://example.org/ref/municipalities.csv</code>:
         </p>
         <pre class="example">
 code,name
@@ -2827,7 +2828,7 @@ code,name
 ...
 </pre>
         <p>
-          This file will of course have its own simple schema, <code>http://example.org/schema/municipalities.json</code>, that provides the datatype for the municipality codes and indicates that they are unique through a primary key:
+          This file will of course have its own simple schema, <code>https://example.org/schema/municipalities.json</code>, that provides the datatype for the municipality codes and indicates that they are unique through a primary key:
         </p>
         <pre class="example">
 {
@@ -2841,7 +2842,7 @@ code,name
 }
 </pre>
         <p>
-          A foreign key in the schema supplied by the statistical authority ensures that the codes used in the unemployment data match up with the standard set supplied by the statistical authority:
+          A <a>foreign key</a> in the schema supplied by the statistical authority ensures that the codes used in the unemployment data match up with the standard set supplied by the statistical authority:
         </p>
         <pre class="example">
 {
@@ -2860,7 +2861,7 @@ code,name
   <strong>"foreignKeys": [{
     "columnReference": "municipality",
     "reference": {
-      "resource": "http://example.org/ref/municipalities.csv",
+      "resource": "https://example.org/ref/municipalities.csv",
       "columnReference": "code"
     }
   }]</strong>
@@ -2871,18 +2872,18 @@ code,name
         </p>
         <pre class="example">
 {
-  "@context": "http://www.w3.org/ns/csvw",
+  "@context": "https://www.w3.org/ns/csvw",
   "tables": [{
-    "url": "http://local.example.org/data/unemployment.csv",
-    <strong>"tableSchema": "http://example.org/schema/unemployment.json"</strong>
+    "url": "https://local.example.org/data/unemployment.csv",
+    <strong>"tableSchema": "https://example.org/schema/unemployment.json"</strong>
   }, {
-    <strong>"url": "http://example.org/ref/municipalities.csv",
-    "tableSchema": "http://example.org/schema/municipalities.json"</strong>
+    <strong>"url": "https://example.org/ref/municipalities.csv",
+    "tableSchema": "https://example.org/schema/municipalities.json"</strong>
   }]
 }
 </pre>
         <p class="note">
-          A more complex example in which there is linking between pairs of files where the schemas are provided by a central authority is provided in the section <a href="http://w3c.github.io/csvw/metadata/#foreign-key-reference-between-schemas">Foreign Key Reference Between Schemas</a> within [[tabular-metadata]].
+          A more complex example in which there is linking between pairs of files where the schemas are provided by a central authority is provided in the section <a href="https://w3c.github.io/csvw/metadata/#foreign-key-reference-between-schemas">Foreign Key Reference Between Schemas</a> within [[tabular-metadata]].
         </p>
         <p>See also:</p>
         <ul>
@@ -2891,7 +2892,7 @@ code,name
           <li><a href="#enumeration-reference" class="sectionRef"></a></li>
           <li><a href="#unique-values" class="sectionRef"></a></li>
           <li><a href="#column-title-languages" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#schema-examples">Examples of Foreign Keys</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#schema-examples">Examples of Foreign Keys</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="row-titles">
@@ -2900,7 +2901,7 @@ code,name
           It is useful to have titles for rows both for screen readers and in other displays where it may be difficult to view the complete context of a table and therefore to understand the content of a row.
         </p>
         <p>
-          The <a href="http://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property within a schema provides an array of columns that provide sufficient context to label the row. These may sometimes be the same as the columns used for the <a href="http://w3c.github.io/csvw/metadata/#schema-primaryKey"><code>primaryKey</code></a> in the table, but are more likely to be columns that contain human readable text.
+          The <a href="https://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property within a schema provides an array of columns that provide sufficient context to label the row. These may sometimes be the same as the columns used for the <a href="https://w3c.github.io/csvw/metadata/#schema-primaryKey"><code>primaryKey</code></a> in the table, but are more likely to be columns that contain human readable text.
         </p>
         <p>
           For example, with the CSV:
@@ -2912,7 +2913,7 @@ code,name
 "bg","eu","Bulgaria","Bulgarie","Bulgarien","42.72567375","25.4823218"
 </pre>
         <p>
-          The <a href="http://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property could be set to reference the columns containing the name of each country, in the different languages available:
+          The <a href="https://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property could be set to reference the columns containing the name of each country, in the different languages available:
         </p>
         <pre class="example">
 "tableSchema": {
@@ -2944,13 +2945,13 @@ code,name
           In this case, a screen reader or other display of the table could choose to read or display only the row title that matched the user's preferred language.
         </p>
         <p>
-          In other cases, the <a href="http://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property may be set to an array of columns that <em>together</em> provided sufficient context to understand the column (eg <code>["firstName", "lastName"]</code>).
+          In other cases, the <a href="https://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code></a> property may be set to an array of columns that <em>together</em> provided sufficient context to understand the column (eg <code>["firstName", "lastName"]</code>).
         </p>
         <p>See also:</p>
         <ul>
           <li><a href="#html-display" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code> property</a> in [[tabular-metadata]]</li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#column-and-row-labelling">Column and Row Labelling</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#schema-rowTitles"><code>rowTitles</code> property</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#column-and-row-labelling">Column and Row Labelling</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
       <section id="dialects">
@@ -2962,7 +2963,7 @@ code,name
           The specification for CSV as a format is [[RFC4180]]. However, this is an informational specification and and not a formal standard. Therefore, applications may deviate from it.
         </p>
         <p>
-          The metadata that's described here can be used with files that contain tabular data but that aren't CSV. You can provide guidance to processors that are trying to parse those files through the <a href="http://w3c.github.io/csvw/metadata/#table-dialect"><code>dialect</code></a> property on a table description. For example, say we were dealing with a tab-separated file that contains multiple header lines at <code>http://example.org/data/unemployment.tsv</code>:
+          The metadata that's described here can be used with files that contain tabular data but that aren't CSV. You can provide guidance to processors that are trying to parse those files through the <a href="https://w3c.github.io/csvw/metadata/#table-dialect"><code>dialect</code></a> property on a table description. For example, say we were dealing with a tab-separated file that contains multiple header lines at <code>https://example.org/data/unemployment.tsv</code>:
         </p>
         <pre class="example overlarge">
 "country"	"country group"	"name (en)"	"name (fr)"	"name (de)"	"latitude"	"longitude"
@@ -2976,8 +2977,8 @@ code,name
 					The metadata for this file could be:
 				</p>
 				<pre class="example">{
-  "@context": "http://www.w3.org/ns/csvw",
-  "url": "http://example.org/data/unemployment.tsv",
+  "@context": "https://www.w3.org/ns/csvw",
+  "url": "https://example.org/data/unemployment.tsv",
   <strong>"dialect": {
     "delimiter": "\t",
     "headerRowCount": 3
@@ -2988,55 +2989,55 @@ code,name
           There are a number of other properties that you can set within the dialect to cater for the large range of weird things that people do in CSV files. They are:
         </p>
         <dl>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-commentPrefix"><code>commentPrefix</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-commentPrefix"><code>commentPrefix</code></a></dt>
           <dd>
             <p>If the file contains comment lines, set this to the character used at the start of the lines that are comments (usually that's <code>#</code>).</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-delimiter"><code>delimiter</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-delimiter"><code>delimiter</code></a></dt>
           <dd>
             <p>If the file doesn't use commas as separators between values, set this to the separator that it uses.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-doubleQuote"><code>doubleQuote</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-doubleQuote"><code>doubleQuote</code></a></dt>
           <dd>
             <p>If the file uses <code>\</code> to escape double quotes within values, set this to <code>false</code>.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-encoding"><code>encoding</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-encoding"><code>encoding</code></a></dt>
           <dd>
             <p>If the encoding of the file is not UTF-8, set this to the encoding.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-header"><code>header</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-header"><code>header</code></a></dt>
           <dd>
             <p>If the file doesn't have a header line, set this to <code>false</code>.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-headerRowCount"><code>headerRowCount</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-headerRowCount"><code>headerRowCount</code></a></dt>
           <dd>
             <p>If the file has more than one header line, set this to the number of header lines it has.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-lineTerminators"><code>lineTerminators</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-lineTerminators"><code>lineTerminators</code></a></dt>
           <dd>
             <p>If the file uses an unusual character at the end of its lines, set this to that character.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-quoteChar"><code>quoteChar</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-quoteChar"><code>quoteChar</code></a></dt>
           <dd>
             <p>If the file doesn't use double quotes (<code>"</code>) around values that contain commas, set this to the character that it does use.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-skipBlankRows"><code>skipBlankRows</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-skipBlankRows"><code>skipBlankRows</code></a></dt>
           <dd>
             <p>If the file contains blank rows that should just be ignored, set this to <code>true</code>.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-skipColumns"><code>skipColumns</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-skipColumns"><code>skipColumns</code></a></dt>
           <dd>
             <p>If the file has some columns at the start that don't contain useful information, set this to that number of columns.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-skipInitialSpace"><code>skipInitialSpace</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-skipInitialSpace"><code>skipInitialSpace</code></a></dt>
           <dd>
             <p>If values in the file sometimes start with whitespace that should be ignored, set this to <code>true</code>.</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-skipRows"><code>skipRows</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-skipRows"><code>skipRows</code></a></dt>
           <dd>
             <p>If the file has some rows at the start that don't contain useful information, set this to that number of rows. (Sometimes people put metadata at the start of a CSV file, before the header lines.)</p>
           </dd>
-          <dt><a href="http://w3c.github.io/csvw/metadata/#dialect-trim"><code>trim</code></a></dt>
+          <dt><a href="https://w3c.github.io/csvw/metadata/#dialect-trim"><code>trim</code></a></dt>
           <dd>
             <p>If you don't want to ignore whitespace around values, set this to <code>false</code>. If you want to only ignore whitespace at the beginning of values, set it to <code>start</code> and if you want to only ignore whitespace at the end of values, to <code>end</code>. By default whitespace at the start and the end of a value will be stripped away.</p>
           </dd>
@@ -3045,8 +3046,8 @@ code,name
         <ul>
           <li><a href="#tabular-data" class="sectionRef"></a></li>
           <li><a href="#tables-from-html" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#parsing">Parsing Tabular Data</a> in [[tabular-data-model]]</li>
-          <li><a href="http://w3c.github.io/csvw/metadata/#dialect-descriptions">Dialect Descriptions</a> in [[tabular-metadata]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#parsing">Parsing Tabular Data</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/metadata/#dialect-descriptions">Dialect Descriptions</a> in [[tabular-metadata]]</li>
         </ul>
       </section>
       <section id="tables-from-html">
@@ -3070,7 +3071,7 @@ code,name
           If processors don't see an appropriate <code>Link</code> header, they will append <code>-metadata.json</code> to the end of the URL of the CSV file to try to find metadata for it. If they can't find a metadata file there, they will look in the directory containing the CSV file for a file called <code>csv-metadata.json</code> and use that file.
         </p>
         <p>
-          Looking for files in this way isn't appropriate on all servers. As a publisher, it might be that you have URLs for CSV files that are automatically generated using queries, such as <code>http://example.org/data?format=csv&amp;x=15&amp;y=53</code> or that you want metadata to live in a separate subdirectory or central location.
+          Looking for files in this way isn't appropriate on all servers. As a publisher, it might be that you have URLs for CSV files that are automatically generated using queries, such as <code>https://example.org/data?format=csv&amp;x=15&amp;y=53</code> or that you want metadata to live in a separate subdirectory or central location.
         </p>
         <p>
           As a publisher, if you can't or don't want to use the <code>Link</code> header, you can control where processors look for metadata for your CSV files by listing the locations to look at within the <code>/.well-known/csvm</code> file on your server. (This is a well-known location as defined in [[RFC5785]].) This file should contain a list of URL patterns which will be expanded by substituting <code>url</code> for the URL of the CSV file, and then resolving against the location of the CSV file. Lines might look like:
@@ -3081,17 +3082,17 @@ code,name
 {+url}m
         </pre>
         <p>
-          With a CSV file at <code>http://example.org/data.csv</code> this would lead the processor to search for metadata at:
+          With a CSV file at <code>https://example.org/data.csv</code> this would lead the processor to search for metadata at:
         </p>
         <pre class="example">
-http://example.org/metadata?for=http://example.org/data.csv
-http://example.org/data.csv?format=metadata
-http://example.org/data.csvm
+https://example.org/metadata?for=https://example.org/data.csv
+https://example.org/data.csv?format=metadata
+https://example.org/data.csvm
         </pre>
         <p>See also:</p>
         <ul>
           <li><a href="#metadata" class="sectionRef"></a></li>
-          <li><a href="http://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a> in [[tabular-data-model]]</li>
+          <li><a href="https://w3c.github.io/csvw/syntax/#locating-metadata">Locating Metadata</a> in [[tabular-data-model]]</li>
         </ul>
       </section>
     </section>

--- a/primer/index.html
+++ b/primer/index.html
@@ -2345,7 +2345,7 @@ a schema:Country
   "titles": "name (en)",
   "dc:description": <strong>{
     "@value": "The official name of the country in English.",
-    "@lang": "en"
+    "@language": "en"
   }</strong>
 }</pre>
         <p>
@@ -2353,13 +2353,13 @@ a schema:Country
         </p>
         <pre class="example">
 "dc:title": [{
-  "@lang": "en",
+  "@language": "en",
   "@value": "Unemployment in Europe (monthly)"
 },{
-  "@lang": "de",
+  "@language": "de",
   "@value": "Arbeitslosigkeit in Europa (monatlich)"
 },{
-  "@lang": "fr",
+  "@language": "fr",
   "@value": "Le Chômage en Europe (mensuel)"
 }]
         </pre>

--- a/primer/index.html
+++ b/primer/index.html
@@ -9,7 +9,7 @@
     <script class="remove" src="../replace-ed-uris.js"></script>
     <script class="remove">
       var respecConfig = {
-          specStatus: "CG-DRAFT",
+          specStatus: "NOTE",
           shortName: "tabular-data-primer",
           //publishDate:  "2014-03-27",
           previousPublishDate: "2016-02-25",
@@ -62,7 +62,7 @@
           issueBase: "https://github.com/w3c/csvw/issues/",
           noIDLIn: true,
           noLegacyStyle: false,
-          group: "csvw"
+          group: "wg/csvw"
           };
     </script>
     <script class="remove">


### PR DESCRIPTION
Update ReSpec config, and makes this into a CG-DRAFT.

Fixes issues with `@lang` as reported in w3c/respec#883.

Updates break link to previous WG-NOTE due to ReSpec limitations.